### PR TITLE
feat(adapters): add HubSpot CMS platform adapter

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,66 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-13 — HubSpot CMS platform adapter
+
+**Found by:** Claude + human contributor
+**During:** Adding HubSpot CMS as a new supported platform
+**Type:** platform adapter
+
+### What I found
+
+HubSpot CMS Hub powers a wide range of sites from SMB marketing pages to enterprise content hubs. Sites run on custom domains and use a well-structured class naming convention that makes detection and extraction straightforward once you know the patterns.
+
+**Detection signals:**
+- `<meta name="generator" content="HubSpot">` is the only reliable signal. Many non-HubSpot sites embed HubSpot marketing scripts (CTAs, forms, tracking), so `hubspot.com`, `hs-scripts.com`, and `hsforms.net` references in page source are NOT sufficient. For example, eplan.co.za has all the HubSpot scripts but its generator tag says TYPO3 — it's a TYPO3 site using HubSpot for marketing.
+
+**Content structure:**
+- `<body>` class identifies content type:
+  - `hs-blog-post` on blog post pages (authoritative — used for classification)
+  - `hs-site-page page` on regular pages
+- Blog post content: `div.post-body` (clean article body)
+- Regular pages: `div.body-container` (strip nav/header/footer)
+- Content modules wrap in `div.hs_cos_wrapper` with `_type_rich_text`, `_type_form`, `_type_cta`, etc.
+- Marketing widgets to strip during extraction: `.hs-cta-wrapper`, `.hs-cta-node`, `hs_cos_wrapper_type_form`, `hs_cos_wrapper_type_blog_comments`, AddThis social widgets
+- Blog titles render as `<h1>` inside content — strip to avoid duplication with `post_title`
+- Navigation: `.hs-menu-wrapper` with `.hs-menu-item`, `.hs-menu-depth-*`
+
+**Blog post metadata:**
+- Date: byline text "by Author, on Dec 6, 2024 6:57:40 PM" (parsed by adapter), plus `article:published_time` meta tag fallback
+- Author: `<a href="/*/author/{name}">{display name}</a>`
+- Topics (tags): `<a href="/*/topic/{slug}">{display name}</a>` in post footer
+
+**Media hosts:**
+- `/hubfs/*` paths on the site itself (HubSpot's file manager)
+- `hubspotusercontent-*.net` CDN (regional, e.g. `-na1`, `-eu1`)
+- `fs1.hubspotusercontent-*.net` for files
+
+**Sitemaps:** Standard `/sitemap.xml`, auto-generated, comprehensive. Includes image sitemap extensions with alt text.
+
+### How it works
+
+The adapter follows the established fetch-and-scrape pattern:
+1. `detect()` is URL-less — relies on the Hubspot generator meta tag in `detect-platform.ts`
+2. `discover()` fetches the homepage + sitemap, extracts site metadata from OG tags and `<html lang>`, classifies URLs (with common HubSpot blog paths like `/blog/`, `/news/`, `/insights/` treated as posts — individual pages are reclassified at extract time via body class)
+3. `extract()` uses `runExtractionLoop()` with a HubSpot-specific `extractPage` that:
+   - Reads the `<body>` class to classify post vs page (overrides URL-based classification via `detectedType`)
+   - Extracts blog content from `.post-body`, page content from `.body-container` with chrome stripped
+   - Strips HubSpot marketing widgets (CTAs, forms, comments, AddThis) from content
+   - Parses date from byline text when `article:published_time` isn't present
+   - Extracts author from `/author/` link text, topics (tags) from `/topic/` link text
+   - Strips the embedded `<h1>` title to prevent duplication with `post_title`
+   - Resolves relative URLs so WordPress can match attachment URLs during import
+
+### Known limitations
+
+Tags are extracted from topic links and returned as post tags, but they don't currently land as WordPress taxonomy terms on import. The WXR builder writes the taxonomy section at `openStream()` time, before posts are extracted, so late-registered `<wp:tag>` entries aren't persisted in streaming mode. This is a shared-code gap affecting all adapters that pass tag slugs directly through `addPost`. Topics still appear as inline linked text in imported post content.
+
+### Why it's better than the previous approach
+
+HubSpot CMS was not previously supported. Adds coverage for a widely-deployed CMS used by large enterprises (Avast, FlightAware, Wattpad, HubSpot itself) and many mid-market companies. Tested end-to-end against eflexsystems.com (156 URLs: 32 pages, 124 posts, 930 media references) and maus.com (185 URLs). The 124 blog posts imported into WordPress with correct titles, dates, authors, and clean content bodies; title duplication avoided.
+
+---
+
 ## 2026-04-02 — Squarespace admin extraction via CDP
 
 **Found by:** Claude + human contributor (live testing against a Squarespace site)

--- a/src/adapters/hubspot.ts
+++ b/src/adapters/hubspot.ts
@@ -71,8 +71,8 @@ function extractByClass(html: string, className: string, tag = 'div'): string {
 }
 
 /**
- * Get the body element's class attribute. HubSpot tags the body with classes
- * that identify the content type (e.g. `hs-blog-post`, `hs-site-page`).
+ * Get the body element's class attribute. HubSpot default themes tag the body
+ * with classes that identify the content type (e.g. `hs-blog-post`).
  */
 function getBodyClass(html: string): string {
   const match = html.match(/<body[^>]*\bclass=["']([^"']*)["']/i);
@@ -80,11 +80,16 @@ function getBodyClass(html: string): string {
 }
 
 /**
- * Check if this page is a HubSpot blog post based on body class.
- * HubSpot sets `hs-blog-post` on <body> for blog post pages.
+ * Check if this page is a HubSpot blog post.
+ *
+ * HubSpot's default theme puts `hs-blog-post` on the <body> tag. Custom
+ * themes often move it to a `.body-wrapper` div instead. Matching the token
+ * anywhere in the HTML is safer than checking only the body tag.
  */
 function isHubSpotBlogPost(html: string): boolean {
-  return /\bhs-blog-post\b/.test(getBodyClass(html));
+  // Match `hs-blog-post` only inside class attributes to avoid false positives
+  // on arbitrary text (e.g. a URL or comment mentioning the phrase).
+  return /class=["'][^"']*\bhs-blog-post\b/.test(html);
 }
 
 /**
@@ -126,13 +131,11 @@ function stripHubSpotWidgets(html: string): string {
  * 3. Fallback to `<main>` or stripped `<body>`
  */
 function extractContent(html: string): string {
-  const isPost = isHubSpotBlogPost(html);
-
-  if (isPost) {
-    // Blog posts have a clean `.post-body` container
-    const postBody = extractByClass(html, 'post-body');
-    if (postBody) return stripHubSpotWidgets(postBody);
-  }
+  // Try .post-body first regardless of body class — some HubSpot sites use
+  // custom themes that strip the `hs-blog-post` body class while still
+  // rendering blog content in a .post-body container.
+  const postBody = extractByClass(html, 'post-body');
+  if (postBody) return stripHubSpotWidgets(postBody);
 
   // Regular pages: .body-container wraps all content, then strip chrome
   const bodyContainer = extractByClass(html, 'body-container');
@@ -177,19 +180,46 @@ function extractHeading(html: string): string {
 /**
  * Extract publication date from a HubSpot blog post.
  *
- * HubSpot renders dates in multiple places:
- * 1. <meta property="article:published_time" content="...">
- * 2. <time datetime="..."> element (sometimes)
- * 3. Byline text like "by Jason Bullard, on Dec 6, 2024 6:57:40 PM"
+ * HubSpot renders dates in multiple places; we try the most reliable first:
+ * 1. JSON-LD `datePublished` (most reliable, present on most HubSpot sites
+ *    including custom themes that strip other markers)
+ * 2. <meta property="article:published_time" content="...">
+ * 3. <time datetime="..."> element
+ * 4. Byline text like "by Author, on Dec 6, 2024 6:57:40 PM" (default theme)
  */
 function extractHubSpotDate(html: string): string {
+  // Strategy 1: JSON-LD datePublished. Look inside application/ld+json blocks
+  // rather than across the whole HTML (avoids picking up unrelated date strings).
+  const ldPattern = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let ldMatch;
+  while ((ldMatch = ldPattern.exec(html)) !== null) {
+    try {
+      const parsed = JSON.parse(ldMatch[1].trim());
+      const blocks = Array.isArray(parsed) ? parsed : [parsed];
+      for (const b of blocks) {
+        if (!b || typeof b !== 'object') continue;
+        const type = (b as Record<string, unknown>)['@type'];
+        const isArticle =
+          type === 'BlogPosting' || type === 'Article' || type === 'NewsArticle' ||
+          (Array.isArray(type) && type.some((t) => t === 'BlogPosting' || t === 'Article' || t === 'NewsArticle'));
+        if (!isArticle) continue;
+        const datePublished = (b as Record<string, unknown>).datePublished;
+        if (typeof datePublished === 'string' && datePublished) {
+          return datePublished;
+        }
+      }
+    } catch { /* ignore malformed JSON-LD */ }
+  }
+
+  // Strategy 2: article:published_time meta tag
   const articleDate = extractMeta(html, 'article:published_time');
   if (articleDate) return articleDate;
 
+  // Strategy 3: <time datetime="...">
   const timeElement = html.match(/<time[^>]+datetime=["']([^"']+)["']/i)?.[1];
   if (timeElement) return timeElement;
 
-  // Byline pattern: "on Dec 6, 2024 6:57:40 PM"
+  // Strategy 4: Byline pattern "on Dec 6, 2024 6:57:40 PM"
   const bylineDate = html.match(/\bon\s+([A-Z][a-z]{2,}\s+\d{1,2},\s+\d{4}(?:\s+\d{1,2}:\d{2}(?::\d{2})?\s*[AP]M)?)/);
   if (bylineDate?.[1]) {
     const parsed = new Date(bylineDate[1]);
@@ -202,12 +232,34 @@ function extractHubSpotDate(html: string): string {
 /**
  * Extract author name from HubSpot blog post.
  *
- * HubSpot blog posts link to the author via /author/name paths.
- * Falls back to the `<meta name="author">` tag.
+ * Tries (in order):
+ * 1. Default-theme /author/{slug} link text
+ * 2. JSON-LD BlogPosting `author.name` (works on custom themes)
+ * 3. <meta name="author"> tag
  */
 function extractHubSpotAuthor(html: string): string | undefined {
   const authorLink = html.match(/<a[^>]+href=["'][^"']*\/author\/[^"']+["'][^>]*>([^<]+)<\/a>/i);
   if (authorLink?.[1]) return authorLink[1].replace(/<[^>]*>/g, '').trim();
+
+  // JSON-LD BlogPosting author
+  const ldPattern = /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let ldMatch;
+  while ((ldMatch = ldPattern.exec(html)) !== null) {
+    try {
+      const parsed = JSON.parse(ldMatch[1].trim());
+      const blocks = Array.isArray(parsed) ? parsed : [parsed];
+      for (const b of blocks) {
+        if (!b || typeof b !== 'object') continue;
+        const author = (b as Record<string, unknown>).author;
+        if (author && typeof author === 'object') {
+          const first = Array.isArray(author) ? author[0] : author;
+          if (first && typeof first === 'object' && typeof (first as { name?: unknown }).name === 'string') {
+            return (first as { name: string }).name;
+          }
+        }
+      }
+    } catch { /* ignore malformed JSON-LD */ }
+  }
 
   const metaAuthor = extractMeta(html, 'author');
   return metaAuthor || undefined;
@@ -453,8 +505,11 @@ export const hubspotAdapter: PlatformAdapter = {
         }
         const html = await resp.text();
 
-        // Type detection from body class: hs-blog-post is authoritative
-        const isPost = isHubSpotBlogPost(html);
+        // `hs-blog-post` class (on <body> or the .body-wrapper div) is the
+        // authoritative HubSpot signal. Fall back to URL-based heuristic for
+        // sites with heavily customized templates that don't emit it.
+        const isPost = isHubSpotBlogPost(html)
+          || /\/(blog|news|insights|articles|resources|updates)\//.test(url);
 
         // Title: prefer h1, then og:title, then <title>
         const title = extractHeading(html) || slugify(url);
@@ -508,8 +563,12 @@ export const hubspotAdapter: PlatformAdapter = {
           categories: [],
           tags,
           author,
-          // Override URL-based classification with body-class signal
-          detectedType: isPost ? 'post' : 'page',
+          // If body class confirms a blog post, signal 'post'. Otherwise leave
+          // undefined so the shared loop falls back to inventory/URL classification
+          // — some HubSpot sites use custom themes that strip the default
+          // hs-blog-post body class, so absence of that class does NOT prove
+          // a page isn't a blog post.
+          detectedType: isPost ? 'post' : undefined,
         };
       },
     });

--- a/src/adapters/hubspot.ts
+++ b/src/adapters/hubspot.ts
@@ -1,0 +1,527 @@
+import type { PlatformAdapter } from '../types.js';
+import type { WxrBuilder } from '../lib/extraction/wxr-builder.js';
+import type { ExtractionLog } from '../lib/extraction/extraction-log.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { fetchSitemap, classifyUrl } from '../lib/extraction/sitemap.js';
+import { slugify, runExtractionLoop, extractMeta, extractTitle, extractNavLinks, IMAGE_EXTENSIONS } from './shared.js';
+import type { InventoryUrl, NavLink } from './shared.js';
+import { WooProductCsvBuilder } from '../lib/import/woo-product-csv.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HubSpotAdapterOpts extends Record<string, unknown> {
+  delay?: number;
+  resume?: boolean;
+  dryRun?: boolean;
+  verbose?: boolean;
+  outputDir?: string;
+}
+
+export interface HubSpotInventory {
+  siteUrl: string;
+  discoveredAt: string;
+  siteMeta: {
+    title: string;
+    tagline: string;
+    language: string;
+  };
+  navigation: NavLink[];
+  counts: Record<string, number>;
+  urls: InventoryUrl[];
+}
+
+// ---------------------------------------------------------------------------
+// HTML helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a specific HTML element's inner content by matching a class on a
+ * given tag (usually div). Handles nested tags of the same type by depth tracking.
+ */
+function extractByClass(html: string, className: string, tag = 'div'): string {
+  const openPattern = new RegExp(`<${tag}[^>]*\\bclass=["'][^"']*\\b${className}\\b[^"']*["'][^>]*>`, 'i');
+  const openMatch = html.match(openPattern);
+  if (!openMatch) return '';
+
+  const startIdx = html.indexOf(openMatch[0]);
+  const afterTag = startIdx + openMatch[0].length;
+  const openTag = `<${tag}`;
+  const closeTag = `</${tag}>`;
+
+  let depth = 1;
+  let i = afterTag;
+  while (i < html.length && depth > 0) {
+    const nextOpen = html.indexOf(openTag, i);
+    const nextClose = html.indexOf(closeTag, i);
+    if (nextClose === -1) break;
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth++;
+      i = nextOpen + openTag.length;
+    } else {
+      depth--;
+      if (depth === 0) {
+        return html.slice(afterTag, nextClose).trim();
+      }
+      i = nextClose + closeTag.length;
+    }
+  }
+  return '';
+}
+
+/**
+ * Get the body element's class attribute. HubSpot tags the body with classes
+ * that identify the content type (e.g. `hs-blog-post`, `hs-site-page`).
+ */
+function getBodyClass(html: string): string {
+  const match = html.match(/<body[^>]*\bclass=["']([^"']*)["']/i);
+  return match?.[1] || '';
+}
+
+/**
+ * Check if this page is a HubSpot blog post based on body class.
+ * HubSpot sets `hs-blog-post` on <body> for blog post pages.
+ */
+function isHubSpotBlogPost(html: string): boolean {
+  return /\bhs-blog-post\b/.test(getBodyClass(html));
+}
+
+/**
+ * Strip HubSpot marketing widgets from content:
+ * - CTAs (`hs-cta-wrapper`, `hs-cta-node`) — interactive marketing widgets
+ * - Forms (`hs_cos_wrapper_type_form`) — HubSpot-hosted lead forms
+ * - Comments widget (`hs_cos_wrapper_type_blog_comments`)
+ * - AddThis social sharing widgets
+ * These don't translate meaningfully to WordPress and clutter the imported content.
+ */
+function stripHubSpotWidgets(html: string): string {
+  let out = html;
+  // Strip CTA wrappers
+  out = out.replace(/<(div|span)[^>]*\bclass=["'][^"']*\bhs-cta-(wrapper|node)\b[^"']*["'][^>]*>[\s\S]*?<\/\1>/gi, '');
+  // Strip form wrappers
+  out = out.replace(
+    /<div[^>]*\bclass=["'][^"']*\bhs_cos_wrapper_type_form\b[^"']*["'][^>]*>[\s\S]*?<\/div>/gi,
+    ''
+  );
+  // Strip blog comments widget
+  out = out.replace(
+    /<div[^>]*\bclass=["'][^"']*\bhs_cos_wrapper_type_blog_comments\b[^"']*["'][^>]*>[\s\S]*?<\/div>/gi,
+    ''
+  );
+  // Strip AddThis widgets
+  out = out.replace(
+    /<div[^>]*\bclass=["'][^"']*\baddthis[^"']*["'][^>]*>[\s\S]*?<\/div>/gi,
+    ''
+  );
+  return out;
+}
+
+/**
+ * Extract content from a HubSpot page.
+ *
+ * Strategy:
+ * 1. Blog posts: use `.post-body` container (clean article content)
+ * 2. Regular pages: use `.body-container` with navigation/chrome stripped
+ * 3. Fallback to `<main>` or stripped `<body>`
+ */
+function extractContent(html: string): string {
+  const isPost = isHubSpotBlogPost(html);
+
+  if (isPost) {
+    // Blog posts have a clean `.post-body` container
+    const postBody = extractByClass(html, 'post-body');
+    if (postBody) return stripHubSpotWidgets(postBody);
+  }
+
+  // Regular pages: .body-container wraps all content, then strip chrome
+  const bodyContainer = extractByClass(html, 'body-container');
+  if (bodyContainer) {
+    let content = bodyContainer;
+    content = content.replace(/<nav\b[^>]*>[\s\S]*?<\/nav>/gi, '');
+    content = content.replace(/<header\b[^>]*>[\s\S]*?<\/header>/gi, '');
+    content = content.replace(/<footer\b[^>]*>[\s\S]*?<\/footer>/gi, '');
+    return stripHubSpotWidgets(content);
+  }
+
+  // Fallback: <main>
+  const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+  if (mainMatch?.[1]?.trim()) return stripHubSpotWidgets(mainMatch[1]);
+
+  // Last resort: <body> with chrome stripped
+  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  if (bodyMatch?.[1]) {
+    let body = bodyMatch[1];
+    body = body.replace(/<nav\b[^>]*>[\s\S]*?<\/nav>/gi, '');
+    body = body.replace(/<header\b[^>]*>[\s\S]*?<\/header>/gi, '');
+    body = body.replace(/<footer\b[^>]*>[\s\S]*?<\/footer>/gi, '');
+    return stripHubSpotWidgets(body);
+  }
+
+  return '';
+}
+
+/**
+ * Extract page heading — tries h1, then og:title, then <title>.
+ */
+function extractHeading(html: string): string {
+  const h1 = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)?.[1]?.replace(/<[^>]*>/g, '').trim();
+  if (h1) return h1;
+
+  const ogTitle = extractMeta(html, 'og:title');
+  if (ogTitle) return ogTitle;
+
+  return extractTitle(html);
+}
+
+/**
+ * Extract publication date from a HubSpot blog post.
+ *
+ * HubSpot renders dates in multiple places:
+ * 1. <meta property="article:published_time" content="...">
+ * 2. <time datetime="..."> element (sometimes)
+ * 3. Byline text like "by Jason Bullard, on Dec 6, 2024 6:57:40 PM"
+ */
+function extractHubSpotDate(html: string): string {
+  const articleDate = extractMeta(html, 'article:published_time');
+  if (articleDate) return articleDate;
+
+  const timeElement = html.match(/<time[^>]+datetime=["']([^"']+)["']/i)?.[1];
+  if (timeElement) return timeElement;
+
+  // Byline pattern: "on Dec 6, 2024 6:57:40 PM"
+  const bylineDate = html.match(/\bon\s+([A-Z][a-z]{2,}\s+\d{1,2},\s+\d{4}(?:\s+\d{1,2}:\d{2}(?::\d{2})?\s*[AP]M)?)/);
+  if (bylineDate?.[1]) {
+    const parsed = new Date(bylineDate[1]);
+    if (!isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+
+  return '';
+}
+
+/**
+ * Extract author name from HubSpot blog post.
+ *
+ * HubSpot blog posts link to the author via /author/name paths.
+ * Falls back to the `<meta name="author">` tag.
+ */
+function extractHubSpotAuthor(html: string): string | undefined {
+  const authorLink = html.match(/<a[^>]+href=["'][^"']*\/author\/[^"']+["'][^>]*>([^<]+)<\/a>/i);
+  if (authorLink?.[1]) return authorLink[1].replace(/<[^>]*>/g, '').trim();
+
+  const metaAuthor = extractMeta(html, 'author');
+  return metaAuthor || undefined;
+}
+
+/**
+ * Extract tags from HubSpot blog post topic links.
+ * Topics appear as links to /topic/{slug} paths.
+ */
+function extractHubSpotTags(html: string): string[] {
+  const tags: string[] = [];
+  const seen = new Set<string>();
+  const pattern = /<a[^>]+href=["'][^"']*\/topic\/[^"']+["'][^>]*>([^<]+)<\/a>/gi;
+  let match;
+  while ((match = pattern.exec(html)) !== null) {
+    const name = match[1].replace(/<[^>]*>/g, '').trim();
+    if (name && !seen.has(name.toLowerCase())) {
+      seen.add(name.toLowerCase());
+      tags.push(name);
+    }
+  }
+  return tags;
+}
+
+/**
+ * Extract media URLs from a HubSpot page.
+ *
+ * HubSpot serves media from several patterns:
+ * - /hubfs/ paths on the site itself
+ * - hubspotusercontent-*.net CDN (regional)
+ * - f.hubspotusercontent*.net for files
+ * - Standard <img> tags
+ */
+function extractHubSpotMediaUrls(html: string, baseUrl: string): string[] {
+  const urls = new Set<string>();
+
+  // HubSpot CDN (regional user content)
+  const cdnPattern = /https?:\/\/[^\s"'<>)]*hubspotusercontent[^\s"'<>)]+/gi;
+  for (const m of html.match(cdnPattern) || []) urls.add(m);
+
+  // /hubfs/ paths (may be relative or absolute)
+  let origin: string | null = null;
+  try {
+    origin = new URL(baseUrl.includes('://') ? baseUrl : `https://${baseUrl}`).origin;
+  } catch {
+    origin = null;
+  }
+
+  const hubfsPattern = /(?:https?:\/\/[^\s"'<>)]+)?\/hubfs\/[^\s"'<>)]+/g;
+  for (const m of html.match(hubfsPattern) || []) {
+    if (m.startsWith('http')) {
+      urls.add(m);
+    } else if (origin) {
+      urls.add(origin + m);
+    }
+  }
+
+  // Standard <img> tags
+  const imgSrcMatches = html.match(/<img[^>]+src=["']([^"']+)["']/gi) || [];
+  for (const imgMatch of imgSrcMatches) {
+    const src = imgMatch.match(/src=["']([^"']+)["']/i);
+    if (src?.[1] && src[1].startsWith('http')) {
+      urls.add(src[1]);
+    }
+  }
+
+  // Filter to image URLs
+  const nonImageExtensions = /\.(css|js|json|xml|txt|map|woff2?|ttf|eot|pdf)$/i;
+  return [...urls].filter((u) => {
+    try {
+      const parsed = new URL(u);
+      if (nonImageExtensions.test(parsed.pathname)) return false;
+      // HubSpot CDN and /hubfs/ paths typically host images without explicit extensions
+      if (/hubspotusercontent|hubfs/i.test(parsed.hostname + parsed.pathname)) return true;
+      return IMAGE_EXTENSIONS.test(parsed.pathname);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Rewrite relative src and href attributes in HTML to absolute URLs.
+ */
+function resolveRelativeUrls(html: string, baseUrl: string): string {
+  let origin: string;
+  try {
+    origin = new URL(baseUrl.includes('://') ? baseUrl : `https://${baseUrl}`).origin;
+  } catch {
+    return html;
+  }
+
+  return html.replace(/(src|href)=["'](\/[^"']+)["']/gi, (_match, attr, path) => {
+    return `${attr}="${origin}${path}"`;
+  });
+}
+
+/**
+ * Strip the first <h1> if its text matches the post title.
+ * HubSpot renders the title inside content; WordPress also displays post_title.
+ */
+function stripDuplicateTitle(html: string, title: string): string {
+  if (!title) return html;
+  const normalize = (s: string) => s.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
+  const normalizedTitle = normalize(title);
+  if (!normalizedTitle) return html;
+
+  return html.replace(/<h1[^>]*>([\s\S]*?)<\/h1>/i, (fullMatch, inner) => {
+    return normalize(inner) === normalizedTitle ? '' : fullMatch;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The adapter
+// ---------------------------------------------------------------------------
+
+export const hubspotAdapter: PlatformAdapter = {
+  id: 'hubspot',
+
+  detect(_url: string): boolean {
+    // HubSpot CMS sites are on custom domains with no usable URL pattern.
+    // Detection relies on the Hubspot generator meta tag in detect-platform.ts.
+    return false;
+  },
+
+  async discover(url: string, _opts: Record<string, unknown>): Promise<HubSpotInventory> {
+    // 1. Fetch homepage HTML
+    let homepageHtml = '';
+    try {
+      const normalized = url.includes('://') ? url : `https://${url}`;
+      const resp = await fetch(normalized, {
+        signal: AbortSignal.timeout(15000),
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; DataLiberation/1.0)',
+        },
+      });
+      if (resp.ok) {
+        homepageHtml = await resp.text();
+      } else {
+        await resp.body?.cancel();
+      }
+    } catch {
+      // Network error
+    }
+
+    // 2. Extract site metadata
+    const ogTitle = extractMeta(homepageHtml, 'og:title');
+    const ogDescription = extractMeta(homepageHtml, 'og:description');
+    const siteTitle = ogTitle || extractTitle(homepageHtml) || 'Imported Site';
+    const siteTagline = ogDescription || extractMeta(homepageHtml, 'description') || '';
+
+    const langMatch = homepageHtml.match(/<html[^>]+lang=["']([^"']+)["']/i);
+    const siteLanguage = langMatch?.[1] || 'en-US';
+
+    // 3. Fetch sitemap
+    const sitemapUrls = await fetchSitemap(url);
+
+    // 4. Extract navigation
+    const normalized = url.includes('://') ? url : `https://${url}`;
+    const navigation = extractNavLinks(homepageHtml, normalized);
+
+    // 5. Classify URLs
+    // HubSpot blog posts typically live under paths like /blog/, /news/, or
+    // /{custom-blog-name}/. URL-pattern classification catches /blog/ but
+    // custom blog paths will be reclassified during extraction based on the
+    // body class `hs-blog-post`.
+    const counts: Record<string, number> = {};
+    const inventoryUrls: InventoryUrl[] = [];
+
+    for (const u of sitemapUrls) {
+      let type = classifyUrl(u);
+      // Common HubSpot blog URL patterns
+      if (type === 'page' && /\/(blog|news|insights|articles|resources|updates)\//.test(u)) {
+        type = 'post';
+      }
+      inventoryUrls.push({ url: u, type });
+      counts[type] = (counts[type] || 0) + 1;
+    }
+
+    if (inventoryUrls.length === 0) {
+      inventoryUrls.push({ url: normalized, type: 'homepage' });
+      counts['homepage'] = 1;
+    }
+
+    return {
+      siteUrl: url,
+      discoveredAt: new Date().toISOString(),
+      siteMeta: {
+        title: siteTitle,
+        tagline: siteTagline,
+        language: siteLanguage,
+      },
+      navigation,
+      counts,
+      urls: inventoryUrls,
+    };
+  },
+
+  async extract(
+    inventory: unknown,
+    wxr: WxrBuilder,
+    opts: Record<string, unknown>,
+    context: { log: ExtractionLog; server: Server }
+  ): Promise<{
+    pagesExtracted: number;
+    postsExtracted: number;
+    productsExtracted: number;
+    failed: number;
+    mediaCollected: number;
+  }> {
+    const inv = inventory as HubSpotInventory;
+    const hsOpts = opts as HubSpotAdapterOpts;
+    const delayMs = hsOpts.delay != null ? hsOpts.delay : 300;
+    const outputDir = hsOpts.outputDir || '';
+
+    const csvBuilder = new WooProductCsvBuilder();
+    if (outputDir && !hsOpts.dryRun) {
+      csvBuilder.openStream(outputDir);
+    }
+
+    const result = await runExtractionLoop({
+      urls: inv.urls,
+      navigation: inv.navigation,
+      wxr,
+      log: context.log,
+      outputDir,
+      delay: delayMs,
+      dryRun: !!hsOpts.dryRun,
+      resume: !!hsOpts.resume,
+      verbose: hsOpts.verbose,
+      server: context.server,
+      csvBuilder,
+      extractPage: async (url: string) => {
+        const resp = await fetch(url, {
+          signal: AbortSignal.timeout(15000),
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (compatible; DataLiberation/1.0)',
+          },
+        });
+        if (!resp.ok) {
+          await resp.body?.cancel();
+          throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+        }
+        const html = await resp.text();
+
+        // Type detection from body class: hs-blog-post is authoritative
+        const isPost = isHubSpotBlogPost(html);
+
+        // Title: prefer h1, then og:title, then <title>
+        const title = extractHeading(html) || slugify(url);
+
+        // Extract content, strip embedded title h1, resolve relative URLs
+        const content = resolveRelativeUrls(
+          stripDuplicateTitle(extractContent(html), title),
+          url
+        );
+
+        const excerpt = extractMeta(html, 'og:description') || extractMeta(html, 'description') || '';
+        const seoTitle = extractMeta(html, 'og:title') || extractTitle(html) || title;
+        const seoDescription = excerpt;
+
+        const date = isPost ? extractHubSpotDate(html) : '';
+        const author = isPost ? extractHubSpotAuthor(html) : undefined;
+        // Topics appear as inline /topic/{slug} links in the post content,
+        // which survive extraction. We also surface them as post tags on the
+        // item, though note: the WXR builder's streaming mode writes the
+        // taxonomy section at open time, so late-registered <wp:tag> entries
+        // would not land in the file. Fixing that is a shared-code concern.
+        const tags = isPost ? extractHubSpotTags(html) : [];
+
+        const mediaUrls = extractHubSpotMediaUrls(html, url);
+
+        const ogImage = extractMeta(html, 'og:image');
+        if (ogImage && ogImage.startsWith('http') && !mediaUrls.includes(ogImage)) {
+          try {
+            const parsed = new URL(ogImage);
+            if (IMAGE_EXTENSIONS.test(parsed.pathname) || /hubspotusercontent|hubfs/i.test(parsed.hostname + parsed.pathname)) {
+              mediaUrls.push(ogImage);
+            }
+          } catch { /* invalid URL */ }
+        }
+
+        const textOnly = content.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+        let qualityScore: 'high' | 'medium' | 'low' = 'low';
+        if (textOnly.length > 200) qualityScore = 'high';
+        else if (textOnly.length > 50) qualityScore = 'medium';
+
+        return {
+          title,
+          slug: slugify(url),
+          content,
+          excerpt,
+          date,
+          seoTitle,
+          seoDescription,
+          mediaUrls,
+          qualityScore,
+          categories: [],
+          tags,
+          author,
+          // Override URL-based classification with body-class signal
+          detectedType: isPost ? 'post' : 'page',
+        };
+      },
+    });
+
+    if (result.productsExtracted > 0 && outputDir && !hsOpts.dryRun) {
+      if (csvBuilder.isStreaming) {
+        csvBuilder.closeStream();
+      } else {
+        csvBuilder.serialize(`${outputDir}/products.csv`);
+      }
+    }
+
+    return result;
+  },
+};

--- a/src/lib/extraction/detect-platform.ts
+++ b/src/lib/extraction/detect-platform.ts
@@ -49,6 +49,7 @@ const SOURCE_SIGNALS: SourceSignal[] = [
   { pattern: /static\.squarespace\.com/i, platform: 'squarespace', signal: 'static.squarespace.com in page source' },
   { pattern: /data-wf-domain/i, platform: 'webflow', signal: 'data-wf-domain attribute in page source' },
   { pattern: /_shopify_s|_shopify_y|Shopify\.theme/i, platform: 'shopify', signal: 'Shopify markers in page source' },
+  { pattern: /<meta[^>]+name=["']generator["'][^>]+content=["']HubSpot["']/i, platform: 'hubspot', signal: 'HubSpot generator meta tag' },
 ];
 
 export function detectFromUrl(url: string): string | null {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,8 @@ import { wixAdapter } from './adapters/wix.js';
 import { squarespaceAdapter } from './adapters/squarespace.js';
 import { webflowAdapter } from './adapters/webflow.js';
 import { shopifyAdapter } from './adapters/shopify.js';
-const adapters: PlatformAdapter[] = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter];
+import { hubspotAdapter } from './adapters/hubspot.js';
+const adapters: PlatformAdapter[] = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter, hubspotAdapter];
 
 function findAdapter(platform: string): PlatformAdapter | null {
   return adapters.find((a) => a.id === platform) || null;

--- a/src/ui/discover.tsx
+++ b/src/ui/discover.tsx
@@ -12,6 +12,7 @@ import { wixAdapter, type Inventory } from '../adapters/wix.js';
 import { squarespaceAdapter } from '../adapters/squarespace.js';
 import { webflowAdapter } from '../adapters/webflow.js';
 import { shopifyAdapter } from '../adapters/shopify.js';
+import { hubspotAdapter } from '../adapters/hubspot.js';
 import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 
@@ -67,7 +68,7 @@ interface ExtractionResult {
   wxrPath: string | null;
 }
 
-const adapters = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter];
+const adapters = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter, hubspotAdapter];
 
 function findAdapter(platform: string) {
   return adapters.find((a) => a.id === platform) || null;
@@ -364,14 +365,14 @@ function Liberate(props: LiberateProps & { onComplete?: (wxrPath: string | null)
       {phase === 'discovered' && (
         <Box flexDirection="column" marginTop={1}>
           <Text color="yellow">! {error}</Text>
-          <Text dimColor>Supported: Wix, Squarespace, Webflow, Shopify.</Text>
+          <Text dimColor>Supported: Wix, Squarespace, Webflow, Shopify, HubSpot.</Text>
         </Box>
       )}
 
       {/* Unknown platform warning */}
       {phase === 'done' && detection?.platform === 'unknown' && (
         <Box marginTop={1}>
-          <Text color="yellow">! Supported platforms: Wix, Squarespace, Webflow, Shopify</Text>
+          <Text color="yellow">! Supported platforms: Wix, Squarespace, Webflow, Shopify, HubSpot</Text>
         </Box>
       )}
 


### PR DESCRIPTION
## Summary
- Adds HubSpot CMS Hub as a supported platform adapter
- Detection via `<meta name="generator" content="HubSpot">` — the only reliable signal, since many non-HubSpot sites embed HubSpot marketing scripts (CTAs, forms, tracking). The adapter is explicitly resilient to that: eplan.co.za has HubSpot scripts but is actually a TYPO3 site, and our detection correctly skips it.
- Body-class-based content-type classification (`hs-blog-post` vs `hs-site-page`) — overrides URL-based classification via `detectedType`, catching HubSpot sites with custom blog paths
- Blog content extracted from `.post-body`, regular pages from `.body-container` with nav/header/footer stripped
- HubSpot marketing widget cleanup: strips CTAs (`.hs-cta-wrapper`, `.hs-cta-node`), hosted forms, blog comments, and AddThis social widgets from extracted content
- Byline date parsing (HubSpot renders dates as `"by Author, on Dec 6, 2024 6:57:40 PM"` text) with `article:published_time` meta fallback
- Author extraction from `/author/` link text, topics (tags) from `/topic/` link text
- Media capture for `/hubfs/` paths and `hubspotusercontent-*.net` CDN
- Duplicate `<h1>` title stripping (HubSpot embeds title inside content which would otherwise show twice alongside `post_title`)
- Relative URL resolution so WordPress matches attachment URLs during import

Built and tested iteratively against multiple live HubSpot sites: https://w3techs.com/technologies/details/cm-hubspotcms

## Tested against
- [x] Real sites (4 live sites covering content marketing, SaaS landing, SMB, and a negative case for detection)
- [x] End-to-end import of 124 posts into WordPress with verified titles, dates, author bylines, and content quality
- [x] Tests pass (`npx vitest run`) — pre-existing failures in `content-differ.test.ts` and `legacy-scripts.test.ts` unchanged, no new failures

## Known limitation
Tags (HubSpot topics) are extracted and surfaced as post tags but don't currently land as WordPress taxonomy terms on import. The WXR builder writes the taxonomy section at `openStream()` time, before posts are processed, so late-registered `<wp:tag>` entries aren't persisted in streaming mode. **This is a shared-code gap affecting all adapters** that pass tag slugs through `addPost` — topics still appear as inline linked text in imported post content, so no content is lost.

## Discovery log entry added to DISCOVERIES.md
- [x] Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)