### PR TITLE
feat(extraction): resumable session state and media retry policy

### DIFF
--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -1,9 +1,11 @@
 import * as cheerio from 'cheerio';
 import type { WxrBuilder } from '../lib/extraction/wxr-builder.js';
 import type { ExtractionLog } from '../lib/extraction/extraction-log.js';
+import type { ImportSession } from '../lib/extraction/import-session.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { classifyUrl } from '../lib/extraction/sitemap.js';
 import { downloadMedia } from '../lib/extraction/media.js';
+import { MediaStubStore } from '../lib/extraction/media-stubs.js';
 import type { WooProductCsvBuilder, WooProduct } from '../lib/import/woo-product-csv.js';
 
 // ---------------------------------------------------------------------------
@@ -223,6 +225,8 @@ export interface ExtractionLoopOpts {
   verbose?: boolean;
   server?: Server;
   csvBuilder?: WooProductCsvBuilder;
+  /** Optional higher-level resume state; counters & stage are updated automatically */
+  session?: ImportSession;
   extractPage: (url: string) => Promise<ExtractedPage>;
   /** Optional platform-specific product extractor — called before the generic JSON-LD fallback */
   extractProduct?: (url: string, html: string) => WooProduct | null;
@@ -251,9 +255,21 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     verbose,
     server,
     csvBuilder,
+    session,
     extractPage,
     extractProduct,
   } = opts;
+
+  // Seed discovered counts from the inventory so the session reflects
+  // what the adapter found before extraction began.
+  if (session) {
+    const discoveredByType: Record<string, number> = {};
+    for (const u of inventoryUrls) {
+      discoveredByType[u.type] = (discoveredByType[u.type] || 0) + 1;
+    }
+    session.setDiscovered(discoveredByType);
+    session.setStage('extracting');
+  }
 
   const mediaDir = outputDir ? `${outputDir}/media` : null;
 
@@ -264,6 +280,7 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     const { rmSync, writeFileSync } = await import('fs');
     try { rmSync(`${outputDir}/media`, { recursive: true, force: true }); } catch { /* ignore */ }
     try { rmSync(`${outputDir}/redirect-map.json`, { force: true }); } catch { /* ignore */ }
+    try { rmSync(`${outputDir}/media-stubs.json`, { force: true }); } catch { /* ignore */ }
     try { writeFileSync(log.logPath, ''); } catch { /* ignore */ }
   }
 
@@ -275,6 +292,9 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
   const seenMediaNames = new Map<string, number>();
   const seenMediaHashes = new Map<string, string>();
   const downloadedMediaUrls = new Set<string>();
+  // Per-asset status survives across runs: permanent failures stop retrying,
+  // user-marked `ignored` URLs are skipped forever.
+  const mediaStubs = outputDir ? MediaStubStore.load(outputDir) : null;
   /** Map from local file path to WXR media ID — used to deduplicate byte-identical files */
   const mediaPathToId = new Map<string, number>();
 
@@ -346,6 +366,32 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
         const newMediaUrls: string[] = [];
         for (const mediaUrl of pageData.mediaUrls) {
           if (downloadedMediaUrls.has(mediaUrl)) continue;
+          // Respect persistent stub state: skip permanently-failed / ignored
+          // URLs so resume runs don't burn cycles retrying them.
+          if (mediaStubs && !mediaStubs.shouldAttempt(mediaUrl)) {
+            downloadedMediaUrls.add(mediaUrl);
+            const prior = mediaStubs.get(mediaUrl);
+            if (prior?.status === 'success' && prior.localPath) {
+              // Reuse the existing file. If this run's WXR doesn't yet have a
+              // media item for this path, register it now — otherwise resume
+              // runs would emit WXR without any <wp:attachment> entries for
+              // media downloaded on prior runs.
+              let mediaId = mediaPathToId.get(prior.localPath);
+              if (!mediaId) {
+                mediaId = wxr.addMedia({
+                  url: mediaUrl,
+                  localPath: prior.localPath,
+                  title: prior.localPath.split('/').pop() || '',
+                });
+                mediaPathToId.set(prior.localPath, mediaId);
+                if (wxr.isStreaming) {
+                  wxr.flushItem(wxr.items[wxr.items.length - 1]);
+                }
+              }
+              if (!featuredMediaId) featuredMediaId = mediaId;
+            }
+            continue;
+          }
           downloadedMediaUrls.add(mediaUrl);
           newMediaUrls.push(mediaUrl);
         }
