### PR TITLE
Add Squarespace migration support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ This file is the entry point for any AI agent using this repository. Read it bef
 3. **User prompts** — non-technical users paste these into their AI to drive the whole migration
 4. **A living playbook** — this repo improves itself through AI-contributed discoveries
 
-Currently supports: **Wix**. Squarespace, Webflow, and Shopify are planned.
+Currently supports: **Wix** and **Squarespace**. Webflow and Shopify are planned.
 
 ## If you're helping a user migrate from Wix
 
@@ -73,6 +73,69 @@ Generate a redirect map (old paths → new WP paths) for the user to configure i
 
 ---
 
+## If you're helping a user migrate from Squarespace
+
+### Step 1 — Understand the site
+
+Help the user launch Chrome with remote debugging and log in to their Squarespace admin:
+
+```bash
+google-chrome --remote-debugging-port=9222
+```
+
+Then run discovery against the admin session:
+
+```bash
+node scripts/squarespace/discover.js <squarespace-url> --cdp-port 9222 --cdp-admin
+```
+
+This connects to the logged-in browser via CDP, intercepts admin API responses and `__NEXT_DATA__` hydration state, and merges admin metadata (drafts, unlisted pages, page IDs) with public URL inventory. Output goes to `output/inventory.json`. Review this with the user before proceeding.
+
+### Step 2 — Extract all content
+
+```bash
+node scripts/squarespace/extract.js <squarespace-url> \
+  --inventory output/inventory.json --cdp-port 9222 --cdp-admin
+```
+
+This runs a Playwright browser that:
+- Navigates to each page in the admin, intercepting API calls (`/api/catalog-preview/`, `/api/content/`, etc.)
+- Extracts `__NEXT_DATA__` hydration state for structured section data
+- Falls back to public DOM extraction if admin data is sparse for a given page
+- Extracts sections (headings, text, images, HTML blocks) from admin JSON
+- Downloads all media from Squarespace's CDN
+
+Output goes to `output/` as structured JSON files, one per page/post, plus `output/media/` for downloaded images and `output/extraction-log.json` for media URL mappings.
+
+### Step 3 — Import to WordPress.com
+
+The user needs:
+- A WordPress.com account ($4/mo Personal plan)
+- An Application Password from: `https://wordpress.com/me/security/application-passwords`
+- Their site's URL (e.g. `mysite.wordpress.com`)
+- Their WordPress.com username
+
+```bash
+node scripts/squarespace/import.js --site <wordpress-site> --username <wpcom-user> --token <app-password>
+```
+
+Import order matters:
+1. Media (images) first — you need the new URLs before creating posts
+2. Pages (with correct parent/child hierarchy)
+3. Posts (with categories, tags, featured images)
+4. Products are logged but skipped (WooCommerce out of scope)
+
+### Step 4 — Verify
+
+After import, check:
+- All URLs in `output/inventory.json` have a corresponding WordPress post/page
+- No posts still have Squarespace CDN image URLs (they'll expire or break)
+- Navigation menus match the original structure
+
+Generate a redirect map (old paths → new WP paths) for the user to configure in their domain settings or a redirect plugin.
+
+---
+
 ## Using Claude in Chrome MCP
 
 If the user has the Chrome DevTools MCP set up (`npx chrome-devtools-mcp@latest`), you can drive extraction directly from the browser without running scripts:
@@ -108,6 +171,17 @@ This approach works for any JavaScript-heavy platform, not just Wix.
 | JavaScript-rendered content | Use Playwright with `waitUntil: 'networkidle'` |
 | Anti-bot blocking | Use real browser via Playwright (not fetch/curl); add delays |
 | Dynamic pages (CMS collections) | Query Wix's `/_api/wix-data-server/` endpoints directly |
+
+### Squarespace
+
+| Problem | Solution |
+|---|---|
+| No structured export (only basic XML) | Intercept admin API calls via CDP for structured JSON |
+| Draft/unlisted pages invisible publicly | Admin CDP extraction discovers all content including drafts |
+| JavaScript-rendered content | Admin API + `__NEXT_DATA__` hydration gives structured data without parsing rendered HTML |
+| Images are CDN URLs | Download immediately from `squarespace-cdn.com`; rewrite URLs at import time |
+| Admin UI noise in extracted content | Smart fallback heuristics filter admin shell text, sidebar artifacts |
+| Products/commerce | Extract metadata but skip import (WooCommerce out of scope) |
 
 ---
 
@@ -149,12 +223,17 @@ data-liberation-agent/
 ├── DISCOVERIES.md         ← log of community-contributed findings
 ├── package.json
 ├── prompts/
-│   └── wix.md             ← what users paste into their AI for a Wix migration
+│   ├── wix.md             ← what users paste into their AI for a Wix migration
+│   └── squarespace.md     ← what users paste into their AI for a Squarespace migration
 ├── scripts/
 │   ├── wix/
 │   │   ├── discover.js    ← inventory the Wix site (sitemap + categorization)
 │   │   └── extract.js     ← extract all content via network interception
-│   └── import.js          ← publish to WordPress.com via REST API (platform-agnostic)
+│   ├── squarespace/
+│   │   ├── discover.js    ← inventory via admin CDP or public JSON API
+│   │   ├── extract.js     ← extract content via admin API interception + DOM fallback
+│   │   └── import.js      ← publish to WordPress.com via REST API
+│   └── import.js          ← publish to WordPress.com via REST API (Wix)
 ├── examples/
 │   ├── wix-api-blog-post.json    ← example of Wix internal API response
 │   └── wp-rest-post-body.json    ← example WordPress REST API request body
@@ -171,6 +250,12 @@ data-liberation-agent/
 - **Password-protected pages**: Require the user to provide credentials.
 - **Very large sites (500+ pages)**: Add `--delay 2000` to extract.js to avoid rate limiting.
 - **Wix Members Area**: No migration path yet.
+
+### Squarespace
+- **Products/Commerce**: Extracted but skipped at import time.
+- **Admin extraction requires CDP**: User must launch Chrome with `--remote-debugging-port` and log in to Squarespace.
+- **Password-protected pages**: Admin extraction may fail without credentials.
+- **Content is HTML, not blocks**: Imported as custom HTML. Block conversion is planned but not yet implemented.
 
 ### General
 - Import creates everything as **drafts** — the user must review and publish manually.

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,40 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-02 — Squarespace admin extraction via CDP
+
+**Found by:** Claude + human contributor (live testing against a Squarespace site)
+**During:** Building the Squarespace extraction pipeline
+**Type:** API endpoint | architecture
+
+### What I found
+
+Connected to a logged-in Chrome session via CDP and intercepted Squarespace's admin API calls and `__NEXT_DATA__` hydration state. Key findings:
+
+**Admin API endpoints discovered:**
+- `/api/catalog-preview/` — page catalog with IDs, URLs, visibility status
+- `/api/content/` — page content with structured sections
+- `/config/pages` — page configuration and navigation structure
+
+**`__NEXT_DATA__` hydration:** Squarespace's admin uses Next.js. The `window.__NEXT_DATA__` object contains page props with structured content, descriptions, and metadata that aren't available through the public API.
+
+**Public `?format=json` API:** Squarespace exposes a no-auth JSON API by appending `?format=json` to any public URL. Returns collection metadata, item counts, tags, categories, and content. Useful as a fallback but lacks draft/unlisted pages and admin-only metadata.
+
+### How it works
+
+The extraction pipeline uses a three-tier fallback chain:
+1. **Admin API interception** — CDP captures JSON responses from admin navigation, filtered to only include data relevant to the target page (excludes `/api/context/`, `/api/billing/`, user profile data)
+2. **Admin `__NEXT_DATA__` hydration** — extracts structured page data from Next.js hydration state
+3. **Public DOM extraction** — falls back to parsing the published page's DOM via the accessibility tree
+
+Smart fallback heuristics trigger the public fallback when admin extraction produces <80 chars of content, <=1 section, or contains admin UI artifacts.
+
+### Why it's better than the previous approach
+
+The public `?format=json` API misses draft pages, unlisted content, and structured section data. Admin extraction via CDP captures everything the site owner can see, with the browser handling authentication automatically.
+
+---
+
 ## 2026-03-31 — Wix Dashboard API reverse engineering via CDP
 
 **Found by:** Claude + human contributor (live probing against Brave browser)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo gives people a prompt they can paste into any AI assistant (Claude, Ch
 | Platform | Status | Prompt |
 |---|---|---|
 | **Wix** | Ready | [`prompts/wix.md`](./prompts/wix.md) |
-| Squarespace | Planned | — |
+| **Squarespace** | Ready | [`prompts/squarespace.md`](./prompts/squarespace.md) |
 | Webflow | Planned | — |
 | Shopify (blog/pages) | Planned | — |
 
@@ -34,7 +34,26 @@ node scripts/wix/discover.js https://yoursite.wixsite.com/sitename
 node scripts/wix/extract.js https://yoursite.wixsite.com/sitename
 
 # 4. Import to WordPress.com
-node scripts/import.js --site your-wp-site --token YOUR_APP_PASSWORD
+node scripts/import.js --site your-wp-site --username your-user --token YOUR_APP_PASSWORD
+```
+
+## Quick start (Squarespace)
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Discover all content on your Squarespace site
+node scripts/squarespace/discover.js https://yoursite.squarespace.com \
+  --cdp-port 9222 --cdp-admin
+
+# 3. Extract all content (intercepts Squarespace's admin API calls)
+node scripts/squarespace/extract.js https://yoursite.squarespace.com \
+  --inventory output/inventory.json --cdp-port 9222 --cdp-admin
+
+# 4. Import to WordPress.com
+node scripts/squarespace/import.js --site your-wp-site \
+  --username your-user --token YOUR_APP_PASSWORD
 ```
 
 Or skip all of that and **paste the prompt into your AI assistant** — it will handle everything.
@@ -58,11 +77,18 @@ This means the playbook gets smarter with every migration.
 - [ ] Wix Stores / WooCommerce migration
 - [ ] Wix Bookings migration
 
+### Squarespace
+- [x] Admin extraction via Chrome DevTools Protocol (CDP)
+- [x] Section-based content extraction (headings, text, images)
+- [x] Media download and URL rewriting
+- [x] WordPress.com XML-RPC import
+- [ ] Block conversion (`core/paragraph`, `core/image`, etc.)
+- [ ] Product/commerce migration
+
 ### General
 - [x] WordPress.com REST API import script
 - [ ] WordPress Studio local-first workflow
 - [ ] Automated redirect generation
-- [ ] Squarespace extractor
 - [ ] Webflow extractor
 
 ## Related

--- a/prompts/squarespace.md
+++ b/prompts/squarespace.md
@@ -1,0 +1,63 @@
+# Squarespace to WordPress.com Migration Prompt
+
+Copy everything below this line and paste it into your AI assistant (Claude, ChatGPT, Gemini, etc.).
+
+---
+
+I want to migrate my website from Squarespace to WordPress.com. My Squarespace site URL is: **[PASTE YOUR SQUARESPACE URL HERE]**
+
+I have (or will create) a WordPress.com account. Please help me migrate using the playbook at https://github.com/Automattic/data-liberation-agent — read AGENTS.md first for full instructions.
+
+Here's what I need you to do:
+
+## Step 1: Inventory my site
+
+- First, help me launch Chrome with remote debugging (`google-chrome --remote-debugging-port=9222`) and log in to my Squarespace admin — the admin session gives access to drafts, unlisted pages, and richer metadata
+- Run `node scripts/squarespace/discover.js [SQUARESPACE URL] --cdp-port 9222 --cdp-admin` to inventory all content via the admin dashboard
+- Categorize each URL (page, blog post, product, gallery, portfolio, etc.)
+- Note my navigation structure and menu items
+- Flag any Squarespace-specific features (commerce, memberships, scheduling, forms) that won't transfer automatically — I need to know these upfront
+- Show me the inventory and wait for my approval before proceeding
+
+## Step 2: Extract all content
+
+For each page and blog post:
+- **Use the admin extraction approach** — run `node scripts/squarespace/extract.js [SQUARESPACE URL] --inventory output/inventory.json --cdp-port 9222 --cdp-admin` from the data-liberation-agent repo
+  - This intercepts Squarespace's admin API calls and `__NEXT_DATA__` hydration to get structured content
+  - It falls back to public DOM extraction automatically if admin data is sparse for a given page
+  - It downloads all media from Squarespace's CDN
+- For blog posts: extract the full archive, not just what's visible on the first page
+- Download every image — don't just save the URL, the files need to actually be retrieved
+- Preserve for each piece of content: title, URL slug, publish date, categories/tags, SEO title and description, featured image
+
+## Step 3: Set up WordPress.com
+
+I need to create/have a WordPress.com site. Help me:
+- Recommend a theme that matches my current site's visual style
+- Create all categories and tags from my Squarespace site
+- Configure basic settings: site title, tagline, permalink structure
+
+For connecting to WordPress.com, I need to generate an Application Password at wordpress.com/me/security/application-passwords.
+
+Tell me when you need it.
+
+## Step 4: Publish everything
+
+Run `node scripts/squarespace/import.js --site [MY-SITE].wordpress.com --username [MY-USERNAME] --token [APP-PASSWORD]`
+
+In this order:
+1. Upload all images to the WordPress media library (Squarespace CDN URLs are rewritten to WordPress URLs)
+2. Create all pages with correct parent/child relationships
+3. Create all blog posts with correct dates, categories, tags, and featured images
+4. Products are logged but skipped — WooCommerce migration is out of scope
+5. Generate a redirect map (`output/redirect-map.json`)
+
+## Step 5: Verify
+
+When done:
+- Give me a URL mapping table: old Squarespace URL → new WordPress URL (for setting up redirects)
+- Flag any posts/pages that are missing or had import errors
+- Check for any images still pointing to Squarespace CDN URLs
+- List everything that needs manual attention (forms, commerce, memberships, scheduling) with your recommendation for what plugin to use
+
+Work methodically — do one step at a time, show me progress, and wait for my go-ahead before moving to the next step. If you hit something unexpected, tell me what you found rather than guessing.

--- a/scripts/import.js
+++ b/scripts/import.js
@@ -6,24 +6,23 @@
  * Import order: media → pages → posts → menus
  *
  * Usage:
- *   node scripts/import.js --site mysite.wordpress.com --token APP_PASSWORD
- *   node scripts/import.js --site mysite.wordpress.com --token APP_PASSWORD --dry-run
+ *   node scripts/import.js --site mysite.wordpress.com --username your-wpcom-user --token APP_PASSWORD
+ *   node scripts/import.js --site mysite.wordpress.com --username your-wpcom-user --token APP_PASSWORD --dry-run
  *
  * Options:
  *   --site <domain>    WordPress.com site domain (e.g. mysite.wordpress.com)
+ *   --username <name>  WordPress.com username that owns the application password
  *   --token <token>    Application password from wordpress.com/me/security/application-passwords
  *   --dry-run          Show what would be imported without actually doing it
  *   --only <type>      Only import 'media', 'pages', or 'posts'
  *
  * Getting your application password:
  *   1. Go to wordpress.com/me/security/application-passwords
- *   2. Create a new application password named "wix-escape"
+ *   2. Create a new application password
  *   3. Copy the password and pass it as --token
  */
 
-import { readFileSync, readdirSync, existsSync } from 'fs';
-import { createReadStream } from 'fs';
-import { basename } from 'path';
+import { readFileSync, readdirSync, existsSync } from "fs";
 
 const args = process.argv.slice(2);
 function getArg(name) {
@@ -31,23 +30,28 @@ function getArg(name) {
   return i !== -1 ? args[i + 1] : null;
 }
 
-const site = getArg('--site');
-const token = getArg('--token');
-const dryRun = args.includes('--dry-run');
-const only = getArg('--only');
+const site = getArg("--site");
+const username = getArg("--username");
+const token = getArg("--token");
+const dryRun = args.includes("--dry-run");
+const only = getArg("--only");
 
-if (!site || !token) {
-  console.error('Usage: node scripts/import.js --site <wordpress-site> --token <app-password>');
-  console.error('  Get your app password at: wordpress.com/me/security/application-passwords');
+if (!site || !username || !token) {
+  console.error(
+    "Usage: node scripts/import.js --site <wordpress-site> --username <wpcom-user> --token <app-password>",
+  );
+  console.error(
+    "  Get your app password at: wordpress.com/me/security/application-passwords",
+  );
   process.exit(1);
 }
 
 const apiBase = `https://public-api.wordpress.com/wp/v2/sites/${site}`;
-const authHeader = `Basic ${Buffer.from(`wix-escape:${token}`).toString('base64')}`;
+const authHeader = `Basic ${Buffer.from(`${username}:${token}`).toString("base64")}`;
 
 async function wpRequest(method, endpoint, body, isFormData = false) {
   const headers = { Authorization: authHeader };
-  if (!isFormData) headers['Content-Type'] = 'application/json';
+  if (!isFormData) headers["Content-Type"] = "application/json";
 
   const options = { method, headers };
   if (body) options.body = isFormData ? body : JSON.stringify(body);
@@ -56,27 +60,31 @@ async function wpRequest(method, endpoint, body, isFormData = false) {
   const data = await res.json().catch(() => ({}));
 
   if (!res.ok) {
-    throw new Error(`${method} ${endpoint} → ${res.status}: ${data.message || JSON.stringify(data)}`);
+    throw new Error(
+      `${method} ${endpoint} → ${res.status}: ${data.message || JSON.stringify(data)}`,
+    );
   }
   return data;
 }
 
 // Extract clean text content from accessibility tree nodes
 function buildContentFromAccessibility(nodes) {
-  if (!nodes?.length) return '';
+  if (!nodes?.length) return "";
   const blocks = [];
   for (const node of nodes) {
     if (!node.name) continue;
-    if (node.role === 'heading') {
+    if (node.role === "heading") {
       // Guess heading level from name length (crude but works as fallback)
       blocks.push(`<h2>${node.name}</h2>`);
-    } else if (['paragraph', 'StaticText', 'article', 'section'].includes(node.role)) {
+    } else if (
+      ["paragraph", "StaticText", "article", "section"].includes(node.role)
+    ) {
       blocks.push(`<p>${node.name}</p>`);
-    } else if (node.role === 'img' && node.description) {
+    } else if (node.role === "img" && node.description) {
       blocks.push(`<!-- image: ${node.description} -->`);
     }
   }
-  return blocks.join('\n');
+  return blocks.join("\n");
 }
 
 // Extract the best available content from a page JSON file
@@ -84,14 +92,18 @@ function extractContent(pageData) {
   // Priority: Wix blog API response > JSON-LD > accessibility tree
   for (const call of pageData.apiCalls || []) {
     // Blog post body is typically in post.content or post.richContent
-    const body = call.data?.post?.content?.plainText ||
-                 call.data?.post?.richContent ||
-                 call.data?.content?.plainText;
-    if (body) return typeof body === 'string' ? `<p>${body}</p>` : JSON.stringify(body);
+    const body =
+      call.data?.post?.content?.plainText ||
+      call.data?.post?.richContent ||
+      call.data?.content?.plainText;
+    if (body)
+      return typeof body === "string" ? `<p>${body}</p>` : JSON.stringify(body);
   }
 
   // JSON-LD article body
-  const article = pageData.globals?.jsonLd?.find(j => j['@type'] === 'Article' || j['@type'] === 'BlogPosting');
+  const article = pageData.globals?.jsonLd?.find(
+    (j) => j["@type"] === "Article" || j["@type"] === "BlogPosting",
+  );
   if (article?.articleBody) return `<p>${article.articleBody}</p>`;
 
   // Fallback to accessibility tree
@@ -101,11 +113,14 @@ function extractContent(pageData) {
 function extractMeta(pageData) {
   const meta = pageData.globals?.meta || {};
   const jsonLd = pageData.globals?.jsonLd || [];
-  const article = jsonLd.find(j => ['Article', 'BlogPosting', 'WebPage'].includes(j['@type']));
+  const article = jsonLd.find((j) =>
+    ["Article", "BlogPosting", "WebPage"].includes(j["@type"]),
+  );
 
   return {
     title: meta.ogTitle || meta.title || article?.headline || pageData.slug,
-    description: meta.description || meta.ogDescription || article?.description || '',
+    description:
+      meta.description || meta.ogDescription || article?.description || "",
     featuredImageUrl: meta.ogImage || article?.image?.url || null,
     publishDate: article?.datePublished || null,
     modifiedDate: article?.dateModified || null,
@@ -116,19 +131,25 @@ function extractMeta(pageData) {
 async function uploadMedia(filePath, filename) {
   if (dryRun) {
     console.log(`  [dry-run] Would upload: ${filename}`);
-    return { id: 0, source_url: `https://example.com/wp-content/uploads/${filename}` };
+    return {
+      id: 0,
+      source_url: `https://example.com/wp-content/uploads/${filename}`,
+    };
   }
 
-  const FormData = (await import('node:buffer')).default;
+  const FormData = (await import("node:buffer")).default;
   // Use fetch with FormData
   const formData = new globalThis.FormData();
   const fileBuffer = readFileSync(filePath);
   const blob = new Blob([fileBuffer]);
-  formData.append('file', blob, filename);
+  formData.append("file", blob, filename);
 
   const res = await fetch(`${apiBase}/media`, {
-    method: 'POST',
-    headers: { Authorization: authHeader, 'Content-Disposition': `attachment; filename="${filename}"` },
+    method: "POST",
+    headers: {
+      Authorization: authHeader,
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
     body: fileBuffer,
   });
 
@@ -140,9 +161,12 @@ async function uploadMedia(filePath, filename) {
 }
 
 async function importMedia() {
-  if (!existsSync('output/media')) { console.log('No media folder found.'); return {}; }
+  if (!existsSync("output/media")) {
+    console.log("No media folder found.");
+    return {};
+  }
 
-  const files = readdirSync('output/media');
+  const files = readdirSync("output/media");
   console.log(`\nUploading ${files.length} media files...`);
 
   const mediaMap = {}; // original filename → WP media URL
@@ -173,15 +197,15 @@ async function importPage(pageData, mediaMap) {
     content,
     excerpt: meta.description,
     slug: meta.slug,
-    status: 'draft', // Start as draft — user publishes manually after review
+    status: "draft", // Start as draft — user publishes manually after review
   };
 
   if (dryRun) {
     console.log(`  [dry-run] Would create page: ${meta.title} (${meta.slug})`);
-    return { id: 0, link: '#' };
+    return { id: 0, link: "#" };
   }
 
-  return wpRequest('POST', '/pages', body);
+  return wpRequest("POST", "/pages", body);
 }
 
 async function importPost(pageData, mediaMap) {
@@ -197,36 +221,40 @@ async function importPost(pageData, mediaMap) {
     content,
     excerpt: meta.description,
     slug: meta.slug,
-    status: 'draft',
+    status: "draft",
     date: meta.publishDate || undefined,
     modified: meta.modifiedDate || undefined,
   };
 
   if (dryRun) {
     console.log(`  [dry-run] Would create post: ${meta.title} (${meta.slug})`);
-    return { id: 0, link: '#' };
+    return { id: 0, link: "#" };
   }
 
-  return wpRequest('POST', '/posts', body);
+  return wpRequest("POST", "/posts", body);
 }
 
 async function main() {
-  if (dryRun) console.log('[DRY RUN — no changes will be made]\n');
+  if (dryRun) console.log("[DRY RUN — no changes will be made]\n");
 
-  if (!existsSync('output/pages')) {
-    console.error('No output/pages directory found. Run extract.js first.');
+  if (!existsSync("output/pages")) {
+    console.error("No output/pages directory found. Run extract.js first.");
     process.exit(1);
   }
 
-  const pageFiles = readdirSync('output/pages').filter(f => f.endsWith('.json'));
+  const pageFiles = readdirSync("output/pages").filter((f) =>
+    f.endsWith(".json"),
+  );
   console.log(`Found ${pageFiles.length} extracted pages`);
 
   // Determine content type from inventory if available
   let typeMap = {};
-  if (existsSync('output/inventory.json')) {
-    const inventory = JSON.parse(readFileSync('output/inventory.json', 'utf8'));
+  if (existsSync("output/inventory.json")) {
+    const inventory = JSON.parse(readFileSync("output/inventory.json", "utf8"));
     for (const item of inventory.urls) {
-      const slug = new URL(item.url).pathname.replace(/^\//, '').replace(/\//g, '--') || 'homepage';
+      const slug =
+        new URL(item.url).pathname.replace(/^\//, "").replace(/\//g, "--") ||
+        "homepage";
       typeMap[slug] = item.type;
     }
   }
@@ -235,26 +263,29 @@ async function main() {
 
   // Step 1: Upload media
   let mediaMap = {};
-  if (!only || only === 'media') {
+  if (!only || only === "media") {
     mediaMap = await importMedia();
   }
 
   // Step 2: Import pages
-  const pages = pageFiles.filter(f => {
-    const slug = f.replace('.json', '');
-    return !typeMap[slug] || typeMap[slug] === 'page' || typeMap[slug] === 'homepage';
+  const pages = pageFiles.filter((f) => {
+    const slug = f.replace(".json", "");
+    return (
+      !typeMap[slug] || typeMap[slug] === "page" || typeMap[slug] === "homepage"
+    );
   });
 
-  if (!only || only === 'pages') {
+  if (!only || only === "pages") {
     console.log(`\nImporting ${pages.length} pages...`);
     for (const file of pages) {
-      const pageData = JSON.parse(readFileSync(`output/pages/${file}`, 'utf8'));
-      const slug = file.replace('.json', '');
+      const pageData = JSON.parse(readFileSync(`output/pages/${file}`, "utf8"));
+      const slug = file.replace(".json", "");
       process.stdout.write(`  ${slug}... `);
       try {
         const result = await importPage(pageData, mediaMap);
         console.log(`✓ ${result.link}`);
-        if (pageData.sourceUrl) urlMap.push({ old: pageData.sourceUrl, new: result.link });
+        if (pageData.sourceUrl)
+          urlMap.push({ old: pageData.sourceUrl, new: result.link });
       } catch (e) {
         console.log(`✗ ${e.message}`);
       }
@@ -262,21 +293,22 @@ async function main() {
   }
 
   // Step 3: Import posts
-  const posts = pageFiles.filter(f => {
-    const slug = f.replace('.json', '');
-    return typeMap[slug] === 'blog-post';
+  const posts = pageFiles.filter((f) => {
+    const slug = f.replace(".json", "");
+    return typeMap[slug] === "blog-post";
   });
 
-  if (!only || only === 'posts') {
+  if (!only || only === "posts") {
     console.log(`\nImporting ${posts.length} blog posts...`);
     for (const file of posts) {
-      const pageData = JSON.parse(readFileSync(`output/pages/${file}`, 'utf8'));
-      const slug = file.replace('.json', '');
+      const pageData = JSON.parse(readFileSync(`output/pages/${file}`, "utf8"));
+      const slug = file.replace(".json", "");
       process.stdout.write(`  ${slug}... `);
       try {
         const result = await importPost(pageData, mediaMap);
         console.log(`✓ ${result.link}`);
-        if (pageData.sourceUrl) urlMap.push({ old: pageData.sourceUrl, new: result.link });
+        if (pageData.sourceUrl)
+          urlMap.push({ old: pageData.sourceUrl, new: result.link });
       } catch (e) {
         console.log(`✗ ${e.message}`);
       }
@@ -285,14 +317,21 @@ async function main() {
 
   // Output redirect map
   if (urlMap.length) {
-    const { writeFileSync } = await import('fs');
-    writeFileSync('output/redirect-map.json', JSON.stringify(urlMap, null, 2));
+    const { writeFileSync } = await import("fs");
+    writeFileSync("output/redirect-map.json", JSON.stringify(urlMap, null, 2));
     console.log(`\nRedirect map written to output/redirect-map.json`);
-    console.log('Use this to set up 301 redirects from your old Wix URLs to WordPress.');
+    console.log(
+      "Use this to set up 301 redirects from your old Wix URLs to WordPress.",
+    );
   }
 
-  console.log('\nImport complete. All content created as drafts — review in WordPress admin before publishing.');
+  console.log(
+    "\nImport complete. All content created as drafts — review in WordPress admin before publishing.",
+  );
   console.log(`https://${site}/wp-admin/`);
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/squarespace/discover.js
+++ b/scripts/squarespace/discover.js
@@ -1,0 +1,719 @@
+#!/usr/bin/env node
+/**
+ * discover.js — Step 1: Inventory a Squarespace site
+ *
+ * Default mode uses Squarespace's public ?format=json API. Admin mode connects
+ * to a logged-in browser over CDP and merges richer page-tree data from the
+ * Squarespace editor.
+ *
+ * Usage:
+ *   node scripts/squarespace/discover.js https://www.example.com
+ *   node scripts/squarespace/discover.js https://www.example.com --cdp-port 9222
+ *   node scripts/squarespace/discover.js https://www.example.com --cdp-admin --cdp-port 9222
+ *
+ * Output:
+ *   output/inventory.json — categorized list of all content URLs
+ */
+
+import { writeFileSync, mkdirSync } from "fs";
+import { chromium } from "playwright";
+import { pathToFileURL } from "url";
+
+const args = process.argv.slice(2);
+const isMainModule = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+const siteUrl = args.find((a) => a.startsWith("http")) || "https://example.com";
+if (isMainModule && !args.find((a) => a.startsWith("http"))) {
+  console.error(
+    "Usage: node scripts/squarespace/discover.js <squarespace-url> [--cdp-port <port>] [--cdp-admin]",
+  );
+  process.exit(1);
+}
+
+function getArg(name, fallback = null) {
+  const index = args.indexOf(name);
+  return index !== -1 ? args[index + 1] : fallback;
+}
+
+const cdpPort = getArg("--cdp-port") ? parseInt(getArg("--cdp-port"), 10) : null;
+const cdpAdmin = args.includes("--cdp-admin");
+if (isMainModule && cdpAdmin && !cdpPort) {
+  console.error("--cdp-admin requires --cdp-port <port>");
+  process.exit(1);
+}
+
+const origin = new URL(siteUrl).origin;
+const targetHost = new URL(siteUrl).host;
+mkdirSync("output", { recursive: true });
+
+const COLLECTION_TYPES = {
+  1: "index",
+  2: "gallery",
+  5: "album",
+  6: "blog",
+  7: "events",
+  8: "products",
+  10: "page",
+  11: "portfolio",
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeHeaders(cookieStr) {
+  const headers = {
+    "User-Agent":
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  };
+  if (cookieStr) headers.Cookie = cookieStr;
+  return headers;
+}
+
+async function fetchJSON(url, cookieStr) {
+  const separator = url.includes("?") ? "&" : "?";
+  const jsonUrl = `${url}${separator}format=json`;
+  try {
+    const res = await fetch(jsonUrl, {
+      headers: makeHeaders(cookieStr),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch (e) {
+    console.error(`  Failed to fetch ${jsonUrl}: ${e.message}`);
+    return null;
+  }
+}
+
+async function fetchSitemap(cookieStr) {
+  const urls = [];
+  try {
+    const res = await fetch(`${origin}/sitemap.xml`, {
+      headers: makeHeaders(cookieStr),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) return urls;
+
+    const text = await res.text();
+    const locs = [...text.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1].trim());
+    for (const loc of locs) {
+      if (loc.endsWith(".xml")) {
+        try {
+          const childRes = await fetch(loc, {
+            headers: makeHeaders(cookieStr),
+            signal: AbortSignal.timeout(15000),
+          });
+          if (!childRes.ok) continue;
+
+          const childText = await childRes.text();
+          const childLocs = [...childText.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+            (m) => m[1].trim(),
+          );
+          urls.push(...childLocs.filter((childLoc) => !childLoc.endsWith(".xml")));
+        } catch {}
+      } else {
+        urls.push(loc);
+      }
+    }
+  } catch (e) {
+    console.error(`  Sitemap fetch failed: ${e.message}`);
+  }
+  return urls;
+}
+
+function classify(type, urlPath, typeName) {
+  if (typeName) {
+    const normalized = String(typeName).toLowerCase();
+    if (normalized.startsWith("blog")) return "blog";
+    if (normalized.startsWith("gallery")) return "gallery";
+    if (normalized.startsWith("portfolio")) return "portfolio";
+    if (normalized.startsWith("events")) return "events";
+    if (normalized.startsWith("products")) return "products";
+    if (normalized.startsWith("index") || normalized.startsWith("folder")) return "index";
+    return normalized;
+  }
+  if (COLLECTION_TYPES[type]) return COLLECTION_TYPES[type];
+
+  const path = urlPath.toLowerCase();
+  if (path.includes("/blog") || path.includes("/post")) return "blog";
+  if (path.includes("/gallery") || path.includes("/portfolio")) return "gallery";
+  if (path.includes("/store") || path.includes("/product")) return "products";
+  if (path.includes("/event")) return "events";
+  return path === "/" ? "homepage" : "page";
+}
+
+function classifyCollectionItem(parentType, item) {
+  if (item?.recordType === 2) return "image";
+  if (parentType === "blog") return "blog-post";
+  if (parentType === "gallery" || parentType === "portfolio") return "image";
+  if (parentType === "products") return "product";
+  if (parentType === "events") return "event";
+  return "item";
+}
+
+async function getCookiesFromCDP(port, domain) {
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  const context = browser.contexts()[0];
+  if (!context) {
+    await browser.close();
+    return "";
+  }
+  const cookies = await context.cookies(domain);
+  await browser.close();
+  return cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("; ");
+}
+
+async function discoverPublic(cookieStr) {
+  console.log("Fetching site data...");
+  const homeData = await fetchJSON(origin, cookieStr);
+  if (!homeData) {
+    console.error("Could not fetch site data. Is this a Squarespace site?");
+    process.exit(1);
+  }
+
+  const website = homeData.website || homeData.websiteData || {};
+  const sqVersion = website.templateVersion || website.siteVersion || null;
+
+  console.log(`  Site: ${website.siteTitle || "(untitled)"}`);
+  console.log(`  Domain: ${website.primaryDomain || origin}`);
+  console.log(`  Website ID: ${website.id || "(unknown)"}`);
+  if (sqVersion) console.log(`  Squarespace version: ${sqVersion}`);
+
+  console.log("\nFetching sitemap...");
+  const sitemapUrls = await fetchSitemap(cookieStr);
+  console.log(`  Found ${sitemapUrls.length} URLs in sitemap`);
+
+  const allUrls = [...new Set(sitemapUrls)];
+  const collections = new Map();
+  const items = [];
+  const navigation = [];
+
+  console.log(`\nProbing ${allUrls.length} URLs for content metadata...`);
+
+  for (let i = 0; i < allUrls.length; i++) {
+    const url = allUrls[i];
+    const path = new URL(url).pathname;
+    if (path === "/page-not-found" || path === "/config") continue;
+
+    process.stdout.write(`  [${i + 1}/${allUrls.length}] ${path}... `);
+    const data = await fetchJSON(url, cookieStr);
+    if (!data) {
+      console.log("skip");
+      continue;
+    }
+
+    const collection = data.collection || {};
+    const collId = collection.id;
+
+    if (data.item) {
+      const item = data.item;
+      const parentType = classify(
+        collection.type,
+        collection.fullUrl || path,
+        collection.typeName,
+      );
+      const itemType = classifyCollectionItem(parentType, item);
+
+      items.push({
+        url,
+        path,
+        type: itemType,
+        title: item.title || path,
+        collectionId: collId,
+        collectionTitle: collection.title,
+        publishDate: item.publishOn ? new Date(item.publishOn).toISOString() : null,
+        hasBody: !!item.body,
+        hasImage: !!item.assetUrl,
+        tags: item.tags || [],
+        categories: item.categories || [],
+      });
+
+      console.log(`${itemType} (in ${collection.title || "unknown"})`);
+    } else if (!collections.has(collId)) {
+      const collType = collection.type;
+      const typeName = classify(collType, path, collection.typeName);
+      const collItems = data.items || [];
+
+      const entry = {
+        url,
+        path,
+        type: typeName,
+        collectionType: collType,
+        collectionId: collId,
+        title: collection.navigationTitle || collection.title || path,
+        itemCount: collection.itemCount || 0,
+        hasMainContent: !!collection.mainContent,
+        fetchedItems: collItems.length,
+        tags: collection.tags || [],
+        categories: collection.categories || [],
+        passwordProtected: !!collection.passwordProtected,
+      };
+
+      if (collection.passwordProtected) {
+        console.log(`  [!] Password-protected: ${path}`);
+      }
+
+      if (typeName === "products") {
+        entry.commerceNote =
+          "Full product data (variants, pricing, inventory) is usually richer in admin mode";
+      }
+
+      if (collItems.length > 0) {
+        entry.items = collItems.map((item) => ({
+          url: `${origin}${item.fullUrl}`,
+          title: item.title,
+          type: classifyCollectionItem(typeName, item),
+          publishDate: item.publishOn ? new Date(item.publishOn).toISOString() : null,
+        }));
+      }
+
+      if (collection.collections) {
+        entry.subCollections = collection.collections.map((sub) => ({
+          title: sub.navigationTitle || sub.title,
+          url: `${origin}${sub.fullUrl || `/${sub.urlId}`}`,
+          type: sub.typeName || COLLECTION_TYPES[sub.type] || "page",
+        }));
+      }
+
+      collections.set(collId, entry);
+      navigation.push({
+        text: collection.navigationTitle || collection.title || path,
+        href: url,
+        type: typeName,
+      });
+
+      console.log(`${typeName} (${entry.itemCount} items)`);
+    } else {
+      console.log(`duplicate (${collection.title || collId})`);
+    }
+
+    if (i < allUrls.length - 1) await sleep(300);
+  }
+
+  for (const entry of collections.values()) {
+    if (
+      entry.itemCount > 20 &&
+      entry.items &&
+      entry.items.length < entry.itemCount
+    ) {
+      console.log(
+        `\n  ${entry.path} has ${entry.itemCount} items, fetched ${entry.items.length} — getting more...`,
+      );
+
+      let pageNumber = 2;
+      let fetched = entry.items.length;
+      while (fetched < entry.itemCount) {
+        const pageData = await fetchJSON(`${entry.url}?page=${pageNumber}`, cookieStr);
+        if (!pageData?.items?.length) break;
+
+        for (const item of pageData.items) {
+          entry.items.push({
+            url: `${origin}${item.fullUrl}`,
+            title: item.title,
+            type: classifyCollectionItem(entry.type, item),
+            publishDate: item.publishOn ? new Date(item.publishOn).toISOString() : null,
+          });
+        }
+
+        fetched += pageData.items.length;
+        pageNumber++;
+        await sleep(300);
+      }
+
+      entry.fetchedItems = entry.items.length;
+      console.log(`    Now have ${entry.items.length} items`);
+    }
+  }
+
+  const counts = {};
+  const allContentUrls = [];
+  for (const entry of collections.values()) {
+    counts[entry.type] = (counts[entry.type] || 0) + 1;
+    allContentUrls.push({ url: entry.url, type: entry.type, title: entry.title });
+
+    for (const item of entry.items || []) {
+      counts[item.type] = (counts[item.type] || 0) + 1;
+      allContentUrls.push({ url: item.url, type: item.type, title: item.title });
+    }
+  }
+
+  const urlsSeen = new Set(allContentUrls.map((item) => item.url));
+  for (const item of items) {
+    if (urlsSeen.has(item.url)) continue;
+    counts[item.type] = (counts[item.type] || 0) + 1;
+    allContentUrls.push({ url: item.url, type: item.type, title: item.title });
+    urlsSeen.add(item.url);
+  }
+
+  const navSeen = new Set();
+  const dedupedNav = navigation.filter((item) => {
+    if (navSeen.has(item.href)) return false;
+    navSeen.add(item.href);
+    return true;
+  });
+
+  return {
+    siteUrl: origin,
+    siteName: website.siteTitle || "",
+    websiteId: website.id || "",
+    squarespaceVersion: sqVersion,
+    discoveredAt: new Date().toISOString(),
+    platform: "squarespace",
+    discoveryMethod: "public-json",
+    navigation: dedupedNav,
+    counts,
+    collections: [...collections.values()],
+    urls: allContentUrls,
+  };
+}
+
+function isAdminApiUrl(url) {
+  return (
+    url.startsWith("https://www.squarespace.com/api/") ||
+    url.startsWith(`https://${targetHost}/api/`) ||
+    url.includes("/api/content/") ||
+    url.includes("/api/commondata/")
+  );
+}
+
+function normalizeSiteUrl(value) {
+  if (!value || typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes("/config/pages")) return null;
+
+  try {
+    const absolute = new URL(trimmed, origin);
+    if (absolute.host !== targetHost) return null;
+    if (
+      absolute.pathname.startsWith("/api/") ||
+      absolute.pathname.includes("/scripts/") ||
+      absolute.pathname.includes("/assets/") ||
+      absolute.pathname.includes("/styles/") ||
+      absolute.pathname.includes("/fonts/") ||
+      absolute.pathname.includes("/static/")
+    ) {
+      return null;
+    }
+    if (
+      absolute.pathname.match(
+        /\.(jpg|jpeg|png|gif|webp|svg|avif|ico|js|css|map|json|txt|xml|pdf|woff2?|ttf|eot)$/i,
+      )
+    ) {
+      return null;
+    }
+    absolute.hash = "";
+    return absolute.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAdminType(rawType, url) {
+  const path = (() => {
+    try {
+      return new URL(url).pathname;
+    } catch {
+      return "/";
+    }
+  })();
+
+  if (typeof rawType === "number") return classify(rawType, path, null);
+  if (typeof rawType === "string") return classify(null, path, rawType);
+  return classify(null, path, null);
+}
+
+function looksLikePageObject(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  if (value.assetUrl || value.scriptUrl || value.mimeType || value.contentType) return false;
+  const hasUrlLikeField = [
+    value.fullUrl,
+    value.publicUrl,
+    value.pageUrl,
+    value.path,
+    value.url,
+    value.href,
+    value.slug,
+  ].some(Boolean);
+  const hasLabel = [value.title, value.navigationTitle, value.name].some(Boolean);
+  const hasId = [value.id, value.pageId, value.collectionId].some(Boolean);
+  return hasUrlLikeField && (hasLabel || hasId);
+}
+
+function extractAdminEntriesFromValue(rootValue) {
+  const entries = new Map();
+  const visited = new WeakSet();
+
+  function visit(value) {
+    if (!value || typeof value !== "object") return;
+    if (visited.has(value)) return;
+    visited.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+
+    if (looksLikePageObject(value)) {
+      const url = normalizeSiteUrl(
+        value.fullUrl ||
+          value.publicUrl ||
+          value.pageUrl ||
+          value.path ||
+          value.url ||
+          value.href ||
+          value.slug,
+      );
+      if (url) {
+        const title = value.navigationTitle || value.title || value.name || new URL(url).pathname;
+        const adminPageId = value.pageId || value.collectionId || value.id || null;
+        const visibility = value.published === false
+          ? "draft"
+          : value.showInNavigation === false || value.navigationHidden || value.unlinked
+            ? "unlinked"
+            : value.passwordProtected
+              ? "password-protected"
+              : "published";
+
+        entries.set(url, {
+          url,
+          title,
+          type: normalizeAdminType(
+            value.typeName || value.pageType || value.type || value.collectionType,
+            url,
+          ),
+          adminPageId: adminPageId ? String(adminPageId) : null,
+          visibility,
+          parentId: value.parentId ? String(value.parentId) : null,
+          pageStatus: value.status || null,
+        });
+      }
+    }
+
+    for (const child of Object.values(value)) visit(child);
+  }
+
+  visit(rootValue);
+  return [...entries.values()];
+}
+
+async function connectToCdpPage(port) {
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  const context = browser.contexts()[0] || (await browser.newContext());
+  const existingPage = context.pages().find((candidate) => {
+    const url = candidate.url();
+    return url.startsWith(`${origin}/config`);
+  });
+  const page = existingPage || (await context.newPage());
+  return { browser, context, page };
+}
+
+async function openAdminSurface(page, candidates) {
+  for (const candidate of candidates) {
+    await page.goto(candidate, {
+      waitUntil: "domcontentloaded",
+      timeout: 45000,
+    });
+    await sleep(3000);
+    await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+    await sleep(1000);
+
+    const noPermissions = await page.evaluate(() => {
+      const text = document.body?.innerText || "";
+      return /No Permissions/i.test(text) || /do not have permission/i.test(text);
+    }).catch(() => false);
+
+    if (!noPermissions) return candidate;
+  }
+
+  throw new Error("Could not open a site admin surface without a No Permissions response");
+}
+
+async function discoverAdmin(port) {
+  console.log("\nConnecting to Squarespace admin via CDP...");
+  const { browser, page } = await connectToCdpPage(port);
+  const apiCalls = [];
+
+  const responseHandler = async (response) => {
+    const responseUrl = response.url();
+    const contentType = response.headers()["content-type"] || "";
+    if (!contentType.includes("application/json") || !isAdminApiUrl(responseUrl)) return;
+
+    try {
+      const data = await response.json();
+      apiCalls.push({ url: responseUrl, data });
+    } catch {}
+  };
+
+  page.on("response", responseHandler);
+
+  try {
+    const adminUrl = await openAdminSurface(page, [`${origin}/config/pages`, `${origin}/config/`]);
+
+    const nextData = await page.evaluate(() => window.__NEXT_DATA__ || null).catch(() => null);
+    const domEntries = await page.evaluate(() => {
+      return [...document.querySelectorAll("a[href*='/config/pages/']")]
+        .map((link) => {
+          const href = link.getAttribute("href") || "";
+          const idMatch = href.match(/\/config\/pages\/([^/?#]+)/);
+          const title = link.textContent?.trim();
+          if (!idMatch || !title) return null;
+          return { adminPageId: idMatch[1], title };
+        })
+        .filter(Boolean);
+    }).catch(() => []);
+
+    const entries = [
+      ...extractAdminEntriesFromValue(apiCalls),
+      ...extractAdminEntriesFromValue(nextData),
+    ];
+
+    const byUrl = new Map(entries.map((entry) => [entry.url, entry]));
+    for (const domEntry of domEntries) {
+      const existing = [...byUrl.values()].find(
+        (entry) => entry.adminPageId && entry.adminPageId === domEntry.adminPageId,
+      );
+      if (existing && !existing.title) existing.title = domEntry.title;
+    }
+
+    return {
+      urls: [...byUrl.values()],
+      adminUrl,
+      apiCallCount: apiCalls.length,
+      domEntryCount: domEntries.length,
+      nextDataPresent: !!nextData,
+    };
+  } finally {
+    page.off("response", responseHandler);
+    await browser.close();
+  }
+}
+
+export function mergeInventory(publicInventory, adminInventory) {
+  if (!adminInventory?.urls?.length) return publicInventory;
+
+  const publicUrlByCollectionId = new Map(
+    (publicInventory.collections || [])
+      .filter((item) => item?.collectionId && item?.url)
+      .map((item) => [String(item.collectionId), item.url]),
+  );
+  const mergedUrls = new Map(
+    publicInventory.urls.map((item) => [item.url, { ...item }]),
+  );
+  for (const adminEntry of adminInventory.urls) {
+    const publicAliasUrl = adminEntry.adminPageId
+      ? publicUrlByCollectionId.get(String(adminEntry.adminPageId))
+      : null;
+    if (publicAliasUrl && publicAliasUrl !== adminEntry.url) {
+      mergedUrls.delete(publicAliasUrl);
+    }
+
+    const existing = mergedUrls.get(adminEntry.url) || {};
+    mergedUrls.set(adminEntry.url, {
+      ...existing,
+      ...adminEntry,
+      type: adminEntry.type || existing.type || "page",
+      title: adminEntry.title || existing.title,
+    });
+  }
+
+  const navigation = [...publicInventory.navigation];
+  for (const [collectionId, publicAliasUrl] of publicUrlByCollectionId.entries()) {
+    const adminReplacement = adminInventory.urls.find((entry) => entry.adminPageId === collectionId);
+    if (adminReplacement && adminReplacement.url !== publicAliasUrl) {
+      const aliasIndex = navigation.findIndex((item) => item.href === publicAliasUrl);
+      if (aliasIndex !== -1) navigation.splice(aliasIndex, 1);
+    }
+  }
+  const navSeen = new Set(navigation.map((item) => item.href));
+  for (const entry of adminInventory.urls) {
+    if (entry.visibility === "unlinked" || entry.visibility === "draft") continue;
+    if (navSeen.has(entry.url)) continue;
+    navigation.push({ text: entry.title, href: entry.url, type: entry.type });
+    navSeen.add(entry.url);
+  }
+
+  const counts = {};
+  for (const item of mergedUrls.values()) {
+    counts[item.type || "page"] = (counts[item.type || "page"] || 0) + 1;
+  }
+
+  return {
+    ...publicInventory,
+    discoveredAt: new Date().toISOString(),
+    discoveryMethod: "cdp-admin",
+    navigation,
+    counts,
+    urls: [...mergedUrls.values()],
+    adminDiscovery: {
+      adminUrl: adminInventory.adminUrl,
+      apiCallCount: adminInventory.apiCallCount,
+      domEntryCount: adminInventory.domEntryCount,
+      nextDataPresent: adminInventory.nextDataPresent,
+    },
+  };
+}
+
+function printSummary(inventory) {
+  console.log("\n" + "=".repeat(50));
+  console.log("Inventory summary:");
+  for (const [type, count] of Object.entries(inventory.counts)) {
+    console.log(`  ${type}: ${count}`);
+  }
+  console.log(`\nTotal: ${inventory.urls.length} content URLs`);
+  if (inventory.navigation.length) {
+    console.log(`\nNavigation (${inventory.navigation.length} items):`);
+    for (const item of inventory.navigation) {
+      console.log(`  ${item.text} -> ${item.href} (${item.type})`);
+    }
+  }
+  console.log("=".repeat(50));
+}
+
+async function main() {
+  console.log(`Discovering: ${siteUrl}\n`);
+
+  let cookieStr = "";
+  if (cdpPort) {
+    console.log(`Extracting cookies from browser on CDP port ${cdpPort}...`);
+    try {
+      cookieStr = await getCookiesFromCDP(cdpPort, origin);
+      console.log(
+        cookieStr
+          ? `  Got ${cookieStr.split(";").length} cookies`
+          : "  No cookies found for this domain",
+      );
+    } catch (e) {
+      console.error(`  Could not connect to CDP: ${e.message}`);
+      console.error("  Continuing without cookies");
+    }
+  }
+
+  const publicInventory = await discoverPublic(cookieStr);
+  let inventory = publicInventory;
+
+  if (cdpAdmin) {
+    try {
+      const adminInventory = await discoverAdmin(cdpPort);
+      inventory = mergeInventory(publicInventory, adminInventory);
+      console.log(`\nAdmin mode found ${adminInventory.urls.length} candidate URLs`);
+    } catch (e) {
+      console.error(`\nAdmin discovery failed: ${e.message}`);
+      console.error("Continuing with public discovery results only");
+    }
+  }
+
+  writeFileSync("output/inventory.json", JSON.stringify(inventory, null, 2));
+  printSummary(inventory);
+  console.log("\nWritten to output/inventory.json");
+  console.log("Review this inventory before running extract.js");
+}
+
+if (isMainModule) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/squarespace/extract.js
+++ b/scripts/squarespace/extract.js
@@ -1,0 +1,1054 @@
+#!/usr/bin/env node
+/**
+ * extract.js — Step 2: Extract all content from a Squarespace site.
+ *
+ * Default mode uses the public ?format=json API. Admin mode connects to a
+ * logged-in browser via CDP, captures editor API responses and hydration state,
+ * and falls back to public extraction when admin data is incomplete.
+ */
+
+import { writeFileSync, mkdirSync, readFileSync, createWriteStream } from "fs";
+import { basename, extname } from "path";
+import { chromium } from "playwright";
+import https from "https";
+import http from "http";
+import { pathToFileURL } from "url";
+
+const args = process.argv.slice(2);
+const isMainModule = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+const siteUrl = args.find((arg) => arg.startsWith("http")) || "https://example.com";
+if (isMainModule && !args.find((arg) => arg.startsWith("http"))) {
+  console.error(
+    "Usage: node scripts/squarespace/extract.js <squarespace-url> [--inventory output/inventory.json] [--cdp-port <port>] [--cdp-admin]",
+  );
+  process.exit(1);
+}
+
+function getArg(name, fallback = null) {
+  const index = args.indexOf(name);
+  return index !== -1 ? args[index + 1] : fallback;
+}
+
+const delay = parseInt(getArg("--delay", "500"), 10);
+const limitArg = getArg("--limit", null);
+const limit = limitArg ? parseInt(limitArg, 10) : Infinity;
+const inventoryFile = getArg("--inventory", null);
+const cdpPort = getArg("--cdp-port") ? parseInt(getArg("--cdp-port"), 10) : null;
+const cdpAdmin = args.includes("--cdp-admin");
+if (isMainModule && cdpAdmin && !cdpPort) {
+  console.error("--cdp-admin requires --cdp-port <port>");
+  process.exit(1);
+}
+
+const origin = new URL(siteUrl).origin;
+const targetHost = new URL(siteUrl).host;
+mkdirSync("output/pages", { recursive: true });
+mkdirSync("output/media", { recursive: true });
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function slugify(url) {
+  return new URL(url).pathname.replace(/^\//, "").replace(/\//g, "--") || "homepage";
+}
+
+function escapeHtml(text) {
+  return String(text)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function makeHeaders(cookieStr) {
+  const headers = {
+    "User-Agent":
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+  };
+  if (cookieStr) headers.Cookie = cookieStr;
+  return headers;
+}
+
+async function getCookiesFromCDP(port, domain) {
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  const context = browser.contexts()[0];
+  if (!context) {
+    await browser.close();
+    return "";
+  }
+  const cookies = await context.cookies(domain);
+  await browser.close();
+  return cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("; ");
+}
+
+async function connectToCdpPage(port) {
+  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  const context = browser.contexts()[0] || (await browser.newContext());
+  const existingPage = context.pages().find((candidate) => candidate.url().startsWith(`${origin}/config`));
+  const page = existingPage || (await context.newPage());
+  return { browser, context, page };
+}
+
+async function createPublicPage() {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  return { browser, context, page };
+}
+
+async function openAdminPage(page, entry) {
+  const candidates = entry.adminPageId
+    ? [`${origin}/config/pages/${entry.adminPageId}`, `${origin}/config/`]
+    : [`${origin}/config/`];
+
+  for (const candidate of candidates) {
+    await page.goto(candidate, {
+      waitUntil: "domcontentloaded",
+      timeout: 45000,
+    });
+    await sleep(2500);
+    await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+    await sleep(750);
+
+    const noPermissions = await page.evaluate(() => {
+      const text = document.body?.innerText || "";
+      return /No Permissions/i.test(text) || /do not have permission/i.test(text);
+    }).catch(() => false);
+
+    if (!noPermissions) return candidate;
+  }
+
+  throw new Error(`Could not open site admin page for ${entry.url}`);
+}
+
+async function fetchJSON(url, cookieStr) {
+  const separator = url.includes("?") ? "&" : "?";
+  const jsonUrl = `${url}${separator}format=json`;
+  try {
+    const res = await fetch(jsonUrl, {
+      headers: makeHeaders(cookieStr),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch (e) {
+    console.error(`  Failed to fetch ${jsonUrl}: ${e.message}`);
+    return null;
+  }
+}
+
+async function downloadFile(url, destPath) {
+  return new Promise((resolve, reject) => {
+    const proto = url.startsWith("https") ? https : http;
+    proto
+      .get(url, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          return downloadFile(res.headers.location, destPath).then(resolve).catch(reject);
+        }
+        const file = createWriteStream(destPath);
+        res.pipe(file);
+        file.on("finish", () => file.close(resolve));
+      })
+      .on("error", reject);
+  });
+}
+
+function unique(items) {
+  return [...new Set(items.filter(Boolean))];
+}
+
+function isLikelyUrlText(value) {
+  return /^https?:\/\//i.test(value) || /^\/api\//i.test(value);
+}
+
+function isLikelyOpaqueId(value) {
+  return /^[a-f0-9]{20,}$/i.test(value);
+}
+
+function isLikelyHtml(value) {
+  return /<[^>]+>/.test(value);
+}
+
+function normalizeMediaUrl(url) {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  if (!trimmed || trimmed.startsWith("data:")) return null;
+
+  try {
+    const parsed = new URL(trimmed, origin);
+    if (!["http:", "https:"].includes(parsed.protocol)) return null;
+    if (["bat.bing.com"].includes(parsed.hostname)) return null;
+    return parsed.toString().split("?")[0];
+  } catch {
+    return null;
+  }
+}
+
+const PUBLIC_CHROME_TEXT = new Set([
+  "SKIP TO CONTENT",
+  "Test Images",
+  "About",
+  "Contact",
+  "Your Site Title",
+  "Location",
+]);
+
+function looksLikeAdminChromeRecord(record) {
+  const text = [record.title, record.description, record.content]
+    .filter(Boolean)
+    .join("\n");
+  return [
+    /\/api\//i,
+    /Main Navigation/i,
+    /Not Linked/i,
+    /Publish update to access/i,
+    /Version 7\.1/i,
+  ].some((pattern) => pattern.test(text));
+}
+
+function shouldUsePublicDomFallback(record, entry) {
+  if (!record) return true;
+  if (!record.content && !record.sections?.length) return true;
+  if (entry.type === "products" || entry.type === "product") return false;
+  if (record.extractionMethod === "cdp-admin-accessibility") return true;
+  if ((record.content || "").length < 80) return true;
+  if ((record.sections || []).length <= 1) return true;
+  return looksLikeAdminChromeRecord(record);
+}
+
+const IGNORED_ADMIN_API_PATTERNS = [
+  "/api/context/",
+  "/api/billing/",
+  "/api/v1/in-product-notification-service/",
+  "/api/v1/config-ui-preferences-service/",
+  "/api/v1/commerce-preferences/",
+  "/api/template/",
+  "/api/multilingual/status",
+  "/api/commerce/settings/payment/feature-gate-list",
+  "/api/popup-overlay/",
+];
+
+const CONTENT_HINT_KEYS = new Set([
+  "id",
+  "pageId",
+  "collectionId",
+  "itemId",
+  "folderId",
+  "recordId",
+  "fullUrl",
+  "url",
+  "pathname",
+  "sourceUrl",
+  "canonicalUrl",
+  "permalink",
+]);
+
+const CONTENT_FIELDS = new Set([
+  "body",
+  "mainContent",
+  "html",
+  "contentHtml",
+  "richText",
+  "richContent",
+  "text",
+  "plainText",
+  "description",
+  "excerpt",
+  "summary",
+  "caption",
+  "title",
+  "heading",
+  "navigationTitle",
+  "assetUrl",
+  "imageUrl",
+  "originalSizeImageUrl",
+  "src",
+  "altText",
+  "alt",
+  "variants",
+  "sku",
+  "priceMoney",
+  "salePriceMoney",
+  "price",
+  "inventory",
+  "stock",
+  "productType",
+]);
+
+function buildEntryNeedles(entry) {
+  const pathname = new URL(entry.url).pathname;
+  const needles = [entry.adminPageId, entry.url];
+  if (pathname && pathname !== "/") {
+    needles.push(pathname, encodeURIComponent(pathname));
+  }
+  return needles.filter(Boolean);
+}
+
+function stringMatchesEntry(value, needles) {
+  if (typeof value !== "string") return false;
+  return needles.some((needle) => value.includes(needle));
+}
+
+function payloadMentionsEntry(value, needles, visited = new WeakSet(), depth = 0) {
+  if (depth > 8 || value == null) return false;
+  if (typeof value === "string") return stringMatchesEntry(value, needles);
+  if (typeof value !== "object") return false;
+  if (visited.has(value)) return false;
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    return value.some((item) => payloadMentionsEntry(item, needles, visited, depth + 1));
+  }
+
+  return Object.entries(value).some(([key, child]) => {
+    if (CONTENT_HINT_KEYS.has(key) && typeof child === "string") {
+      return stringMatchesEntry(child, needles);
+    }
+    return payloadMentionsEntry(child, needles, visited, depth + 1);
+  });
+}
+
+function filterRelevantPayload(value, entry, visited = new WeakSet(), depth = 0) {
+  if (depth > 8 || value == null) return null;
+  const needles = buildEntryNeedles(entry);
+
+  if (typeof value === "string") {
+    return stringMatchesEntry(value, needles) ? value : null;
+  }
+
+  if (typeof value !== "object") return value;
+  if (visited.has(value)) return null;
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => filterRelevantPayload(item, entry, visited, depth + 1))
+      .filter((item) => item != null);
+    return items.length ? items : null;
+  }
+
+  const objectMentionsEntry = payloadMentionsEntry(value, needles);
+  const filtered = {};
+
+  for (const [key, child] of Object.entries(value)) {
+    if (CONTENT_HINT_KEYS.has(key)) {
+      if (typeof child === "string" && stringMatchesEntry(child, needles)) {
+        filtered[key] = child;
+      }
+      continue;
+    }
+
+    if (CONTENT_FIELDS.has(key)) {
+      if (objectMentionsEntry || payloadMentionsEntry(child, needles)) {
+        filtered[key] = child;
+      }
+      continue;
+    }
+
+    const nextValue = filterRelevantPayload(child, entry, visited, depth + 1);
+    if (nextValue != null) filtered[key] = nextValue;
+  }
+
+  return Object.keys(filtered).length ? filtered : null;
+}
+
+function extractImageUrls(data) {
+  const urls = new Set();
+  const str = JSON.stringify(data);
+  const matches =
+    str.match(
+      /https:\/\/(?:static1?\.squarespace\.com|images\.squarespace-cdn\.com)[^"'\s)}\]]+/g,
+    ) || [];
+
+  for (const url of matches) {
+    const clean = normalizeMediaUrl(url);
+    if (!clean) continue;
+    if (clean.match(/\.(jpg|jpeg|png|gif|webp|svg|avif|ico)$/i)) {
+      urls.add(clean);
+    }
+  }
+
+  return [...urls];
+}
+
+function normalizeType(typeName, url) {
+  const pathname = new URL(url).pathname.toLowerCase();
+  const normalized = String(typeName || "").toLowerCase();
+  if (normalized.startsWith("blog")) return "blog-post";
+  if (normalized.startsWith("gallery") || normalized.startsWith("portfolio")) return "gallery";
+  if (normalized.startsWith("product")) return "product";
+  if (normalized.startsWith("event")) return "event";
+  if (normalized.startsWith("index") || normalized.startsWith("folder")) return "index";
+  if (normalized) return normalized;
+  if (pathname.includes("/blog") || pathname.includes("/post")) return "blog-post";
+  if (pathname.includes("/store") || pathname.includes("/product")) return "product";
+  if (pathname.includes("/event")) return "event";
+  return pathname === "/" ? "homepage" : "page";
+}
+
+function extractContentFromItem(item) {
+  if (item.body) return item.body;
+  if (item.excerpt) return item.excerpt;
+  return "";
+}
+
+function extractContentFromCollection(collection) {
+  if (collection.mainContent) return collection.mainContent;
+  return "";
+}
+
+function extractPublicRecord(data, entry) {
+  const collection = data.collection || {};
+  const item = data.item || null;
+  const isItem = !!item;
+  const source = isItem ? item : collection;
+  const type = entry?.type || normalizeType(collection.typeName, entry.url);
+  const content = isItem ? extractContentFromItem(item) : extractContentFromCollection(collection);
+  const title = source.title || source.navigationTitle || entry.title || new URL(entry.url).pathname;
+  const description = source.seoDescription || source.metaDescription || item?.excerpt || "";
+  const publishDate = source.publishOn
+    ? new Date(source.publishOn).toISOString()
+    : source.addedOn
+      ? new Date(source.addedOn).toISOString()
+      : null;
+  const modifiedDate = source.updatedOn ? new Date(source.updatedOn).toISOString() : null;
+  const featuredImage =
+    source.assetUrl ||
+    source.socialMediaImageUrl ||
+    item?.systemDataVariants?.replace(/~.*/, "") ||
+    null;
+  const media = unique([...extractImageUrls(data), featuredImage]);
+
+  return {
+    sourceUrl: entry.url,
+    slug: slugify(entry.url),
+    extractedAt: new Date().toISOString(),
+    platform: "squarespace",
+    type,
+    title,
+    content,
+    sections: content ? [{ type: "html", content }] : [],
+    description,
+    publishDate,
+    modifiedDate,
+    featuredImage,
+    tags: source.tags || [],
+    categories: source.categories || [],
+    seo: {
+      title: source.seoTitle || title,
+      description,
+    },
+    media,
+    collectionId: collection.id || null,
+    collectionTitle: collection.title || null,
+    passwordProtected: !!collection.passwordProtected,
+    extractionMethod: "public-json",
+    adminPageId: entry.adminPageId || null,
+    raw: data,
+  };
+}
+
+function loadInventoryEntries(filePath) {
+  const inventory = JSON.parse(readFileSync(filePath, "utf8"));
+  const seen = new Map();
+  const canonicalAdminIds = new Set((inventory.urls || []).map((entry) => entry.adminPageId).filter(Boolean));
+
+  function mergeEntry(entry) {
+    if (!entry?.url) return;
+    const existing = seen.get(entry.url) || {};
+    seen.set(entry.url, {
+      ...existing,
+      ...entry,
+      type: entry.type || existing.type || null,
+      title: entry.title || existing.title || null,
+      adminPageId: entry.adminPageId || existing.adminPageId || null,
+    });
+  }
+
+  for (const collection of inventory.collections || []) {
+    if (collection.collectionId && canonicalAdminIds.has(collection.collectionId)) continue;
+    mergeEntry(collection);
+    for (const item of collection.items || []) mergeEntry(item);
+  }
+
+  for (const entry of inventory.urls || []) mergeEntry(entry);
+  return [...seen.values()];
+}
+
+function addSection(section, sections, seen) {
+  if (!section) return;
+  const normalized = { ...section };
+  if (normalized.content) {
+    normalized.content = String(normalized.content).replace(/\s+/g, " ").trim();
+  }
+  if (normalized.src) normalized.src = normalizeMediaUrl(String(normalized.src).trim());
+  if (normalized.type === "text") {
+    if (!normalized.content || isLikelyUrlText(normalized.content) || isLikelyOpaqueId(normalized.content)) {
+      return;
+    }
+    if (PUBLIC_CHROME_TEXT.has(normalized.content)) return;
+    if (isLikelyHtml(normalized.content)) {
+      normalized.type = "html";
+    }
+  }
+  if (normalized.type === "heading" && PUBLIC_CHROME_TEXT.has(normalized.content)) return;
+  if (normalized.type === "heading" && normalized.content && normalized.content.length > 200) return;
+  if (normalized.type === "heading" && normalized.content) {
+    const previous = sections[sections.length - 1];
+    if (previous?.type === "heading" && previous.content) {
+      const currentCompact = normalized.content.toLowerCase().replace(/\s+/g, "");
+      const previousCompact = previous.content.toLowerCase().replace(/\s+/g, "");
+      if (previousCompact.length >= 12 && currentCompact.includes(previousCompact.repeat(2))) return;
+    }
+  }
+  if (!normalized.content && !normalized.src) return;
+
+  const key = JSON.stringify([
+    normalized.type,
+    normalized.content?.slice(0, 300) || null,
+    normalized.src || null,
+    normalized.alt || null,
+  ]);
+  if (seen.has(key)) return;
+  seen.add(key);
+  sections.push(normalized);
+}
+
+function addSectionsFromText(text, sections, seen) {
+  if (!text || typeof text !== "string") return;
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length < 20) return;
+  addSection({ type: isLikelyHtml(trimmed) ? "html" : "text", content: trimmed }, sections, seen);
+}
+
+export function addSectionsFromValue(
+  value,
+  sections,
+  seen,
+  visited = new WeakSet(),
+  depth = 0,
+) {
+  if (depth > 8 || value == null) return;
+
+  if (typeof value === "string") {
+    addSectionsFromText(value, sections, seen);
+    return;
+  }
+
+  if (typeof value !== "object") return;
+  if (visited.has(value)) return;
+  visited.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) addSectionsFromValue(item, sections, seen, visited, depth + 1);
+    return;
+  }
+
+  const htmlFields = ["body", "mainContent", "html", "contentHtml", "richText", "richContent"];
+  for (const field of htmlFields) {
+    if (typeof value[field] === "string" && value[field].trim()) {
+      addSection({ type: "html", content: value[field].trim() }, sections, seen);
+    }
+  }
+
+  const textFields = ["text", "plainText", "description", "excerpt", "summary", "caption"];
+  for (const field of textFields) {
+    if (typeof value[field] === "string") addSectionsFromText(value[field], sections, seen);
+  }
+
+  const heading = value.title || value.heading || value.navigationTitle || null;
+  if (typeof heading === "string" && heading.trim() && heading.trim().length <= 200) {
+    addSection({ type: "heading", content: heading.trim() }, sections, seen);
+  }
+
+  const imageSrc = value.assetUrl || value.imageUrl || value.originalSizeImageUrl || value.src || null;
+  const normalizedImageSrc = normalizeMediaUrl(imageSrc);
+  if (normalizedImageSrc) {
+    addSection(
+      {
+        type: "image",
+        src: normalizedImageSrc,
+        alt: value.altText || value.alt || value.title || value.caption || "",
+      },
+      sections,
+      seen,
+    );
+  }
+
+  for (const child of Object.values(value)) {
+    addSectionsFromValue(child, sections, seen, visited, depth + 1);
+  }
+}
+
+export function domSectionsToHtml(sections) {
+  return sections
+    .map((section) => {
+      if (section.type === "html") return section.content;
+      if (section.type === "heading") return `<h2>${escapeHtml(section.content)}</h2>`;
+      if (section.type === "image") {
+        const alt = section.alt ? ` alt="${escapeHtml(section.alt)}"` : " alt=\"\"";
+        const caption = section.alt ? `<figcaption>${escapeHtml(section.alt)}</figcaption>` : "";
+        return `<figure><img src="${escapeHtml(section.src)}"${alt} />${caption}</figure>`;
+      }
+      return `<p>${escapeHtml(section.content)}</p>`;
+    })
+    .join("\n");
+}
+
+async function getAccessibilitySections(page) {
+  const session = await page.context().newCDPSession(page);
+  try {
+    const ax = await session.send("Accessibility.getFullAXTree", { depth: 10 });
+    return (ax.nodes || [])
+      .filter((node) => ["heading", "paragraph", "StaticText", "img"].includes(node.role?.value))
+      .map((node) => {
+        const role = node.role?.value;
+        if (role === "img") {
+          return {
+            type: "image",
+            src: null,
+            alt: node.description?.value || node.name?.value || "",
+          };
+        }
+        return {
+          type: role === "heading" ? "heading" : "text",
+          content: node.name?.value || "",
+        };
+      })
+      .filter((section) => section.content || section.alt);
+  } catch {
+    return [];
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
+async function getDomSections(page) {
+  return page
+    .evaluate(() => {
+      const container = document.querySelector("main") || document.querySelector('[role="main"]') || document.body;
+      const elements = [...container.querySelectorAll("h1, h2, h3, p, li, img")];
+      return elements
+        .map((element) => {
+          if (element.tagName === "IMG") {
+            const src = element.getAttribute("src");
+            return src
+              ? {
+                  type: "image",
+                  src,
+                  alt: element.getAttribute("alt") || "",
+                }
+              : null;
+          }
+
+          const content = element.textContent?.trim();
+          if (!content) return null;
+          return {
+            type: ["H1", "H2", "H3"].includes(element.tagName) ? "heading" : "text",
+            content,
+          };
+        })
+        .filter(Boolean)
+        .slice(0, 250);
+    })
+    .catch(() => []);
+}
+
+async function extractPublicDomRecord(page, entry) {
+  await page.goto(entry.url, {
+    waitUntil: "domcontentloaded",
+    timeout: 45000,
+  });
+  await sleep(2000);
+  await page.waitForLoadState("networkidle", { timeout: 10000 }).catch(() => {});
+  await sleep(500);
+
+  const landedUrl = page.url();
+  if (landedUrl.includes("/config") || landedUrl.includes("squarespace.com/dashboard")) {
+    throw new Error(`Public DOM navigation landed on admin surface: ${landedUrl}`);
+  }
+
+  const title = await page.title().catch(() => entry.title || slugify(entry.url));
+  const domSections = await getDomSections(page);
+  const accessibilitySections = await getAccessibilitySections(page);
+  const sections = [];
+  const seen = new Set();
+  const fallbackSections = domSections.length ? domSections : accessibilitySections;
+  for (const section of fallbackSections) {
+    addSection(section, sections, seen);
+  }
+
+  const content = domSectionsToHtml(sections);
+  const media = unique(
+    sections
+      .filter((section) => section.type === "image" && section.src)
+      .map((section) => section.src),
+  );
+  const description = sections.find((section) => section.type === "text")?.content || "";
+
+  return {
+    sourceUrl: entry.url,
+    slug: slugify(entry.url),
+    extractedAt: new Date().toISOString(),
+    platform: "squarespace",
+    type: entry.type || normalizeType(null, entry.url),
+    title: entry.title || title,
+    content,
+    sections,
+    description,
+    publishDate: null,
+    modifiedDate: null,
+    featuredImage: media[0] || null,
+    tags: [],
+    categories: [],
+    seo: {
+      title: entry.title || title,
+      description,
+    },
+    media,
+    extractionMethod: "public-dom",
+    adminPageId: entry.adminPageId || null,
+    raw: {
+      domSections,
+      accessibility: accessibilitySections,
+    },
+  };
+}
+
+function isAdminApiUrl(url, entry) {
+  if (
+    !(
+      url.startsWith("https://www.squarespace.com/api/") ||
+      url.startsWith(`https://${targetHost}/api/`) ||
+      url.includes("/api/content/") ||
+      url.includes("/api/commondata/")
+    )
+  ) {
+    return false;
+  }
+
+  if (IGNORED_ADMIN_API_PATTERNS.some((pattern) => url.includes(pattern))) {
+    return false;
+  }
+
+  const pathname = new URL(entry.url).pathname;
+  return [entry.adminPageId, entry.url, pathname === "/" ? null : pathname, encodeURIComponent(pathname)]
+    .filter(Boolean)
+    .some((needle) => url.includes(needle));
+}
+
+function extractProductData(source) {
+  const visited = new WeakSet();
+  function visit(value) {
+    if (!value || typeof value !== "object") return null;
+    if (visited.has(value)) return null;
+    visited.add(value);
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const result = visit(item);
+        if (result) return result;
+      }
+      return null;
+    }
+
+    const hasProductMarkers =
+      value.variants || value.sku || value.priceMoney || value.salePriceMoney || value.productType;
+    if (hasProductMarkers) {
+      return {
+        id: value.id || value.productId || null,
+        sku: value.sku || null,
+        price: value.priceMoney || value.salePriceMoney || value.price || null,
+        variants: value.variants || [],
+        inventory: value.inventory || value.stock || null,
+      };
+    }
+
+    for (const child of Object.values(value)) {
+      const result = visit(child);
+      if (result) return result;
+    }
+    return null;
+  }
+
+  return visit(source);
+}
+
+export function mergeRecords(primary, fallback) {
+  if (!fallback) return primary;
+  if (!primary) return fallback;
+
+  return {
+    ...fallback,
+    ...primary,
+    title: primary.title || fallback.title,
+    type: primary.type || fallback.type,
+    content: primary.content || fallback.content,
+    sections: primary.sections?.length ? primary.sections : fallback.sections,
+    description: primary.description || fallback.description,
+    publishDate: primary.publishDate || fallback.publishDate,
+    modifiedDate: primary.modifiedDate || fallback.modifiedDate,
+    featuredImage: primary.featuredImage || fallback.featuredImage,
+    tags: primary.tags?.length ? primary.tags : fallback.tags,
+    categories: primary.categories?.length ? primary.categories : fallback.categories,
+    media: unique([...(fallback.media || []), ...(primary.media || [])]),
+    adminPageId: primary.adminPageId || fallback.adminPageId || null,
+    raw: {
+      public: fallback.raw || null,
+      admin: primary.raw || null,
+    },
+  };
+}
+
+export function buildAdminRecordFromCaptured(captured, entry) {
+  const filteredApiCalls = (captured.apiCalls || [])
+    .map((call) => ({ ...call, data: filterRelevantPayload(call.data, entry) }))
+    .filter((call) => call.data);
+  const filteredNextData = filterRelevantPayload(captured.nextData, entry);
+
+  const apiSections = [];
+  const apiSeen = new Set();
+  addSectionsFromValue(filteredApiCalls, apiSections, apiSeen);
+
+  const nextSections = [];
+  const nextSeen = new Set();
+  addSectionsFromValue(filteredNextData, nextSections, nextSeen);
+
+  const fallbackSections = [];
+  const fallbackSeen = new Set();
+  for (const section of [...(captured.domSections || []), ...(captured.accessibilitySections || [])]) {
+    addSection(section, fallbackSections, fallbackSeen);
+  }
+
+  let sections = apiSections;
+  let extractionMethod = "cdp-admin-api";
+  if (!sections.length) {
+    sections = nextSections;
+    extractionMethod = "cdp-admin-next-data";
+  }
+  if (!sections.length) {
+    sections = fallbackSections;
+    extractionMethod = "cdp-admin-accessibility";
+  }
+
+  const content = domSectionsToHtml(sections);
+  const media = unique([
+    ...extractImageUrls({ apiCalls: filteredApiCalls, nextData: filteredNextData }),
+    ...sections.filter((section) => section.type === "image" && section.src).map((section) => section.src),
+  ]);
+  const title =
+    entry.title || sections.find((section) => section.type === "heading")?.content || slugify(entry.url);
+  const description = sections.find((section) => section.type === "text")?.content || "";
+
+  return {
+    sourceUrl: entry.url,
+    slug: slugify(entry.url),
+    extractedAt: new Date().toISOString(),
+    platform: "squarespace",
+    type: entry.type || normalizeType(null, entry.url),
+    title,
+    content,
+    sections,
+    description,
+    publishDate: null,
+    modifiedDate: null,
+    featuredImage: media[0] || null,
+    tags: [],
+    categories: [],
+    seo: {
+      title,
+      description,
+    },
+    media,
+    extractionMethod,
+    adminPageId: entry.adminPageId,
+    visibility: entry.visibility || null,
+    pageStatus: entry.pageStatus || null,
+    product: extractProductData([filteredApiCalls, filteredNextData]),
+    raw: {
+      apiCalls: filteredApiCalls,
+      nextData: filteredNextData,
+      accessibility: captured.accessibilitySections,
+      domSections: captured.domSections,
+    },
+  };
+}
+
+async function extractAdminRecord(page, entry) {
+  const captured = { apiCalls: [], nextData: null, domSections: [], accessibilitySections: [] };
+
+  const responseHandler = async (response) => {
+    const responseUrl = response.url();
+    const contentType = response.headers()["content-type"] || "";
+    if (!contentType.includes("application/json") || !isAdminApiUrl(responseUrl, entry)) return;
+    try {
+      const data = await response.json();
+      captured.apiCalls.push({ url: responseUrl, data });
+    } catch {}
+  };
+
+  page.on("response", responseHandler);
+  try {
+    await openAdminPage(page, entry);
+
+    captured.nextData = await page.evaluate(() => window.__NEXT_DATA__ || null).catch(() => null);
+    captured.domSections = await getDomSections(page);
+    captured.accessibilitySections = await getAccessibilitySections(page);
+  } finally {
+    page.off("response", responseHandler);
+  }
+
+  return buildAdminRecordFromCaptured(captured, entry);
+}
+
+async function main() {
+  console.log(`Extracting: ${siteUrl}\n`);
+
+  let cookieStr = "";
+  if (cdpPort) {
+    console.log(`Extracting cookies from browser on CDP port ${cdpPort}...`);
+    try {
+      cookieStr = await getCookiesFromCDP(cdpPort, origin);
+      console.log(
+        cookieStr
+          ? `  Got ${cookieStr.split(";").length} cookies`
+          : "  No cookies found for this domain",
+      );
+    } catch (e) {
+      console.error(`  Could not connect to CDP: ${e.message}`);
+      console.error("  Continuing without cookies");
+    }
+  }
+
+  let entries;
+  if (inventoryFile) {
+    console.log(`Loading URLs from ${inventoryFile}...`);
+    entries = loadInventoryEntries(inventoryFile);
+  } else {
+    console.log("No inventory file — run discover.js first for best results.");
+    console.log("Falling back to homepage only.");
+    entries = [{ url: origin, type: "homepage", title: "Homepage", adminPageId: null }];
+  }
+
+  entries = entries.slice(0, limit);
+  console.log(`Processing ${entries.length} URLs...\n`);
+
+  const log = { processed: [], failed: [], mediaDownloaded: [] };
+  const allImageUrls = new Set();
+
+  let adminPage = null;
+  let adminBrowser = null;
+  let publicBrowser = null;
+  let publicPage = null;
+  if (cdpAdmin) {
+    const cdp = await connectToCdpPage(cdpPort);
+    adminBrowser = cdp.browser;
+    adminPage = cdp.page;
+    const publicSession = await createPublicPage();
+    publicBrowser = publicSession.browser;
+    publicPage = publicSession.page;
+  }
+
+  try {
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const slug = slugify(entry.url);
+      process.stdout.write(`[${i + 1}/${entries.length}] ${slug}... `);
+
+      try {
+        let record = null;
+        let publicDomRecord = null;
+        let publicRecord = null;
+
+        if (cdpAdmin && adminPage && entry.adminPageId) {
+          try {
+            record = await extractAdminRecord(adminPage, entry);
+          } catch (e) {
+            log.failed.push({ url: entry.url, error: `Admin extract: ${e.message}` });
+          }
+        }
+
+        if (cdpAdmin && publicPage && shouldUsePublicDomFallback(record, entry)) {
+          try {
+            publicDomRecord = await extractPublicDomRecord(publicPage, entry);
+            if (publicDomRecord?.content) {
+              record = publicDomRecord;
+            }
+          } catch (e) {
+            log.failed.push({ url: entry.url, error: `Public DOM extract: ${e.message}` });
+          }
+        }
+
+        const needsPublicFallback = !record || (!record.content && !record.sections?.length);
+        if (needsPublicFallback || (publicDomRecord && !publicDomRecord.content)) {
+          const publicData = await fetchJSON(entry.url, cookieStr);
+          if (publicData) publicRecord = extractPublicRecord(publicData, entry);
+        }
+
+        record = mergeRecords(record, publicRecord);
+        if (!record) {
+          console.log("skip (no data)");
+          log.failed.push({ url: entry.url, error: "No JSON or admin data" });
+          continue;
+        }
+
+        writeFileSync(`output/pages/${slug}.json`, JSON.stringify(record, null, 2));
+        for (const imageUrl of record.media || []) allImageUrls.add(imageUrl);
+        if (record.featuredImage) allImageUrls.add(record.featuredImage);
+
+        log.processed.push({
+          url: entry.url,
+          slug,
+          type: record.type,
+          extractionMethod: record.extractionMethod,
+        });
+        console.log(
+          `${record.type} (${record.content.length} chars, ${record.media.length} images, ${record.extractionMethod})`,
+        );
+      } catch (e) {
+        console.error(`FAILED: ${e.message}`);
+        log.failed.push({ url: entry.url, error: e.message });
+      }
+
+      if (i < entries.length - 1) await sleep(delay);
+    }
+  } finally {
+    if (adminBrowser) await adminBrowser.close();
+    if (publicBrowser) await publicBrowser.close();
+  }
+
+  console.log(`\nDownloading ${allImageUrls.size} media files...`);
+  let downloaded = 0;
+  for (const imageUrl of allImageUrls) {
+    const pathname = new URL(imageUrl).pathname;
+    const filename = basename(pathname) || `image-${Date.now()}${extname(pathname) || ".jpg"}`;
+    const dest = `output/media/${filename}`;
+    try {
+      await downloadFile(imageUrl, dest);
+      log.mediaDownloaded.push({ url: imageUrl, file: dest });
+      downloaded++;
+      process.stdout.write(".");
+    } catch (e) {
+      log.failed.push({ url: imageUrl, error: `Media download: ${e.message}` });
+      process.stdout.write("x");
+    }
+  }
+
+  writeFileSync("output/extraction-log.json", JSON.stringify(log, null, 2));
+  console.log("\n\nDone.");
+  console.log(`  Pages extracted: ${log.processed.length}`);
+  console.log(`  Media downloaded: ${downloaded}`);
+  console.log(`  Failures: ${log.failed.length}`);
+  if (log.failed.length) console.log("  See output/extraction-log.json for details");
+  console.log("\nRun import.js to publish to WordPress.com");
+}
+
+if (isMainModule) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/scripts/squarespace/import.js
+++ b/scripts/squarespace/import.js
@@ -1,0 +1,555 @@
+#!/usr/bin/env node
+/**
+ * import.js — Step 3: Import Squarespace content to WordPress.com
+ *
+ * Reads output/ from extract.js and publishes to WordPress.com via REST API.
+ * Import order: media → pages → posts → menus
+ *
+ * Usage:
+ *   node scripts/squarespace/import.js --site mysite.wordpress.com --username your-wpcom-user --token APP_PASSWORD
+ *   node scripts/squarespace/import.js --site mysite.wordpress.com --username your-wpcom-user --token APP_PASSWORD --dry-run
+ *
+ * Options:
+ *   --site <domain>    WordPress.com site domain (e.g. mysite.wordpress.com)
+ *   --username <name>  WordPress.com username that owns the application password
+ *   --token <token>    Application password from wordpress.com/me/security/application-passwords
+ *   --dry-run          Show what would be imported without actually doing it
+ *   --only <type>      Only import 'media', 'pages', or 'posts'
+ *
+ * Getting your application password:
+ *   1. Go to wordpress.com/me/security/application-passwords
+ *   2. Create a new application password
+ *   3. Copy the password and pass it as --token
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { pathToFileURL } from "url";
+
+const args = process.argv.slice(2);
+function getArg(name) {
+  const i = args.indexOf(name);
+  return i !== -1 ? args[i + 1] : null;
+}
+
+const site = getArg("--site");
+const username = getArg("--username");
+const token = getArg("--token");
+const dryRun = args.includes("--dry-run");
+const only = getArg("--only");
+const isMainModule = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isMainModule && (!site || !username || !token)) {
+  console.error(
+    "Usage: node scripts/squarespace/import.js --site <wordpress-site> --username <wpcom-user> --token <app-password>",
+  );
+  console.error(
+    "  Get your app password at: wordpress.com/me/security/application-passwords",
+  );
+  process.exit(1);
+}
+
+const PAGE_TYPES = new Set([
+  "page",
+  "homepage",
+  "index",
+  "gallery",
+  "portfolio",
+  "event",
+  "events",
+  "album",
+]);
+const POST_TYPES = new Set(["blog-post"]);
+const PRODUCT_TYPES = new Set(["product", "products"]);
+
+const apiBase = `https://public-api.wordpress.com/rest/v1.1/sites/${site}`;
+const xmlRpcUrl = `https://${site}/xmlrpc.php`;
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function toIso8601(dateString) {
+  if (!dateString) return null;
+  return new Date(dateString)
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+function xmlValue(value) {
+  if (value == null) return "<nil/>";
+  if (Buffer.isBuffer(value))
+    return `<base64>${value.toString("base64")}</base64>`;
+  if (value instanceof Date)
+    return `<dateTime.iso8601>${toIso8601(value.toISOString())}</dateTime.iso8601>`;
+  if (typeof value === "boolean") return `<boolean>${value ? 1 : 0}</boolean>`;
+  if (typeof value === "number")
+    return Number.isInteger(value)
+      ? `<int>${value}</int>`
+      : `<double>${value}</double>`;
+  if (Array.isArray(value)) {
+    return `<array><data>${value.map((item) => `<value>${xmlValue(item)}</value>`).join("")}</data></array>`;
+  }
+  if (typeof value === "object") {
+    return `<struct>${Object.entries(value)
+      .filter(([, item]) => item !== undefined)
+      .map(
+        ([key, item]) =>
+          `<member><name>${escapeXml(key)}</name><value>${xmlValue(item)}</value></member>`,
+      )
+      .join("")}</struct>`;
+  }
+  return `<string>${escapeXml(value)}</string>`;
+}
+
+function parseSimpleXmlRpcValue(xml) {
+  const faultMatch = xml.match(
+    /<fault>[\s\S]*?<name>faultString<\/name>\s*<value><string>([\s\S]*?)<\/string><\/value>[\s\S]*?<\/fault>/,
+  );
+  if (faultMatch) throw new Error(faultMatch[1]);
+
+  const struct = {};
+  const namedStringRegex =
+    /<name>([^<]+)<\/name>\s*<value><string>([\s\S]*?)<\/string><\/value>/g;
+  const namedIntRegex =
+    /<name>([^<]+)<\/name>\s*<value><(?:int|i4)>([\s\S]*?)<\/(?:int|i4)><\/value>/g;
+  const namedBoolRegex =
+    /<name>([^<]+)<\/name>\s*<value><boolean>([01])<\/boolean><\/value>/g;
+  let member;
+  while ((member = namedStringRegex.exec(xml))) struct[member[1]] = member[2];
+  while ((member = namedIntRegex.exec(xml)))
+    struct[member[1]] = Number(member[2]);
+  while ((member = namedBoolRegex.exec(xml)))
+    struct[member[1]] = member[2] === "1";
+  if (Object.keys(struct).length) return struct;
+
+  const stringMatch = xml.match(/<string>([\s\S]*?)<\/string>/);
+  if (stringMatch) return stringMatch[1];
+  const intMatch = xml.match(/<(?:int|i4)>([\s\S]*?)<\/(?:int|i4)>/);
+  if (intMatch) return Number(intMatch[1]);
+  const boolMatch = xml.match(/<boolean>([01])<\/boolean>/);
+  if (boolMatch) return boolMatch[1] === "1";
+
+  return null;
+}
+
+async function xmlRpcCall(methodName, params) {
+  const body = `<?xml version="1.0"?><methodCall><methodName>${methodName}</methodName><params>${params
+    .map((param) => `<param><value>${xmlValue(param)}</value></param>`)
+    .join("")}</params></methodCall>`;
+
+  const res = await fetch(xmlRpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "text/xml" },
+    body,
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${methodName} → ${res.status}: ${text}`);
+  return parseSimpleXmlRpcValue(text);
+}
+
+let cachedBlogId = null;
+async function getBlogId() {
+  if (cachedBlogId) return cachedBlogId;
+  const res = await fetch(apiBase);
+  const data = await res.json().catch(() => ({}));
+  if (!data.ID) throw new Error(`Could not determine site ID for ${site}`);
+  cachedBlogId = data.ID;
+  return cachedBlogId;
+}
+
+// Extract clean text content from accessibility tree nodes
+function buildContentFromAccessibility(nodes) {
+  if (!nodes?.length) return "";
+  const blocks = [];
+  for (const node of nodes) {
+    if (!node.name) continue;
+    if (node.role === "heading") {
+      // Guess heading level from name length (crude but works as fallback)
+      blocks.push(`<h2>${node.name}</h2>`);
+    } else if (
+      ["paragraph", "StaticText", "article", "section"].includes(node.role)
+    ) {
+      blocks.push(`<p>${node.name}</p>`);
+    } else if (node.role === "img" && node.description) {
+      blocks.push(`<!-- image: ${node.description} -->`);
+    }
+  }
+  return blocks.join("\n");
+}
+
+// Extract the best available content from a page JSON file
+export function extractContent(pageData) {
+  // Direct content field (Squarespace extract.js produces this)
+  if (pageData.content) return pageData.content;
+
+  for (const call of pageData.apiCalls || []) {
+    // Blog post body is typically in post.content or post.richContent
+    const body =
+      call.data?.post?.content?.plainText ||
+      call.data?.post?.richContent ||
+      call.data?.content?.plainText;
+    if (body)
+      return typeof body === "string" ? `<p>${body}</p>` : JSON.stringify(body);
+  }
+
+  // JSON-LD article body
+  const article = pageData.globals?.jsonLd?.find(
+    (j) => j["@type"] === "Article" || j["@type"] === "BlogPosting",
+  );
+  if (article?.articleBody) return `<p>${article.articleBody}</p>`;
+
+  // Fallback to accessibility tree
+  return buildContentFromAccessibility(pageData.accessibility);
+}
+
+export function extractMeta(pageData) {
+  return {
+    title: pageData.title || pageData.slug,
+    description: pageData.description || "",
+    featuredImageUrl: pageData.featuredImage || null,
+    publishDate: pageData.publishDate || null,
+    modifiedDate: pageData.modifiedDate || null,
+    slug: pageData.slug,
+    tags: pageData.tags || [],
+    categories: pageData.categories || [],
+  };
+}
+
+function guessMimeType(filename) {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".gif")) return "image/gif";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".svg")) return "image/svg+xml";
+  if (lower.endsWith(".avif")) return "image/avif";
+  return "application/octet-stream";
+}
+
+async function uploadMedia(filePath, filename) {
+  if (dryRun) {
+    console.log(`  [dry-run] Would upload: ${filename}`);
+    return {
+      id: 0,
+      source_url: `https://example.com/wp-content/uploads/${filename}`,
+    };
+  }
+  const fileBuffer = readFileSync(filePath);
+  const blogId = await getBlogId();
+  const result = await xmlRpcCall("wp.uploadFile", [
+    blogId,
+    username,
+    token,
+    {
+      name: filename,
+      type: guessMimeType(filename),
+      bits: fileBuffer,
+      overwrite: true,
+    },
+  ]);
+
+  return {
+    id: result.id || 0,
+    source_url: result.url,
+  };
+}
+
+function loadOriginalMediaUrlsByFile() {
+  const byFile = {};
+  if (!existsSync("output/extraction-log.json")) return byFile;
+
+  try {
+    const log = JSON.parse(readFileSync("output/extraction-log.json", "utf8"));
+    for (const item of log.mediaDownloaded || []) {
+      if (!item?.file || !item?.url) continue;
+      const filename = item.file.split("/").pop();
+      if (!filename) continue;
+      byFile[filename] ||= [];
+      byFile[filename].push(item.url);
+    }
+  } catch (e) {
+    console.warn(`Could not read output/extraction-log.json: ${e.message}`);
+  }
+
+  return byFile;
+}
+
+async function importMedia() {
+  if (!existsSync("output/media")) {
+    console.log("No media folder found.");
+    return {};
+  }
+
+  const files = readdirSync("output/media");
+  console.log(`\nUploading ${files.length} media files...`);
+
+  const mediaMap = {};
+  const originalUrlsByFile = loadOriginalMediaUrlsByFile();
+  for (const file of files) {
+    process.stdout.write(`  ${file}... `);
+    try {
+      const result = await uploadMedia(`output/media/${file}`, file);
+      for (const originalUrl of originalUrlsByFile[file] || []) {
+        mediaMap[originalUrl] = result.source_url;
+      }
+      console.log(`\u2713 ${result.source_url}`);
+    } catch (e) {
+      console.log(`\u2717 ${e.message}`);
+    }
+  }
+  return mediaMap;
+}
+
+export function replaceMediaUrls(content, mediaMap) {
+  if (!content) return "";
+
+  let nextContent = content;
+  const entries = Object.entries(mediaMap).sort(
+    ([a], [b]) => b.length - a.length,
+  );
+  for (const [originalUrl, wpUrl] of entries) {
+    nextContent = nextContent.replaceAll(originalUrl, wpUrl);
+  }
+  return nextContent;
+}
+
+export function classifyFilesForImport(
+  pageFiles,
+  pageDataByFile,
+  inventoryTypeMap = {},
+) {
+  const typeMap = {};
+
+  for (const file of pageFiles) {
+    const slug = file.replace(".json", "");
+    const pageData = pageDataByFile[file] || null;
+    typeMap[slug] = pageData?.type || inventoryTypeMap[slug] || null;
+  }
+
+  const pages = pageFiles.filter((file) => {
+    const slug = file.replace(".json", "");
+    return !typeMap[slug] || PAGE_TYPES.has(typeMap[slug]);
+  });
+  const posts = pageFiles.filter((file) => {
+    const slug = file.replace(".json", "");
+    return POST_TYPES.has(typeMap[slug]);
+  });
+  const products = pageFiles.filter((file) => {
+    const slug = file.replace(".json", "");
+    return PRODUCT_TYPES.has(typeMap[slug]);
+  });
+  const unsupported = pageFiles.filter(
+    (file) =>
+      !pages.includes(file) &&
+      !posts.includes(file) &&
+      !products.includes(file),
+  );
+
+  return { typeMap, pages, posts, products, unsupported };
+}
+
+async function importPage(pageData, mediaMap) {
+  const meta = extractMeta(pageData);
+  const content = replaceMediaUrls(extractContent(pageData), mediaMap);
+
+  if (dryRun) {
+    console.log(`  [dry-run] Would create page: ${meta.title} (${meta.slug})`);
+    return { id: 0, link: "#" };
+  }
+
+  const blogId = await getBlogId();
+  const id = await xmlRpcCall("wp.newPost", [
+    blogId,
+    username,
+    token,
+    {
+      post_type: "page",
+      post_status: "draft",
+      post_title: meta.title,
+      post_content: content,
+      post_excerpt: meta.description,
+      wp_slug: meta.slug,
+    },
+  ]);
+
+  return {
+    id,
+    link: `https://${site}/wp-admin/post.php?post=${id}&action=edit`,
+  };
+}
+
+async function importPost(pageData, mediaMap) {
+  const meta = extractMeta(pageData);
+  const content = replaceMediaUrls(extractContent(pageData), mediaMap);
+
+  if (dryRun) {
+    console.log(`  [dry-run] Would create post: ${meta.title} (${meta.slug})`);
+    return { id: 0, link: "#" };
+  }
+
+  const blogId = await getBlogId();
+  const id = await xmlRpcCall("wp.newPost", [
+    blogId,
+    username,
+    token,
+    {
+      post_type: "post",
+      post_status: "draft",
+      post_title: meta.title,
+      post_content: content,
+      post_excerpt: meta.description,
+      wp_slug: meta.slug,
+      post_date: meta.publishDate ? new Date(meta.publishDate) : undefined,
+      terms_names:
+        meta.categories?.length || meta.tags?.length
+          ? {
+              category: meta.categories || [],
+              post_tag: meta.tags || [],
+            }
+          : undefined,
+    },
+  ]);
+
+  return {
+    id,
+    link: `https://${site}/wp-admin/post.php?post=${id}&action=edit`,
+  };
+}
+
+async function main() {
+  if (dryRun) console.log("[DRY RUN — no changes will be made]\n");
+
+  if (!existsSync("output/pages")) {
+    console.error("No output/pages directory found. Run extract.js first.");
+    process.exit(1);
+  }
+
+  const pageFiles = readdirSync("output/pages").filter((f) =>
+    f.endsWith(".json"),
+  );
+  console.log(`Found ${pageFiles.length} extracted pages`);
+
+  const inventoryTypeMap = {};
+  if (existsSync("output/inventory.json")) {
+    const inventory = JSON.parse(readFileSync("output/inventory.json", "utf8"));
+    for (const item of inventory.urls) {
+      const slug =
+        new URL(item.url).pathname.replace(/^\//, "").replace(/\//g, "--") ||
+        "homepage";
+      inventoryTypeMap[slug] = item.type;
+    }
+  }
+
+  const pageDataByFile = new Map();
+  const urlMap = [];
+
+  let mediaMap = {};
+  if (!only || only === "media") {
+    mediaMap = await importMedia();
+  }
+
+  for (const file of pageFiles) {
+    try {
+      const pd = JSON.parse(readFileSync(`output/pages/${file}`, "utf8"));
+      pageDataByFile.set(file, pd);
+    } catch {}
+  }
+
+  const { typeMap, pages, posts, products, unsupported } =
+    classifyFilesForImport(
+      pageFiles,
+      Object.fromEntries(pageDataByFile),
+      inventoryTypeMap,
+    );
+
+  if (!only || only === "pages") {
+    console.log(`\nImporting ${pages.length} pages...`);
+    for (const file of pages) {
+      const pageData =
+        pageDataByFile.get(file) ||
+        JSON.parse(readFileSync(`output/pages/${file}`, "utf8"));
+      const slug = file.replace(".json", "");
+      process.stdout.write(`  ${slug}... `);
+      try {
+        const result = await importPage(pageData, mediaMap);
+        console.log(`\u2713 ${result.link}`);
+        if (pageData.sourceUrl)
+          urlMap.push({ old: pageData.sourceUrl, new: result.link });
+      } catch (e) {
+        console.log(`\u2717 ${e.message}`);
+      }
+    }
+  }
+
+  if (!only || only === "posts") {
+    console.log(`\nImporting ${posts.length} blog posts...`);
+    for (const file of posts) {
+      const pageData =
+        pageDataByFile.get(file) ||
+        JSON.parse(readFileSync(`output/pages/${file}`, "utf8"));
+      const slug = file.replace(".json", "");
+      process.stdout.write(`  ${slug}... `);
+      try {
+        const result = await importPost(pageData, mediaMap);
+        console.log(`\u2713 ${result.link}`);
+        if (pageData.sourceUrl)
+          urlMap.push({ old: pageData.sourceUrl, new: result.link });
+      } catch (e) {
+        console.log(`\u2717 ${e.message}`);
+      }
+    }
+  }
+
+  if (!only || only === "pages" || only === "posts") {
+    if (products.length) {
+      console.log(
+        `\nSkipped ${products.length} product records (WooCommerce import is out of scope):`,
+      );
+      for (const file of products) {
+        const pageData = pageDataByFile.get(file);
+        const title = pageData?.title || file.replace(".json", "");
+        console.log(`  ${title} [${typeMap[file.replace(".json", "")]}]`);
+      }
+    }
+
+    if (unsupported.length) {
+      console.log(
+        `\nSkipped ${unsupported.length} records with unsupported types:`,
+      );
+      for (const file of unsupported) {
+        console.log(
+          `  ${file.replace(".json", "")} [${typeMap[file.replace(".json", "")] || "unknown"}]`,
+        );
+      }
+    }
+  }
+
+  if (urlMap.length) {
+    const { writeFileSync } = await import("fs");
+    writeFileSync("output/redirect-map.json", JSON.stringify(urlMap, null, 2));
+    console.log(`\nRedirect map written to output/redirect-map.json`);
+    console.log(
+      "Use this to set up 301 redirects from your old site URLs to WordPress.",
+    );
+  }
+
+  console.log(
+    "\nImport complete. All content created as drafts — review in WordPress admin before publishing.",
+  );
+  console.log(`https://${site}/wp-admin/`);
+}
+
+if (isMainModule) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- New `scripts/squarespace/discover.js` — inventories a Squarespace site via CDP admin interception or public `?format=json` API. Merges admin + public inventory for draft/unlisted page coverage.
- New `scripts/squarespace/extract.js` — extracts content via admin API interception, `__NEXT_DATA__` hydration, and public DOM fallback. Downloads media from Squarespace CDN.
- New `scripts/squarespace/import.js` — publishes to WordPress.com via XML-RPC. Squarespace has its own import script because its extracted data has a different shape (top-level `content`/`title`/`description` fields, `extraction-log.json` for full-URL media mapping, and platform-specific type classification for galleries, portfolios, albums, etc.).
- New `prompts/squarespace.md` — user-facing migration prompt covering CDP setup, content extraction, and import.
- Updated `scripts/import.js` — fixes hardcoded `wix-escape` username in Basic auth header, now requires `--username` flag.
- Updated `AGENTS.md`, `README.md`, `DISCOVERIES.md` with Squarespace documentation.

## How I found it

Built and tested as a new platform contribution. Squarespace's admin uses Next.js with interceptable API calls (`/api/catalog-preview/`, `/api/content/`), and the public site exposes `?format=json` endpoints without authentication.

## Tested against
- [x] Real Squarespace site (nonagon-flounder-8x38.squarespace.com)
- [x] CDP admin discovery + extraction
- [x] Full end-to-end import to squarespaceimporttest5.wordpress.com
- [x] 11 media files uploaded, 3 pages created as drafts
- [x] Product records correctly identified and skipped

## Future improvements
- Product/commerce migration (currently extracted but skipped at import time)
- Block conversion — map Squarespace sections to `core/paragraph`, `core/image`, `core/heading` blocks instead of importing as custom HTML

## Discovery log entry added to DISCOVERIES.md
- [x] Yes