### PR TITLE
fix(qa): correct content-differ direction semantics

### DIFF
--- a/src/lib/qa/content-differ.ts
+++ b/src/lib/qa/content-differ.ts
@@ -22,54 +22,55 @@ export function diffContent(origin: ContentModel, wxr: ContentModel, postTitle?:
     origin.images.length === 0 &&
     origin.links.length === 0;
 
-  // Use containment (what fraction of WXR words appear in the origin) rather
-  // than Jaccard similarity. The origin page often has far more content than
-  // what we extract (JS widgets, section builders, etc.), which tanks Jaccard.
-  // Containment answers the right question: "is the extracted content real?"
-  const textSimilarity = isEmpty ? 1 : containment(wxr.text, origin.text);
+  // `missing` semantics across this module: items present in the origin
+  // that we failed to carry into the WXR output. This matches both the UI
+  // label ("N missing images") and the test expectations. Detects extraction
+  // loss — the thing users actually want to know about.
+  const textSimilarity = isEmpty ? 1 : containment(origin.text, wxr.text);
 
   // Filter out the post title h1 from origin headings — WXR stores it as metadata, not content
   const originHeadings = postTitle
     ? origin.headings.filter((h) => !(h.level === 1 && normalize(h.text) === normalize(postTitle)))
     : origin.headings;
 
-  // Headings: check that WXR headings exist in the origin (containment direction)
-  const originHeadingSet = new Set(originHeadings.map((h) => `${h.level}:${normalize(h.text)}`));
-  const missingHeadings = wxr.headings.filter(
-    (wh) => !originHeadingSet.has(`${wh.level}:${normalize(wh.text)}`),
+  // Headings: origin headings not carried over to WXR
+  const wxrHeadingSet = new Set(wxr.headings.map((h) => `${h.level}:${normalize(h.text)}`));
+  const missingHeadings = originHeadings.filter(
+    (oh) => !wxrHeadingSet.has(`${oh.level}:${normalize(oh.text)}`),
   );
 
-  // Images: check that WXR images exist in the origin (containment direction)
-  const originFilenames = new Set(origin.images.map((img) => extractFilename(img.src)));
-  const missingImages = wxr.images.filter(
-    (img) => !originFilenames.has(extractFilename(img.src)),
+  // Images: origin images not carried over to WXR (match on filename so the
+  // CDN query string / host rewrite doesn't produce false negatives)
+  const wxrFilenames = new Set(wxr.images.map((img) => extractFilename(img.src)));
+  const missingImages = origin.images.filter(
+    (img) => !wxrFilenames.has(extractFilename(img.src)),
   );
 
-  // Links: check that WXR links exist in the origin (containment direction)
-  const originHrefs = new Set(origin.links.map((l) => l.href));
-  const missingLinks = wxr.links.filter((l) => !originHrefs.has(l.href));
+  // Links: origin links not carried over to WXR
+  const wxrHrefs = new Set(wxr.links.map((l) => l.href));
+  const missingLinks = origin.links.filter((l) => !wxrHrefs.has(l.href));
 
   const headingsMatch = {
     origin: originHeadings.length,
     wxr: wxr.headings.length,
-    missing: missingHeadings.length, // WXR headings NOT found in origin
+    missing: missingHeadings.length,
   };
   const imagesMatch = {
     origin: origin.images.length,
     wxr: wxr.images.length,
-    missing: missingImages.length, // WXR images NOT found in origin
+    missing: missingImages.length,
   };
   const linksMatch = {
     origin: origin.links.length,
     wxr: wxr.links.length,
-    missing: missingLinks.length, // WXR links NOT found in origin
+    missing: missingLinks.length,
   };
 
-  // Grade: weighted score — text 50%, headings 20%, images 20%, links 10%
-  // Scores measure containment: what fraction of WXR content is verified in origin
-  const headingsScore = wxr.headings.length === 0 ? 1 : 1 - missingHeadings.length / wxr.headings.length;
-  const imagesScore = wxr.images.length === 0 ? 1 : 1 - missingImages.length / wxr.images.length;
-  const linksScore = wxr.links.length === 0 ? 1 : 1 - missingLinks.length / wxr.links.length;
+  // Grade: weighted score — text 50%, headings 20%, images 20%, links 10%.
+  // Each dimension measures "what fraction of origin content made it into WXR".
+  const headingsScore = originHeadings.length === 0 ? 1 : 1 - missingHeadings.length / originHeadings.length;
+  const imagesScore = origin.images.length === 0 ? 1 : 1 - missingImages.length / origin.images.length;
+  const linksScore = origin.links.length === 0 ? 1 : 1 - missingLinks.length / origin.links.length;
 
   const overall = isEmpty
     ? 1
@@ -102,8 +103,8 @@ function normalize(s: string): string {
 
 /**
  * What fraction of words in `subset` also appear in `superset`?
- * Returns 1.0 when every extracted word exists in the origin — meaning
- * we captured real content, even if the origin has much more.
+ * Called with `containment(origin, wxr)` to answer "how much of the origin
+ * content was preserved in the WXR output".
  */
 function containment(subset: string, superset: string): number {
   const subWords = wordSet(subset);


### PR DESCRIPTION
## What this changes

Flips the direction of `diffContent` in `src/lib/qa/content-differ.ts` so it measures extraction *loss* (origin items not in WXR) instead of hallucination (WXR items not in origin). This matches both the UI label ("N missing images") and the long-standing test expectations.

## How I found it

Four tests in `test/content-differ.test.ts` had been failing on `main` for a while. The impl had drifted to "hallucination detection" semantics while every consumer was written for "extraction loss" detection. Consumer code didn't need to change — the test/UI contract was always the correct one.

## Type of change

- [x] Bug fix

## Tested

```
npm test -- test/content-differ.test.ts
# 7/7 passing (previously 3/7)
```

## Scope

- 1 commit, 1 file (`src/lib/qa/content-differ.ts`), +27/-26 lines
- No API shape changes; `ContentDiff` fields keep the same names and types
- Independent of any other in-flight work, ships first