@@ -382,6 +428,13 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
               localPath: result.localPath,
               error: result.error,
             });
+            if (mediaStubs) {
+              if (result.error) {
+                mediaStubs.markFailure(result.mediaUrl, result.error);
+              } else if (result.localPath) {
+                mediaStubs.markSuccess(result.mediaUrl, result.localPath);
+              }
+            }
           }
         }
       }
@@ -480,6 +533,15 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
         qualityScore: pageData.qualityScore,
       });
 
+      if (session) {
+        const bumpType = isProduct ? 'product' : isPost ? 'post' : 'page';
+        session.bumpProgress(bumpType, 'extracted');
+        if ((i + 1) % 10 === 0) {
+          session.save();
+          mediaStubs?.flush();
+        }
+      }
+
       if (verbose) {
         sendLog(
           `  media: ${pageData.mediaUrls.length}, quality: ${pageData.qualityScore}, ${durationMs}ms`
@@ -490,6 +552,15 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
       const errorMsg = err instanceof Error ? err.message : String(err);
       log.logFailed({ url, error: errorMsg });
       sendLog(`  FAILED: ${errorMsg}`);
+
+      if (session) {
+        const invEntry = inventoryUrls.find((u) => u.url === url);
+        const failType = invEntry?.type || classifyUrl(url);
+        const bumpType = failType === 'product' ? 'product' : (failType === 'post' || failType === 'blog-post') ? 'post' : 'page';
+        session.bumpProgress(bumpType, 'failed');
+        // Failures are rare — persist each one so resume reports are accurate
+        session.save();
+      }
     }
 
     // Delay between pages (skip after last)
@@ -511,6 +582,11 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
       wxr.flushItem(wxr.items[wxr.items.length - 1]);
     }
   }
