### PR TITLE
feat(woo-csv): SEO title/desc, cost of goods, and custom meta columns

### DIFF
--- a/src/lib/import/woo-product-csv.ts
+++ b/src/lib/import/woo-product-csv.ts
@@ -32,7 +32,23 @@ export interface WooProduct {
     global?: boolean;
   }>;
   parentSku?: string;
+  /** SEO title — emitted as `meta:_yoast_wpseo_title` */
+  seoTitle?: string;
+  /** SEO description — emitted as `meta:_yoast_wpseo_metadesc` */
+  seoDescription?: string;
+  /** Cost of goods sold — emitted as `meta:_wc_cog_cost` (WooCommerce COGS plugin) */
+  costOfGoods?: string;
+  /** Arbitrary custom post meta — each key becomes a `meta:<key>` column */
+  meta?: Record<string, string>;
 }
+
+// WooCommerce post-meta keys for the three first-class SEO/cost fields.
+// These columns are always present in the output (even when empty) so that
+// the CSV shape is stable across runs and predictable for import tooling.
+const META_KEY_SEO_TITLE = '_yoast_wpseo_title';
+const META_KEY_SEO_DESC = '_yoast_wpseo_metadesc';
+const META_KEY_COGS = '_wc_cog_cost';
+const FIXED_META_KEYS = [META_KEY_SEO_TITLE, META_KEY_SEO_DESC, META_KEY_COGS] as const;
 
 
 export class WooProductCsvBuilder {
@@ -60,9 +76,25 @@ export class WooProductCsvBuilder {
   }
 
   /**
+   * Collect the union of custom `meta` keys across all products, excluding
+   * the three fixed first-class keys (which always get a column regardless).
+   */
+  private customMetaKeys(): string[] {
+    const keys = new Set<string>();
+    for (const p of this.products) {
+      if (!p.meta) continue;
+      for (const k of Object.keys(p.meta)) {
+        if ((FIXED_META_KEYS as readonly string[]).includes(k)) continue;
+        keys.add(k);
+      }
+    }
+    return [...keys].sort();
+  }
+
+  /**
    * Build the header row.
    */
-  private buildHeaders(): string[] {
+  private buildHeaders(customMetaKeys: string[]): string[] {
     const headers = [
       'id',
       'type',
@@ -94,6 +126,15 @@ export class WooProductCsvBuilder {
 
     headers.push('parent_id');
 
+    // First-class meta columns — always present for a stable shape.
+    for (const key of FIXED_META_KEYS) {
+      headers.push(`meta:${key}`);
+    }
+    // Adapter-supplied custom meta keys.
+    for (const key of customMetaKeys) {
+      headers.push(`meta:${key}`);
+    }
+
     return headers;
   }
 
@@ -106,9 +147,21 @@ export class WooProductCsvBuilder {
   }
 
   /**
+   * Resolve the value for a given meta key on a product. The three fixed
+   * keys read from their first-class fields first, then fall through to
+   * `product.meta`. Custom keys read only from `product.meta`.
+   */
+  private static metaValue(product: WooProduct, key: string): string {
+    if (key === META_KEY_SEO_TITLE && product.seoTitle) return product.seoTitle;
+    if (key === META_KEY_SEO_DESC && product.seoDescription) return product.seoDescription;
+    if (key === META_KEY_COGS && product.costOfGoods) return product.costOfGoods;
+    return product.meta?.[key] || '';
+  }
+
+  /**
    * Build a CSV row for a single product.
    */
-  private buildRow(product: WooProduct, attrCount: number): string[] {
+  private buildRow(product: WooProduct, attrCount: number, customMetaKeys: string[]): string[] {
     const c = WooProductCsvBuilder.collapseNewlines;
     const row: string[] = [
       '', // ID — empty for new products
@@ -145,6 +198,13 @@ export class WooProductCsvBuilder {
 
     row.push(product.parentSku || '');
 
+    for (const key of FIXED_META_KEYS) {
+      row.push(c(WooProductCsvBuilder.metaValue(product, key)));
+    }
+    for (const key of customMetaKeys) {
+      row.push(c(WooProductCsvBuilder.metaValue(product, key)));
+    }
+
     return row;
   }
 
@@ -154,10 +214,11 @@ export class WooProductCsvBuilder {
   serialize(outputPath: string): void {
     mkdirSync(dirname(outputPath), { recursive: true });
 
-    const headers = this.buildHeaders();
+    const customMetaKeys = this.customMetaKeys();
+    const headers = this.buildHeaders(customMetaKeys);
     const attrCount = this.maxAttributes();
 
-    const data = this.products.map(p => this.buildRow(p, attrCount));
+    const data = this.products.map(p => this.buildRow(p, attrCount, customMetaKeys));
     const csv = Papa.unparse({ fields: headers, data }, { newline: '\r\n' });
     writeFileSync(outputPath, csv, 'utf8');
   }
@@ -176,14 +237,18 @@ export class WooProductCsvBuilder {
 
   /**
    * Begin streaming mode. Products are appended as JSONL lines.
+   * Pass `{ resume: true }` to append to an existing file instead of
+   * truncating — required for adapters that persist cross-run state
+   * (e.g. Shopify GraphQL product handles) in the extraction session.
    */
-  openStream(outputDir: string): void {
+  openStream(outputDir: string, { resume = false }: { resume?: boolean } = {}): void {
     mkdirSync(outputDir, { recursive: true });
     this._streamDir = outputDir;
     this._jsonlPath = join(outputDir, 'products.jsonl');
     this._streaming = true;
-    // Clear any existing JSONL from a previous run
-    writeFileSync(this._jsonlPath, '', 'utf8');
+    if (!resume) {
+      writeFileSync(this._jsonlPath, '', 'utf8');
+    }
   }
 
   /**

--- a/src/lib/qa/content-differ.ts
+++ b/src/lib/qa/content-differ.ts
@@ -22,54 +22,55 @@ export function diffContent(origin: ContentModel, wxr: ContentModel, postTitle?:
     origin.images.length === 0 &&
     origin.links.length === 0;
 
-  // Use containment (what fraction of WXR words appear in the origin) rather
-  // than Jaccard similarity. The origin page often has far more content than
-  // what we extract (JS widgets, section builders, etc.), which tanks Jaccard.
-  // Containment answers the right question: "is the extracted content real?"
-  const textSimilarity = isEmpty ? 1 : containment(wxr.text, origin.text);
+  // `missing` semantics across this module: items present in the origin
+  // that we failed to carry into the WXR output. This matches both the UI
+  // label ("N missing images") and the test expectations. Detects extraction
+  // loss — the thing users actually want to know about.
+  const textSimilarity = isEmpty ? 1 : containment(origin.text, wxr.text);
 
   // Filter out the post title h1 from origin headings — WXR stores it as metadata, not content
   const originHeadings = postTitle
     ? origin.headings.filter((h) => !(h.level === 1 && normalize(h.text) === normalize(postTitle)))
     : origin.headings;
 
-  // Headings: check that WXR headings exist in the origin (containment direction)
-  const originHeadingSet = new Set(originHeadings.map((h) => `${h.level}:${normalize(h.text)}`));
-  const missingHeadings = wxr.headings.filter(
-    (wh) => !originHeadingSet.has(`${wh.level}:${normalize(wh.text)}`),
+  // Headings: origin headings not carried over to WXR
+  const wxrHeadingSet = new Set(wxr.headings.map((h) => `${h.level}:${normalize(h.text)}`));
+  const missingHeadings = originHeadings.filter(
+    (oh) => !wxrHeadingSet.has(`${oh.level}:${normalize(oh.text)}`),
   );
 
-  // Images: check that WXR images exist in the origin (containment direction)
-  const originFilenames = new Set(origin.images.map((img) => extractFilename(img.src)));
-  const missingImages = wxr.images.filter(
-    (img) => !originFilenames.has(extractFilename(img.src)),
+  // Images: origin images not carried over to WXR (match on filename so the
+  // CDN query string / host rewrite doesn't produce false negatives)
+  const wxrFilenames = new Set(wxr.images.map((img) => extractFilename(img.src)));
+  const missingImages = origin.images.filter(
+    (img) => !wxrFilenames.has(extractFilename(img.src)),
   );
 
-  // Links: check that WXR links exist in the origin (containment direction)
-  const originHrefs = new Set(origin.links.map((l) => l.href));
-  const missingLinks = wxr.links.filter((l) => !originHrefs.has(l.href));
+  // Links: origin links not carried over to WXR
+  const wxrHrefs = new Set(wxr.links.map((l) => l.href));
+  const missingLinks = origin.links.filter((l) => !wxrHrefs.has(l.href));
 
   const headingsMatch = {
     origin: originHeadings.length,
     wxr: wxr.headings.length,
-    missing: missingHeadings.length, // WXR headings NOT found in origin
+    missing: missingHeadings.length,
   };
   const imagesMatch = {
     origin: origin.images.length,
     wxr: wxr.images.length,
-    missing: missingImages.length, // WXR images NOT found in origin
+    missing: missingImages.length,
   };
   const linksMatch = {
     origin: origin.links.length,
     wxr: wxr.links.length,
-    missing: missingLinks.length, // WXR links NOT found in origin
+    missing: missingLinks.length,
   };
 
-  // Grade: weighted score — text 50%, headings 20%, images 20%, links 10%
-  // Scores measure containment: what fraction of WXR content is verified in origin
-  const headingsScore = wxr.headings.length === 0 ? 1 : 1 - missingHeadings.length / wxr.headings.length;
-  const imagesScore = wxr.images.length === 0 ? 1 : 1 - missingImages.length / wxr.images.length;
-  const linksScore = wxr.links.length === 0 ? 1 : 1 - missingLinks.length / wxr.links.length;
+  // Grade: weighted score — text 50%, headings 20%, images 20%, links 10%.
+  // Each dimension measures "what fraction of origin content made it into WXR".
+  const headingsScore = originHeadings.length === 0 ? 1 : 1 - missingHeadings.length / originHeadings.length;
+  const imagesScore = origin.images.length === 0 ? 1 : 1 - missingImages.length / origin.images.length;
+  const linksScore = origin.links.length === 0 ? 1 : 1 - missingLinks.length / origin.links.length;
 
   const overall = isEmpty
     ? 1
@@ -102,8 +103,8 @@ function normalize(s: string): string {
 
 /**
  * What fraction of words in `subset` also appear in `superset`?
- * Returns 1.0 when every extracted word exists in the origin — meaning
- * we captured real content, even if the origin has much more.
+ * Called with `containment(origin, wxr)` to answer "how much of the origin
+ * content was preserved in the WXR output".
  */
 function containment(subset: string, superset: string): number {
   const subWords = wordSet(subset);

--- a/test/woo-product-csv.test.ts
+++ b/test/woo-product-csv.test.ts
@@ -328,6 +328,63 @@ describe('WooProductCsvBuilder', () => {
     expect(csv).toContain('Color');
   });
 
+  it('emits fixed meta columns for SEO title/desc and cost of goods', () => {
+    const builder = new WooProductCsvBuilder();
+    builder.addProduct({
+      name: 'Widget',
+      seoTitle: 'Best Widget Ever',
+      seoDescription: 'The finest widget available',
+      costOfGoods: '4.25',
+    });
+
+    const csv = buildAndRead(builder);
+    const rows = parseRows(csv);
+    const idx = (name: string) => rows[0].indexOf(name);
+
+    expect(idx('meta:_yoast_wpseo_title')).toBeGreaterThan(-1);
+    expect(idx('meta:_yoast_wpseo_metadesc')).toBeGreaterThan(-1);
+    expect(idx('meta:_wc_cog_cost')).toBeGreaterThan(-1);
+    expect(dataRow(rows, 1, idx('meta:_yoast_wpseo_title'))).toBe('Best Widget Ever');
+    expect(dataRow(rows, 1, idx('meta:_yoast_wpseo_metadesc'))).toBe('The finest widget available');
+    expect(dataRow(rows, 1, idx('meta:_wc_cog_cost'))).toBe('4.25');
+  });
+
+  it('fixed meta columns are always present even when empty', () => {
+    const builder = new WooProductCsvBuilder();
+    builder.addProduct({ name: 'Bare' });
+    const csv = buildAndRead(builder);
+    expect(csv).toContain('meta:_yoast_wpseo_title');
+    expect(csv).toContain('meta:_yoast_wpseo_metadesc');
+    expect(csv).toContain('meta:_wc_cog_cost');
+  });
+
+  it('emits columns for adapter-supplied custom meta keys', () => {
+    const builder = new WooProductCsvBuilder();
+    builder.addProduct({ name: 'A', meta: { _custom_field: 'alpha' } });
+    builder.addProduct({ name: 'B', meta: { _custom_field: 'beta', _other: 'gamma' } });
+    const csv = buildAndRead(builder);
+    const rows = parseRows(csv);
+    const idx = (name: string) => rows[0].indexOf(name);
+
+    expect(idx('meta:_custom_field')).toBeGreaterThan(-1);
+    expect(idx('meta:_other')).toBeGreaterThan(-1);
+    expect(dataRow(rows, 1, idx('meta:_custom_field'))).toBe('alpha');
+    expect(dataRow(rows, 2, idx('meta:_other'))).toBe('gamma');
+  });
+
+  it('first-class fields take precedence over meta[] for the same key', () => {
+    const builder = new WooProductCsvBuilder();
+    builder.addProduct({
+      name: 'Widget',
+      seoTitle: 'From field',
+      meta: { _yoast_wpseo_title: 'From meta' },
+    });
+    const csv = buildAndRead(builder);
+    const rows = parseRows(csv);
+    const idx = (name: string) => rows[0].indexOf(name);
+    expect(dataRow(rows, 1, idx('meta:_yoast_wpseo_title'))).toBe('From field');
+  });
+
   it('uses instock/outofstock for stock_status', () => {
     const builder = new WooProductCsvBuilder();
     builder.addProduct({ name: 'In Stock', inStock: true });


### PR DESCRIPTION
## What this changes

Extends `WooProduct` and `WooProductCsvBuilder` with first-class fields for SEO metadata and cost of goods, plus an open `meta` record so adapters can push arbitrary WooCommerce post meta without schema churn.

- New `WooProduct` fields: `seoTitle`, `seoDescription`, `costOfGoods`, and `meta: Record<string, string>`
- Builder emits three fixed meta columns unconditionally (`meta:_yoast_wpseo_title`, `meta:_yoast_wpseo_metadesc`, `meta:_wc_cog_cost`) so output shape is stable across runs
- Any adapter-supplied custom meta keys are collected into additional sorted `meta:<key>` columns at serialize time
- First-class fields take precedence over `meta[]` for the same key
- `openStream({ resume: true })` appends to `products.jsonl` instead of truncating — required for adapters that track emitted products across runs (used by the Shopify GraphQL work in #17)

## How I found it

Working on the Shopify GraphQL mapper (stacked follow-up) I had richer product data with nowhere to put it — one early draft was abusing `shortDescription` as an SEO-title container. WooCommerce's CSV importer supports `meta:<key>` columns natively, so this was purely a builder limitation. Shipped as a standalone PR because it's useful to every adapter, not just Shopify.

## Type of change

- [x] New capability (no breaking behavior)

## Tested

```
npm test -- test/woo-product-csv.test.ts
# 15/15 passing (4 new tests for meta columns)
```

## Scope

- 2 commits, 3 files, +156/-33 lines
- Modified: `src/lib/import/woo-product-csv.ts`, `test/woo-product-csv.test.ts`
- Output shape change: existing CSVs gain three new columns at the end (after `parent_id`). WooCommerce's importer tolerates extra columns — any external tooling that parses the CSV by column index would see a position shift.

## Dependency note

Includes #14 (content-differ fix) as a base commit for CI greenness. That commit will disappear on rebase once #14 merges.