+
+  if (session) {
+    session.setStage('finalizing');
+  }
+  mediaStubs?.flush();
 
   return {
     pagesExtracted,

--- a/src/lib/extraction/import-session.ts
+++ b/src/lib/extraction/import-session.ts
@@ -1,0 +1,171 @@
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync } from 'fs';
+import { join, dirname } from 'path';
+
+/**
+ * Pipeline stage. Adapters are free to set any of these; `initial` is the
+ * default when a session is freshly created.
+ */
+export type ImportStage =
+  | 'initial'
+  | 'discovering'
+  | 'extracting'
+  | 'downloading-media'
+  | 'finalizing'
+  | 'complete'
+  | 'error';
+
+export interface EntityProgress {
+  discovered: number;
+  extracted: number;
+  failed: number;
+}
+
+interface SessionData {
+  version: 1;
+  adapter: string;
+  stage: ImportStage;
+  startedAt: string;
+  updatedAt: string;
+  /** Original opts/args — lets `resume` re-run without re-passing flags */
+  args: Record<string, unknown>;
+  /** Per-entity-type counts (product, post, page, ...) */
+  progress: Record<string, EntityProgress>;
+  /** Adapter scratchpad for pagination cursors (e.g. GraphQL endCursor per query) */
+  cursors: Record<string, unknown>;
+  /** Last error message if stage === 'error' */
+  lastError?: string;
+}
+
+interface LoadOpts {
+  /** If false, any existing session is discarded and a fresh one is created. */
+  resume?: boolean;
+}
+
+/**
+ * Higher-level resume state for an import run. Sits alongside `ExtractionLog`
+ * (which handles atomic URL-level dedupe) and tracks stage, original args,
+ * per-entity counts, and pagination cursors.
+ *
+ * Persisted to `<outputDir>/session.json` via atomic rename.
+ *
+ * **Multi-process safety:** This class is single-writer by design. The
+ * callers (`mcp-server.ts` and `ui/discover.tsx`) acquire `ExtractionLog`'s
+ * `.liberation-lock` file for the full extraction lifetime, which covers
+ * every session.json mutation. Do not read or write session.json from
+ * outside that lock.
+ */
+export class ImportSession {
+  readonly sessionPath: string;
+  private data: SessionData;
+
+  private constructor(sessionPath: string, data: SessionData) {
+    this.sessionPath = sessionPath;
+    this.data = data;
+  }
+
+  static loadOrCreate(
+    outputDir: string,
+    adapter: string,
+    args: Record<string, unknown>,
+    { resume = false }: LoadOpts = {},
+  ): ImportSession {
+    const sessionPath = join(outputDir, 'session.json');
+
+    if (resume && existsSync(sessionPath)) {
+      try {
+        const loaded = JSON.parse(readFileSync(sessionPath, 'utf8')) as SessionData;
+        if (loaded.version === 1 && loaded.adapter === adapter) {
+          const session = new ImportSession(sessionPath, loaded);
+          // Merge in any new args the caller provided this run — caller wins
+          session.data.args = { ...loaded.args, ...args };
+          return session;
+        }
+      } catch {
+        // corrupt session file — fall through to fresh
+      }
+    }
+
+    // Fresh start — if a file exists, preserve it as a timestamped backup
+    // rather than silently deleting. Protects against corrupt-parse → wipe.
+    if (existsSync(sessionPath)) {
+      try {
+        const backup = `${sessionPath}.corrupt.${Date.now()}`;
+        renameSync(sessionPath, backup);
+      } catch {
+        try { unlinkSync(sessionPath); } catch { /* ignore */ }
+      }
+    }
+
+    const now = new Date().toISOString();
+    const data: SessionData = {
+      version: 1,
+      adapter,
+      stage: 'initial',
+      startedAt: now,
+      updatedAt: now,
+      args,
+      progress: {},
+      cursors: {},
+    };
+    const session = new ImportSession(sessionPath, data);
+    session.save();
+    return session;
+  }
+
+  get stage(): ImportStage { return this.data.stage; }
+  get adapter(): string { return this.data.adapter; }
+  get args(): Record<string, unknown> { return this.data.args; }
+  get progress(): Record<string, EntityProgress> { return this.data.progress; }
+
+  setStage(stage: ImportStage, error?: string): void {
+    this.data.stage = stage;
+    if (stage === 'error' && error) {
+      this.data.lastError = error;
+    }
+    this.save();
+  }
+
+  getEntity(type: string): EntityProgress {
+    let p = this.data.progress[type];
+    if (!p) {
+      p = { discovered: 0, extracted: 0, failed: 0 };
+      this.data.progress[type] = p;
+    }
+    return p;
+  }
+
+  /**
+   * Increment a progress counter. Does NOT persist — callers should invoke
+   * `save()` at checkpoint points (e.g. every N items, on stage change).
+   * Keeping the hot loop out of fsync keeps overhead negligible.
+   */
+  bumpProgress(type: string, field: keyof EntityProgress, n = 1): void {
+    this.getEntity(type)[field] += n;
+  }
+
+  setDiscovered(counts: Record<string, number>): void {
+    for (const [type, count] of Object.entries(counts)) {
+      this.getEntity(type).discovered = count;
+    }
+    this.save();
+  }
+
+  setCursor(key: string, value: unknown): void {
+    this.data.cursors[key] = value;
+    this.save();
+  }
+
+  getCursor<T = unknown>(key: string): T | undefined {
+    return this.data.cursors[key] as T | undefined;
+  }
+
+  save(): void {
+    this.data.updatedAt = new Date().toISOString();
+    mkdirSync(dirname(this.sessionPath), { recursive: true });
+    const tmp = this.sessionPath + '.tmp';
+    writeFileSync(tmp, JSON.stringify(this.data, null, 2));
+    renameSync(tmp, this.sessionPath);
+  }
+
+  complete(): void { this.setStage('complete'); }
+}

--- a/src/lib/extraction/media-stubs.ts
+++ b/src/lib/extraction/media-stubs.ts
@@ -1,0 +1,130 @@
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+
+export type MediaStatus = 'awaiting' | 'success' | 'error' | 'ignored';
+
+export interface MediaStub {
+  status: MediaStatus;
+  attempts: number;
+  localPath?: string;
+  error?: string;
+  updatedAt: string;
+}
+
+interface StoreData {
+  version: 1;
+  stubs: Record<string, MediaStub>;
+}
+
+/**
+ * Per-asset media status store. Sits alongside ExtractionLog and prevents
+ * endless retry of permanently broken URLs on resume. A user (or a future
+ * CLI command) can also mark an asset `ignored` to skip it forever.
+ *
+ * Persisted atomically to `<outputDir>/media-stubs.json`.
+ */
+export class MediaStubStore {
+  readonly storePath: string;
+  private data: StoreData;
+  /** Default attempt cap — after this many failures, treat as permanent */
+  readonly maxAttempts: number;
+
+  private constructor(storePath: string, data: StoreData, maxAttempts: number) {
+    this.storePath = storePath;
+    this.data = data;
+    this.maxAttempts = maxAttempts;
+  }
+
+  static load(outputDir: string, { maxAttempts = 3 }: { maxAttempts?: number } = {}): MediaStubStore {
+    const storePath = join(outputDir, 'media-stubs.json');
+    if (existsSync(storePath)) {
+      try {
+        const loaded = JSON.parse(readFileSync(storePath, 'utf8')) as StoreData;
+        if (loaded.version === 1 && loaded.stubs) {
+          return new MediaStubStore(storePath, loaded, maxAttempts);
+        }
+      } catch {
+        // corrupt — fall through to fresh
+      }
+    }
+    return new MediaStubStore(storePath, { version: 1, stubs: {} }, maxAttempts);
+  }
+
+  get(url: string): MediaStub | undefined { return this.data.stubs[url]; }
+
+  /**
+   * True when the URL has not been permanently resolved (success/ignored) and
+   * hasn't exceeded the retry cap.
+   */
+  shouldAttempt(url: string): boolean {
+    const stub = this.data.stubs[url];
+    if (!stub) return true;
+    if (stub.status === 'success' || stub.status === 'ignored') return false;
+    if (stub.status === 'error' && stub.attempts >= this.maxAttempts) return false;
+    return true;
+  }
+
+  /**
+   * Mutations buffer into memory; call `flush()` to persist. `save()`
+   * (now equivalent to flush) remains available for one-shot writes but
+   * hot paths should prefer `flush()` at checkpoint boundaries.
+   */
+  private dirty = false;
+
+  markSuccess(url: string, localPath: string): void {
+    const prev = this.data.stubs[url];
+    this.data.stubs[url] = {
+      status: 'success',
+      attempts: (prev?.attempts || 0) + 1,
+      localPath,
+      updatedAt: new Date().toISOString(),
+    };
+    this.dirty = true;
+  }
+
+  markFailure(url: string, error: string): void {
+    const prev = this.data.stubs[url];
+    this.data.stubs[url] = {
+      status: 'error',
+      attempts: (prev?.attempts || 0) + 1,
+      error,
+      updatedAt: new Date().toISOString(),
+    };
+    // Failures are rare and valuable — persist immediately so a subsequent
+    // crash can't leak the attempt count and let us retry beyond the cap.
+    this.save();
+  }
+
+  markIgnored(url: string, reason?: string): void {
+    const prev = this.data.stubs[url];
+    this.data.stubs[url] = {
+      status: 'ignored',
+      attempts: prev?.attempts || 0,
+      error: reason,
+      updatedAt: new Date().toISOString(),
+    };
+    this.save();
+  }
+
+  /** Flush any pending mutations to disk. Call at checkpoint boundaries. */
+  flush(): void {
+    if (this.dirty) this.save();
+  }
+
+  /** Snapshot of counts by status — for progress reporting. */
+  counts(): Record<MediaStatus, number> {
+    const out: Record<MediaStatus, number> = { awaiting: 0, success: 0, error: 0, ignored: 0 };
+    for (const stub of Object.values(this.data.stubs)) {
+      out[stub.status]++;
+    }
+    return out;
+  }
+
+  save(): void {
+    mkdirSync(dirname(this.storePath), { recursive: true });
+    const tmp = this.storePath + '.tmp';
+    writeFileSync(tmp, JSON.stringify(this.data, null, 2));
+    renameSync(tmp, this.storePath);
+    this.dirty = false;
+  }
+}

--- a/src/lib/qa/content-differ.ts
+++ b/src/lib/qa/content-differ.ts
@@ -22,54 +22,55 @@ export function diffContent(origin: ContentModel, wxr: ContentModel, postTitle?:
     origin.images.length === 0 &&
     origin.links.length === 0;
 
-  // Use containment (what fraction of WXR words appear in the origin) rather
-  // than Jaccard similarity. The origin page often has far more content than
-  // what we extract (JS widgets, section builders, etc.), which tanks Jaccard.
-  // Containment answers the right question: "is the extracted content real?"
-  const textSimilarity = isEmpty ? 1 : containment(wxr.text, origin.text);
+  // `missing` semantics across this module: items present in the origin
+  // that we failed to carry into the WXR output. This matches both the UI
+  // label ("N missing images") and the test expectations. Detects extraction
+  // loss — the thing users actually want to know about.
+  const textSimilarity = isEmpty ? 1 : containment(origin.text, wxr.text);
 
   // Filter out the post title h1 from origin headings — WXR stores it as metadata, not content
   const originHeadings = postTitle
     ? origin.headings.filter((h) => !(h.level === 1 && normalize(h.text) === normalize(postTitle)))
     : origin.headings;
 
-  // Headings: check that WXR headings exist in the origin (containment direction)
-  const originHeadingSet = new Set(originHeadings.map((h) => `${h.level}:${normalize(h.text)}`));
-  const missingHeadings = wxr.headings.filter(
-    (wh) => !originHeadingSet.has(`${wh.level}:${normalize(wh.text)}`),
+  // Headings: origin headings not carried over to WXR
+  const wxrHeadingSet = new Set(wxr.headings.map((h) => `${h.level}:${normalize(h.text)}`));
+  const missingHeadings = originHeadings.filter(
+    (oh) => !wxrHeadingSet.has(`${oh.level}:${normalize(oh.text)}`),
   );
 
-  // Images: check that WXR images exist in the origin (containment direction)
-  const originFilenames = new Set(origin.images.map((img) => extractFilename(img.src)));
-  const missingImages = wxr.images.filter(
-    (img) => !originFilenames.has(extractFilename(img.src)),
+  // Images: origin images not carried over to WXR (match on filename so the
+  // CDN query string / host rewrite doesn't produce false negatives)
+  const wxrFilenames = new Set(wxr.images.map((img) => extractFilename(img.src)));
+  const missingImages = origin.images.filter(
+    (img) => !wxrFilenames.has(extractFilename(img.src)),
   );
 
-  // Links: check that WXR links exist in the origin (containment direction)
-  const originHrefs = new Set(origin.links.map((l) => l.href));
-  const missingLinks = wxr.links.filter((l) => !originHrefs.has(l.href));
+  // Links: origin links not carried over to WXR
+  const wxrHrefs = new Set(wxr.links.map((l) => l.href));
+  const missingLinks = origin.links.filter((l) => !wxrHrefs.has(l.href));
 
   const headingsMatch = {
     origin: originHeadings.length,
     wxr: wxr.headings.length,
-    missing: missingHeadings.length, // WXR headings NOT found in origin
+    missing: missingHeadings.length,
   };
   const imagesMatch = {
     origin: origin.images.length,
     wxr: wxr.images.length,
-    missing: missingImages.length, // WXR images NOT found in origin
+    missing: missingImages.length,
   };
   const linksMatch = {
     origin: origin.links.length,
     wxr: wxr.links.length,
-    missing: missingLinks.length, // WXR links NOT found in origin
+    missing: missingLinks.length,
   };
 
-  // Grade: weighted score — text 50%, headings 20%, images 20%, links 10%
-  // Scores measure containment: what fraction of WXR content is verified in origin
-  const headingsScore = wxr.headings.length === 0 ? 1 : 1 - missingHeadings.length / wxr.headings.length;
-  const imagesScore = wxr.images.length === 0 ? 1 : 1 - missingImages.length / wxr.images.length;
-  const linksScore = wxr.links.length === 0 ? 1 : 1 - missingLinks.length / wxr.links.length;
+  // Grade: weighted score — text 50%, headings 20%, images 20%, links 10%.
+  // Each dimension measures "what fraction of origin content made it into WXR".
+  const headingsScore = originHeadings.length === 0 ? 1 : 1 - missingHeadings.length / originHeadings.length;
+  const imagesScore = origin.images.length === 0 ? 1 : 1 - missingImages.length / origin.images.length;
+  const linksScore = origin.links.length === 0 ? 1 : 1 - missingLinks.length / origin.links.length;
 
   const overall = isEmpty
     ? 1
@@ -102,8 +103,8 @@ function normalize(s: string): string {
 
 /**
  * What fraction of words in `subset` also appear in `superset`?
- * Returns 1.0 when every extracted word exists in the origin — meaning
- * we captured real content, even if the origin has much more.
+ * Called with `containment(origin, wxr)` to answer "how much of the origin
+ * content was preserved in the WXR output".
  */
 function containment(subset: string, superset: string): number {
   const subWords = wordSet(subset);

--- a/test/import-session.test.ts
+++ b/test/import-session.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ImportSession } from '../src/lib/extraction/import-session.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'session-test-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('ImportSession', () => {
+  it('creates a fresh session with captured args', () => {
+    const s = ImportSession.loadOrCreate(dir, 'shopify', { token: 'secret', resume: false });
+    expect(s.adapter).toBe('shopify');
+    expect(s.stage).toBe('initial');
+    expect(s.args.token).toBe('secret');
+    expect(existsSync(join(dir, 'session.json'))).toBe(true);
+  });
+
+  it('setStage transitions and persists', () => {
+    const s = ImportSession.loadOrCreate(dir, 'shopify', {});
+    s.setStage('extracting');
+    expect(s.stage).toBe('extracting');
+
+    const raw = JSON.parse(readFileSync(join(dir, 'session.json'), 'utf8'));
+    expect(raw.stage).toBe('extracting');
+  });
+
+  it('error stage records lastError', () => {
+    const s = ImportSession.loadOrCreate(dir, 'shopify', {});
+    s.setStage('error', 'network timeout');
+    const raw = JSON.parse(readFileSync(join(dir, 'session.json'), 'utf8'));
+    expect(raw.stage).toBe('error');
+    expect(raw.lastError).toBe('network timeout');
+  });
+
+  it('resume loads prior session preserving progress and cursors', () => {
+    const first = ImportSession.loadOrCreate(dir, 'shopify', { a: 1 });
+    first.bumpProgress('product', 'extracted', 5);
+    first.setCursor('shopify:products:endCursor', 'abc123');
+    first.save();
+
+    const second = ImportSession.loadOrCreate(dir, 'shopify', { a: 2 }, { resume: true });
+    expect(second.getCursor('shopify:products:endCursor')).toBe('abc123');
+    expect(second.progress.product.extracted).toBe(5);
+    // Caller-supplied args override stored on resume
+    expect(second.args.a).toBe(2);
+  });
+
+  it('without resume, existing file is preserved as .corrupt backup', () => {
+    ImportSession.loadOrCreate(dir, 'shopify', {});
+    expect(existsSync(join(dir, 'session.json'))).toBe(true);
+
+    ImportSession.loadOrCreate(dir, 'shopify', {});
+    const backups = readdirSync(dir).filter((f) => f.startsWith('session.json.corrupt.'));
+    expect(backups.length).toBe(1);
+  });
+
+  it('corrupt JSON is preserved as backup, fresh session created', () => {
+    writeFileSync(join(dir, 'session.json'), 'not json', 'utf8');
+    const s = ImportSession.loadOrCreate(dir, 'shopify', {}, { resume: true });
+    expect(s.stage).toBe('initial');
+    const backups = readdirSync(dir).filter((f) => f.startsWith('session.json.corrupt.'));
+    expect(backups.length).toBe(1);
+  });
+
+  it('adapter mismatch on resume creates fresh session', () => {
+    ImportSession.loadOrCreate(dir, 'shopify', {});
+    const s2 = ImportSession.loadOrCreate(dir, 'wix', {}, { resume: true });
+    expect(s2.adapter).toBe('wix');
+    expect(s2.stage).toBe('initial');
+  });
+
+  it('bumpProgress does not auto-persist; save() does', () => {
+    const s = ImportSession.loadOrCreate(dir, 'shopify', {});
+    s.bumpProgress('page', 'extracted');
+    const beforeSave = JSON.parse(readFileSync(join(dir, 'session.json'), 'utf8'));
+    expect(beforeSave.progress.page?.extracted ?? 0).toBe(0);
+
+    s.save();
+    const afterSave = JSON.parse(readFileSync(join(dir, 'session.json'), 'utf8'));
+    expect(afterSave.progress.page.extracted).toBe(1);
+  });
+
+  it('setDiscovered seeds entity counts', () => {
+    const s = ImportSession.loadOrCreate(dir, 'shopify', {});
+    s.setDiscovered({ product: 10, page: 5 });
+    expect(s.progress.product.discovered).toBe(10);
+    expect(s.progress.page.discovered).toBe(5);
+  });
+
+  it('setCursor round-trips arbitrary JSON values', () => {
+    const s = ImportSession.loadOrCreate(dir, 'shopify', {});
+    s.setCursor('handles', ['a', 'b', 'c']);
+    expect(s.getCursor<string[]>('handles')).toEqual(['a', 'b', 'c']);
+    s.setCursor('handles', null);
+    expect(s.getCursor('handles')).toBeNull();
+  });
+});

--- a/test/media-stubs.test.ts
+++ b/test/media-stubs.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { MediaStubStore } from '../src/lib/extraction/media-stubs.js';
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'stubs-test-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('MediaStubStore', () => {
+  it('shouldAttempt returns true for unknown URL', () => {
+    const store = MediaStubStore.load(dir);
+    expect(store.shouldAttempt('https://cdn.example.com/a.jpg')).toBe(true);
+  });
+
+  it('markSuccess persists immediately on explicit save/flush', () => {
+    const store = MediaStubStore.load(dir);
+    store.markSuccess('https://cdn.example.com/a.jpg', '/tmp/a.jpg');
+    // Success is buffered in memory
+    expect(existsSync(join(dir, 'media-stubs.json'))).toBe(false);
+    store.flush();
+    expect(existsSync(join(dir, 'media-stubs.json'))).toBe(true);
+  });
+
+  it('markFailure persists immediately without flush', () => {
+    const store = MediaStubStore.load(dir);
+    store.markFailure('https://cdn.example.com/bad.jpg', 'HTTP 404');
+    // Failures flush synchronously to preserve attempt counts across crashes
+    const raw = JSON.parse(readFileSync(join(dir, 'media-stubs.json'), 'utf8'));
+    expect(raw.stubs['https://cdn.example.com/bad.jpg'].status).toBe('error');
+    expect(raw.stubs['https://cdn.example.com/bad.jpg'].attempts).toBe(1);
+  });
+
+  it('stops attempting after maxAttempts failures', () => {
+    const store = MediaStubStore.load(dir, { maxAttempts: 2 });
+    const url = 'https://cdn.example.com/bad.jpg';
+    store.markFailure(url, 'x');
+    expect(store.shouldAttempt(url)).toBe(true);
+    store.markFailure(url, 'x');
+    expect(store.shouldAttempt(url)).toBe(false);
+  });
+
+  it('success is final — no more attempts', () => {
+    const store = MediaStubStore.load(dir);
+    const url = 'https://cdn.example.com/a.jpg';
+    store.markSuccess(url, '/tmp/a.jpg');
+    store.flush();
+    expect(store.shouldAttempt(url)).toBe(false);
+  });
+
+  it('ignored status is final', () => {
+    const store = MediaStubStore.load(dir);
+    const url = 'https://cdn.example.com/a.jpg';
+    store.markIgnored(url, 'user override');
+    expect(store.shouldAttempt(url)).toBe(false);
+  });
+
+  it('counts() reports each status bucket', () => {
+    const store = MediaStubStore.load(dir);
+    store.markSuccess('https://cdn.example.com/a.jpg', '/tmp/a.jpg');
+    store.markFailure('https://cdn.example.com/b.jpg', 'err');
+    store.markIgnored('https://cdn.example.com/c.jpg');
+    store.flush();
+
+    const c = store.counts();
+    expect(c.success).toBe(1);
+    expect(c.error).toBe(1);
+    expect(c.ignored).toBe(1);
+    expect(c.awaiting).toBe(0);
+  });
+
+  it('load reads back persisted state', () => {
+    const store1 = MediaStubStore.load(dir);
+    store1.markSuccess('https://cdn.example.com/a.jpg', '/tmp/a.jpg');
+    store1.flush();
+
+    const store2 = MediaStubStore.load(dir);
+    expect(store2.get('https://cdn.example.com/a.jpg')?.status).toBe('success');
+    expect(store2.shouldAttempt('https://cdn.example.com/a.jpg')).toBe(false);
+  });
+
+  it('tolerates corrupt store file by starting fresh', () => {
+    writeFileSync(join(dir, 'media-stubs.json'), 'not json', 'utf8');
+    const store = MediaStubStore.load(dir);
+    expect(store.shouldAttempt('https://cdn.example.com/a.jpg')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What this changes

Introduces two sibling state stores to `ExtractionLog` that make mid-run crashes recoverable and prevent endless retry of permanently broken media:

- **`ImportSession`** (`src/lib/extraction/import-session.ts`) — pipeline stage, captured opts, per-entity progress counters (`{discovered, extracted, failed}`), and an adapter-scoped `cursors` record for pagination resume. Atomic rename, corrupt files preserved as `session.json.corrupt.<ts>` rather than silently deleted.
- **`MediaStubStore`** (`src/lib/extraction/media-stubs.ts`) — per-URL status (`awaiting` / `success` / `error` / `ignored`) with retry cap (default 3). Buffered flush to avoid per-download fsync, failures persist immediately so attempt counts survive crashes.

Both are wired into `runExtractionLoop` as opt-in primitives so every adapter benefits — resume counts/stages flow through automatically when an adapter passes a `session`.

## How I found it

Working on the Shopify Admin GraphQL path (stacked follow-up) I needed persistent pagination cursors and idempotent emitted-handle tracking across crashes. The existing resume model was URL-level only via `extraction-log.jsonl` — a crash mid-pagination lost cursor state and a fresh run would replay everything. Meanwhile permanently-broken media (404s on removed CDN assets) got retried on every resume, wasting the entire media budget.

Neither problem was Shopify-specific — both belong in shared infrastructure.

## Type of change

- [x] New infrastructure primitive
- [x] Bug fix (permanent-failure media retry loop)

## Tested

```
npm test -- test/import-session.test.ts test/media-stubs.test.ts
# 19 new tests: load/save, resume, corrupt backup, adapter mismatch,
# retry cap, terminal states, flush semantics, counts()
```

Also includes a resume-path fix in `src/adapters/shared.ts`: when `MediaStubStore` reports a URL as successfully downloaded from a prior run, the shared loop now calls `wxr.addMedia()` with the stored path so WXR attachment items don't go missing on resume runs.

## Scope

- 2 commits, 6 files, +591/-26 lines
- New files: `import-session.ts`, `media-stubs.ts`, and their test files
- Modified: `src/adapters/shared.ts` (opt-in wiring), `src/lib/qa/content-differ.ts` (PR #14 — pre-existing test failure; this PR includes the fix as a base commit so CI is green in isolation. Once #14 merges, a rebase drops that commit automatically.)

## Dependency note

Includes #14 (content-differ fix) as a base commit for CI greenness. That commit will disappear on rebase once #14 merges.