### PR TITLE
feat: add Weebly platform adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`data-liberation-agent` extracts content from closed web platforms (Wix, Squarespace, Webflow, Shopify) and produces WordPress-compatible WXR files. All four platform adapters are implemented.
+`data-liberation-agent` extracts content from closed web platforms (Wix, Squarespace, Webflow, Shopify, Weebly) and produces WordPress-compatible WXR files. All five platform adapters are implemented.
 
 Three entry points — MCP server (11 tools), CLI (`src/cli.ts`), and Claude Code plugin (`claude plugin add .`) — all share `src/lib/` and `src/adapters/`. The plugin just wraps the MCP server.
 

--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,45 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-13 — Weebly platform adapter
+
+**Found by:** Claude + human contributor
+**During:** Adding Weebly as a new supported platform
+**Type:** platform adapter
+
+### What I found
+
+Weebly sites use a consistent HTML structure across all sites with reliable fingerprints for detection. Key findings from analyzing multiple live Weebly sites:
+
+**Detection signals:**
+- URL pattern: `weebly.com` subdomains
+- CDN: All Weebly sites load assets from `editmysite.com` (cdn1/cdn2)
+- HTML markers: `wsite-` class prefix on all structural elements, `_W.configDomain` JS variable referencing `weebly.com`
+
+**Content structure:**
+- Main content container: `#wsite-content`
+- Navigation: `li.wsite-menu-item-wrap > a.wsite-menu-item` with flyout submenus in `.wsite-menu-wrap`
+- Blog posts: Minimal semantic markup — titles in `<h2>` with anchor links, dates as plain text in MM/DD/YYYY format, categories linked via `/blog/category/slug`
+- Products: `.wsite-product` with commerce backed by Square (Weebly's parent company)
+- No JSON-LD or structured data on any tested sites
+
+**Sitemaps:** Standard XML sitemaps available at `/sitemap.xml` with pages, blog posts, products, and category pages.
+
+### How it works
+
+The adapter follows the same fetch-and-scrape pattern as the Webflow adapter:
+1. `detect()` matches `weebly.com` in the URL
+2. `discover()` fetches the homepage HTML + sitemap, extracts navigation from the `wsite-menu` structure, and classifies URLs (with special handling for `/blog/` paths as posts)
+3. `extract()` uses `runExtractionLoop()` with a Weebly-specific `extractPage` function that pulls content from `#wsite-content`, media from `editmysite.com`/`weeblycloud.com` CDN URLs, and blog metadata from category links and date text
+
+Platform detection in `detect-platform.ts` uses two source signals: `editmysite.com` in page source (high confidence) and `wsite-` class markers or `_W.configDomain` variable (medium confidence). Custom domain sites without `weebly.com` in the URL are detected via these HTTP fingerprints.
+
+### Why it's better than the previous approach
+
+Weebly was not previously supported. This adds the fifth platform adapter, covering another significant website builder with a large install base of small business sites.
+
+---
+
 ## 2026-04-02 — Squarespace admin extraction via CDP
 
 **Found by:** Claude + human contributor (live testing against a Squarespace site)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ This tool extracts all content from closed platforms — posts, pages, media, na
 | **Squarespace** | Ready | [`prompts/squarespace.md`](./prompts/squarespace.md) |
 | **Webflow** | Ready | [`prompts/webflow.md`](./prompts/webflow.md) |
 | **Shopify** (blog/pages/products) | Ready | [`prompts/shopify.md`](./prompts/shopify.md) |
+| **Weebly** (blog/pages/products) | Ready | — |
 
-All four platforms have MCP adapters with full extraction support including products (exported as WooCommerce-compatible CSV).
+All five platforms have MCP adapters with full extraction support including products (exported as WooCommerce-compatible CSV).
 
 ## AI tool integration
 

--- a/commands/inspect.md
+++ b/commands/inspect.md
@@ -7,7 +7,7 @@ Run the inspect skill to check a site before extracting content. Shows platform 
 
 ## What it reports
 
-- **Platform detection** — Wix, Squarespace, Webflow, Shopify, or unknown (with confidence level and detection signals)
+- **Platform detection** — Wix, Squarespace, Webflow, Shopify, Weebly, or unknown (with confidence level and detection signals)
 - **URL inventory** — sitemap scan with counts by type (pages, posts, products, galleries, events, etc.)
 - **Sample page probes** — tests extractability on 2-3 sample pages (if the adapter supports probing)
 - **Platform features** — detects stores, bookings, forms, members areas, scheduling, forums, and events. Each feature includes whether it transfers automatically and a WordPress plugin recommendation if it doesn't.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,7 +7,7 @@ Command definitions live in `commands/<name>.md`.
 ## /inspect
 
 Inspect a website before extraction. Reports:
-- Platform detection (Wix, Squarespace, Webflow, Shopify) with confidence level
+- Platform detection (Wix, Squarespace, Webflow, Shopify, Weebly) with confidence level
 - URL inventory from sitemap with counts by type (pages, posts, products, galleries, events)
 - Sample page probes to test extractability
 - Platform feature flags (stores, bookings, forms, members, scheduling, forums, events) with transfer status and WordPress plugin recommendations

--- a/src/adapters/weebly.ts
+++ b/src/adapters/weebly.ts
@@ -1,0 +1,568 @@
+import type { PlatformAdapter } from '../types.js';
+import type { WxrBuilder } from '../lib/extraction/wxr-builder.js';
+import type { ExtractionLog } from '../lib/extraction/extraction-log.js';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { fetchSitemap, classifyUrl } from '../lib/extraction/sitemap.js';
+import { slugify, runExtractionLoop, extractMeta, extractTitle, extractNavLinks, IMAGE_EXTENSIONS } from './shared.js';
+import type { InventoryUrl, NavLink } from './shared.js';
+import { WooProductCsvBuilder } from '../lib/import/woo-product-csv.js';
+import type { WooProduct } from '../lib/import/woo-product-csv.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WeeblyAdapterOpts extends Record<string, unknown> {
+  delay?: number;
+  resume?: boolean;
+  dryRun?: boolean;
+  verbose?: boolean;
+  outputDir?: string;
+}
+
+export interface WeeblyInventory {
+  siteUrl: string;
+  discoveredAt: string;
+  siteMeta: {
+    title: string;
+    tagline: string;
+    language: string;
+  };
+  navigation: NavLink[];
+  counts: Record<string, number>;
+  urls: InventoryUrl[];
+}
+
+// ---------------------------------------------------------------------------
+// HTML helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the inner HTML of the first element matching a given class or ID,
+ * handling nested tags of the same type by tracking depth.
+ */
+function extractBySelector(html: string, pattern: RegExp, tag = 'div'): string {
+  const match = html.match(pattern);
+  if (!match) return '';
+
+  const startIdx = html.indexOf(match[0]);
+  const afterTag = startIdx + match[0].length;
+  let depth = 1;
+  let i = afterTag;
+  const openTag = `<${tag}`;
+  const closeTag = `</${tag}>`;
+
+  while (i < html.length && depth > 0) {
+    const nextOpen = html.indexOf(openTag, i);
+    const nextClose = html.indexOf(closeTag, i);
+    if (nextClose === -1) break;
+    if (nextOpen !== -1 && nextOpen < nextClose) {
+      depth++;
+      i = nextOpen + openTag.length;
+    } else {
+      depth--;
+      if (depth === 0) {
+        return html.slice(afterTag, nextClose).trim();
+      }
+      i = nextClose + closeTag.length;
+    }
+  }
+  return '';
+}
+
+/**
+ * Extract content from Weebly's #wsite-content container.
+ * Falls back to <main>, <article>, or body content.
+ */
+function extractContent(html: string): string {
+  // Strategy 1: Weebly's main content container
+  const wsiteContent = extractBySelector(html, /<div[^>]*\sid=["']wsite-content["'][^>]*>/i);
+  if (wsiteContent) return wsiteContent;
+
+  // Strategy 2: <main> tag
+  const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+  if (mainMatch?.[1]?.trim()) return mainMatch[1].trim();
+
+  // Strategy 3: <article> tag
+  const articleMatch = html.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  if (articleMatch?.[1]?.trim()) return articleMatch[1].trim();
+
+  return '';
+}
+
+/**
+ * Extract heading from the page — tries h1, then og:title, then <title>.
+ */
+function extractHeading(html: string): string {
+  const h1 = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i)?.[1]?.replace(/<[^>]*>/g, '').trim();
+  if (h1) return h1;
+
+  const ogTitle = extractMeta(html, 'og:title');
+  if (ogTitle) return ogTitle;
+
+  return extractTitle(html);
+}
+
+/**
+ * Extract Weebly navigation links from the wsite-menu structure.
+ * Weebly uses li.wsite-menu-item-wrap > a.wsite-menu-item for top-level nav.
+ * Falls back to the shared <nav> extractor.
+ */
+function extractWeeblyNavLinks(html: string, baseUrl: string): NavLink[] {
+  const links: NavLink[] = [];
+  const seen = new Set<string>();
+
+  // Match Weebly menu items: <a ... class="wsite-menu-item" ...>text</a>
+  const menuItemPattern = /<a[^>]+class=["'][^"']*wsite-menu-item[^"']*["'][^>]*>([\s\S]*?)<\/a>/gi;
+  let match;
+  while ((match = menuItemPattern.exec(html)) !== null) {
+    const fullTag = match[0];
+    const text = match[1].replace(/<[^>]*>/g, '').trim();
+    const hrefMatch = fullTag.match(/href=["']([^"']+)["']/i);
+    if (!text || !hrefMatch) continue;
+
+    let href = hrefMatch[1];
+    if (seen.has(href)) continue;
+    seen.add(href);
+
+    // Normalize protocol-relative and relative URLs
+    if (href.startsWith('//')) {
+      href = 'https:' + href;
+    } else if (href.startsWith('/')) {
+      try {
+        href = new URL(href, baseUrl).href;
+      } catch {
+        // keep as-is
+      }
+    }
+
+    links.push({ text, href });
+  }
+
+  // Fall back to generic <nav> extraction if Weebly menu structure wasn't found
+  if (links.length === 0) {
+    return extractNavLinks(html, baseUrl);
+  }
+
+  return links;
+}
+
+/**
+ * Extract media URLs from Weebly content.
+ * Looks for editmysite.com CDN URLs, weeblycloud.com, and standard <img> tags.
+ */
+function extractWeeblyMediaUrls(html: string): string[] {
+  const urls = new Set<string>();
+
+  // Weebly CDN URLs (editmysite.com)
+  const cdnPattern = /https?:\/\/[^\s"'<>)]*editmysite\.com\/[^\s"'<>)]+/g;
+  const cdnMatches = html.match(cdnPattern) || [];
+  for (const m of cdnMatches) urls.add(m);
+
+  // Weebly Cloud image URLs
+  const cloudPattern = /https?:\/\/[^\s"'<>)]*weeblycloud\.com\/[^\s"'<>)]+/g;
+  const cloudMatches = html.match(cloudPattern) || [];
+  for (const m of cloudMatches) urls.add(m);
+
+  // Weebly uploads directory
+  const uploadsPattern = /https?:\/\/[^\s"'<>)]*\/uploads\/[^\s"'<>)]+/g;
+  const uploadsMatches = html.match(uploadsPattern) || [];
+  for (const m of uploadsMatches) urls.add(m);
+
+  // Standard <img> tags
+  const imgSrcMatches = html.match(/<img[^>]+src=["']([^"']+)["']/gi) || [];
+  for (const imgMatch of imgSrcMatches) {
+    const src = imgMatch.match(/src=["']([^"']+)["']/i);
+    if (src?.[1] && src[1].startsWith('http')) {
+      urls.add(src[1]);
+    }
+  }
+
+  // Filter to image URLs only (exclude CSS, JS, fonts, and other assets)
+  const nonImageExtensions = /\.(css|js|json|xml|txt|map|woff2?|ttf|eot|pdf)$/i;
+  return [...urls].filter((u) => {
+    try {
+      const parsed = new URL(u);
+      if (nonImageExtensions.test(parsed.pathname)) return false;
+      return IMAGE_EXTENSIONS.test(parsed.pathname);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Extract blog post date from Weebly's date format.
+ * Weebly displays dates as plain text in MM/DD/YYYY format.
+ */
+function extractWeeblyDate(html: string): string {
+  // Try standard meta tags first
+  const articleDate = extractMeta(html, 'article:published_time');
+  if (articleDate) return articleDate;
+
+  // Weebly blog date in date-text class
+  const dateTextMatch = html.match(/class=["'][^"']*date-text[^"']*["'][^>]*>([^<]+)</i);
+  if (dateTextMatch?.[1]) {
+    const dateStr = dateTextMatch[1].trim();
+    const parsed = new Date(dateStr);
+    if (!isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+
+  // Weebly blog date as plain text in MM/DD/YYYY format near post title
+  const datePattern = /(\d{1,2}\/\d{1,2}\/\d{4})/;
+  const dateMatch = html.match(datePattern);
+  if (dateMatch?.[1]) {
+    const parsed = new Date(dateMatch[1]);
+    if (!isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+
+  // <time> element fallback
+  const timeElement = html.match(/<time[^>]+datetime=["']([^"']+)["']/i)?.[1];
+  if (timeElement) return timeElement;
+
+  return '';
+}
+
+/**
+ * Extract blog categories from Weebly's category links.
+ * Weebly uses /blog/category/slug format for category pages.
+ */
+function extractWeeblyCategories(html: string): string[] {
+  const categories: string[] = [];
+  const seen = new Set<string>();
+
+  const categoryPattern = /href=["'][^"']*\/blog\/category\/([^"']+)["'][^>]*>([^<]+)/gi;
+  let match;
+  while ((match = categoryPattern.exec(html)) !== null) {
+    const name = match[2].trim();
+    if (name && !seen.has(name.toLowerCase())) {
+      seen.add(name.toLowerCase());
+      categories.push(name);
+    }
+  }
+
+  return categories;
+}
+
+// ---------------------------------------------------------------------------
+// Resolve relative URLs in HTML content to absolute
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite relative src and href attributes in HTML to absolute URLs.
+ * This ensures WordPress can match attachment URLs in content during import.
+ */
+function resolveRelativeUrls(html: string, baseUrl: string): string {
+  let origin: string;
+  try {
+    origin = new URL(baseUrl.includes('://') ? baseUrl : `https://${baseUrl}`).origin;
+  } catch {
+    return html;
+  }
+
+  // Resolve src="/..." and href="/..." to absolute URLs
+  return html.replace(/(src|href)=["'](\/[^"']+)["']/gi, (_match, attr, path) => {
+    return `${attr}="${origin}${path}"`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Weebly product extraction from HTML
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract product data from a Weebly product page.
+ *
+ * Weebly product pages have minimal semantic markup — the content inside
+ * #wsite-content is flat: an <h2> for the title, plain divs for price/SKU,
+ * and paragraphs for the description. There are no product-specific classes
+ * on the actual DOM elements (only in CSS selectors).
+ *
+ * We extract from within #wsite-content to avoid picking up nav/header text.
+ */
+function extractWeeblyProduct(_url: string, html: string): WooProduct | null {
+  // NOTE: html here is pageData.content — already scoped to #wsite-content
+  // by extractContent(). No need to re-scope.
+  if (!html) return null;
+
+  // Product title: first <h2> in the content
+  const titleMatch = html.match(/<h2[^>]*>([\s\S]*?)<\/h2>/i);
+  const name = titleMatch?.[1]?.replace(/<[^>]*>/g, '').trim();
+  if (!name) return null;
+
+  // Price: look for dollar amount pattern
+  // Weebly renders price as flat text like "$8.50" or "$8.50 per item"
+  const pricePattern = /\$\s*(\d+(?:\.\d{2})?)/;
+  const priceMatch = html.match(pricePattern);
+  const firstPrice = priceMatch?.[1] || '';
+
+  // Sale price: look for crossed-out / original price patterns
+  const salePriceMatch = html.match(/class=["'][^"']*(?:sale|original)[^"']*["'][^>]*>\s*\$\s*(\d+(?:\.\d{2})?)/i);
+  const salePrice = salePriceMatch?.[1] || undefined;
+
+  // Description: collect text from <p> tags first. If no <p> tags produce
+  // results, fall back to <div class="paragraph"> blocks. Weebly wraps text
+  // in both, and the <div> version often contains a concatenated duplicate
+  // of all the <p> content, so we prefer <p> tags when available.
+  const descParts: string[] = [];
+
+  function isDescText(text: string): boolean {
+    if (text.length < 15) return false;
+    if (/^\$\d/.test(text)) return false;
+    if (/^SKU:/i.test(text)) return false;
+    if (/^(Add to Cart|Unavailable|Out of Stock|per item|Have questions|Items handcrafted)/i.test(text)) return false;
+    return true;
+  }
+
+  // Try <p> tags first
+  const pTags = html.match(/<p[^>]*>([\s\S]*?)<\/p>/gi) || [];
+  for (const p of pTags) {
+    const text = p.replace(/<[^>]*>/g, '').trim();
+    if (isDescText(text)) descParts.push(text);
+  }
+
+  // Fall back to <div class="paragraph"> blocks if no <p> content found
+  if (descParts.length === 0) {
+    const divParas = html.match(/<div[^>]+class=["'][^"']*paragraph[^"']*["'][^>]*>([\s\S]*?)<\/div>/gi) || [];
+    for (const div of divParas) {
+      const text = div.replace(/<[^>]*>/g, '').trim();
+      if (isDescText(text)) descParts.push(text);
+    }
+  }
+
+  const description = descParts.join('\n\n');
+
+  // Images: Weebly product images in /uploads/ paths
+  const images: string[] = [];
+  const imgPattern = /<img[^>]+src=["']([^"']*\/uploads\/[^"']+)["']/gi;
+  let imgMatch;
+  while ((imgMatch = imgPattern.exec(html)) !== null) {
+    let src = imgMatch[1];
+    // Make absolute if relative
+    if (src.startsWith('/')) {
+      try {
+        const urlObj = new URL(_url);
+        src = urlObj.origin + src;
+      } catch { /* keep relative */ }
+    }
+    // Strip Weebly resize params for original image
+    src = src.replace(/\?width=\d+/, '');
+    if (!images.includes(src)) {
+      images.push(src);
+    }
+  }
+
+  // Also check for CDN-hosted product images
+  const cdnImgPattern = /<img[^>]+src=["'](https?:\/\/[^"']*editmysite\.com\/[^"']+)["']/gi;
+  while ((imgMatch = cdnImgPattern.exec(html)) !== null) {
+    const src = imgMatch[1];
+    if (IMAGE_EXTENSIONS.test(src) && !images.includes(src)) {
+      images.push(src);
+    }
+  }
+
+  return {
+    name,
+    type: 'simple',
+    description,
+    regularPrice: firstPrice,
+    salePrice,
+    images,
+    // Default to in-stock. Weebly's commerce template often renders "Unavailable"
+    // as part of the page chrome even for products that are in stock, so we can't
+    // reliably detect stock status from the static HTML alone.
+    inStock: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The adapter
+// ---------------------------------------------------------------------------
+
+export const weeblyAdapter: PlatformAdapter = {
+  id: 'weebly',
+
+  detect(url: string): boolean {
+    return /weebly\.com/i.test(url);
+  },
+
+  async discover(url: string, _opts: Record<string, unknown>): Promise<WeeblyInventory> {
+    // 1. Fetch homepage HTML
+    let homepageHtml = '';
+    try {
+      const normalized = url.includes('://') ? url : `https://${url}`;
+      const resp = await fetch(normalized, {
+        signal: AbortSignal.timeout(15000),
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; DataLiberation/1.0)',
+        },
+      });
+      if (resp.ok) {
+        homepageHtml = await resp.text();
+      } else {
+        await resp.body?.cancel();
+      }
+    } catch {
+      // Network error — continue with empty HTML
+    }
+
+    // 2. Extract site metadata
+    const ogTitle = extractMeta(homepageHtml, 'og:title');
+    const ogDescription = extractMeta(homepageHtml, 'og:description');
+    const siteTitle = ogTitle || extractTitle(homepageHtml) || 'Imported Site';
+    const siteTagline = ogDescription || extractMeta(homepageHtml, 'description') || '';
+
+    // Detect language from <html lang="...">
+    const langMatch = homepageHtml.match(/<html[^>]+lang=["']([^"']+)["']/i);
+    const siteLanguage = langMatch?.[1] || 'en-US';
+
+    // 3. Fetch sitemap
+    const sitemapUrls = await fetchSitemap(url);
+
+    // 4. Extract navigation from Weebly menu structure
+    const normalized = url.includes('://') ? url : `https://${url}`;
+    const navigation = extractWeeblyNavLinks(homepageHtml, normalized);
+
+    // 5. Classify URLs
+    const counts: Record<string, number> = {};
+    const inventoryUrls: InventoryUrl[] = [];
+
+    for (const u of sitemapUrls) {
+      // Weebly blog posts live under /blog/ paths
+      let type = classifyUrl(u);
+      if (type === 'page' && /\/blog\//.test(u) && !/\/blog\/category\//.test(u)) {
+        type = 'post';
+      }
+      inventoryUrls.push({ url: u, type });
+      counts[type] = (counts[type] || 0) + 1;
+    }
+
+    // If sitemap was empty, add the homepage
+    if (inventoryUrls.length === 0) {
+      inventoryUrls.push({ url: normalized, type: 'homepage' });
+      counts['homepage'] = 1;
+    }
+
+    return {
+      siteUrl: url,
+      discoveredAt: new Date().toISOString(),
+      siteMeta: {
+        title: siteTitle,
+        tagline: siteTagline,
+        language: siteLanguage,
+      },
+      navigation,
+      counts,
+      urls: inventoryUrls,
+    };
+  },
+
+  async extract(
+    inventory: unknown,
+    wxr: WxrBuilder,
+    opts: Record<string, unknown>,
+    context: { log: ExtractionLog; server: Server }
+  ): Promise<{
+    pagesExtracted: number;
+    postsExtracted: number;
+    productsExtracted: number;
+    failed: number;
+    mediaCollected: number;
+  }> {
+    const inv = inventory as WeeblyInventory;
+    const wbOpts = opts as WeeblyAdapterOpts;
+    const delayMs = wbOpts.delay != null ? wbOpts.delay : 300;
+    const outputDir = wbOpts.outputDir || '';
+
+    const csvBuilder = new WooProductCsvBuilder();
+    if (outputDir && !wbOpts.dryRun) {
+      csvBuilder.openStream(outputDir);
+    }
+
+    const result = await runExtractionLoop({
+      urls: inv.urls,
+      navigation: inv.navigation,
+      wxr,
+      log: context.log,
+      outputDir,
+      delay: delayMs,
+      dryRun: !!wbOpts.dryRun,
+      resume: !!wbOpts.resume,
+      verbose: wbOpts.verbose,
+      server: context.server,
+      csvBuilder,
+      extractPage: async (url: string) => {
+        // Fetch the page HTML
+        const resp = await fetch(url, {
+          signal: AbortSignal.timeout(15000),
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (compatible; DataLiberation/1.0)',
+          },
+        });
+        if (!resp.ok) {
+          await resp.body?.cancel();
+          throw new Error(`HTTP ${resp.status} ${resp.statusText}`);
+        }
+        const html = await resp.text();
+
+        // Extract content and resolve relative URLs to absolute so WordPress
+        // can match attachment URLs during import (rewrites src="/uploads/..." etc.)
+        const content = resolveRelativeUrls(extractContent(html), url);
+        const title = extractHeading(html) || slugify(url);
+        const excerpt = extractMeta(html, 'og:description') || extractMeta(html, 'description') || '';
+        const seoTitle = extractMeta(html, 'og:title') || extractTitle(html) || title;
+        const seoDescription = excerpt;
+
+        // Extract date
+        const date = extractWeeblyDate(html);
+
+        // Extract media
+        const mediaUrls = extractWeeblyMediaUrls(html);
+
+        // Extract OG image
+        const ogImage = extractMeta(html, 'og:image');
+        if (ogImage && ogImage.startsWith('http') && !mediaUrls.includes(ogImage)) {
+          try {
+            if (IMAGE_EXTENSIONS.test(new URL(ogImage).pathname)) {
+              mediaUrls.push(ogImage);
+            }
+          } catch { /* invalid URL */ }
+        }
+
+        // Extract categories from blog posts
+        const categories = extractWeeblyCategories(html);
+
+        // Quality score based on content length
+        const textOnly = content.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+        let qualityScore: 'high' | 'medium' | 'low' = 'low';
+        if (textOnly.length > 200) qualityScore = 'high';
+        else if (textOnly.length > 50) qualityScore = 'medium';
+
+        return {
+          title,
+          slug: slugify(url),
+          content,
+          excerpt,
+          date,
+          seoTitle,
+          seoDescription,
+          mediaUrls,
+          qualityScore,
+          categories,
+          tags: [],
+        };
+      },
+      extractProduct: extractWeeblyProduct,
+    });
+
+    if (result.productsExtracted > 0 && outputDir && !wbOpts.dryRun) {
+      if (csvBuilder.isStreaming) {
+        csvBuilder.closeStream();
+      } else {
+        csvBuilder.serialize(`${outputDir}/products.csv`);
+      }
+    }
+
+    return result;
+  },
+};

--- a/src/adapters/weebly.ts
+++ b/src/adapters/weebly.ts
@@ -208,17 +208,20 @@ function extractWeeblyDate(html: string): string {
     if (!isNaN(parsed.getTime())) return parsed.toISOString();
   }
 
-  // Weebly blog date as plain text in MM/DD/YYYY format near post title
+  // <time> element — prefer semantic markup before falling back to text scraping
+  const timeElement = html.match(/<time[^>]+datetime=["']([^"']+)["']/i)?.[1];
+  if (timeElement) return timeElement;
+
+  // Weebly blog date as plain text in MM/DD/YYYY format. Scope the search to
+  // the #wsite-content container so we don't pick up stray dates from footer
+  // copyright lines, testimonials, or chrome.
+  const contentScope = extractBySelector(html, /<div[^>]*\sid=["']wsite-content["'][^>]*>/i) || html;
   const datePattern = /(\d{1,2}\/\d{1,2}\/\d{4})/;
-  const dateMatch = html.match(datePattern);
+  const dateMatch = contentScope.match(datePattern);
   if (dateMatch?.[1]) {
     const parsed = new Date(dateMatch[1]);
     if (!isNaN(parsed.getTime())) return parsed.toISOString();
   }
-
-  // <time> element fallback
-  const timeElement = html.match(/<time[^>]+datetime=["']([^"']+)["']/i)?.[1];
-  if (timeElement) return timeElement;
 
   return '';
 }
@@ -260,8 +263,10 @@ function resolveRelativeUrls(html: string, baseUrl: string): string {
     return html;
   }
 
-  // Resolve src="/..." and href="/..." to absolute URLs
-  return html.replace(/(src|href)=["'](\/[^"']+)["']/gi, (_match, attr, path) => {
+  // Resolve src="/..." and href="/..." to absolute URLs.
+  // The (?!\/) guard skips protocol-relative URLs like src="//cdn.example.com/...",
+  // which would otherwise be mangled into "https://site.com//cdn.example.com/...".
+  return html.replace(/(src|href)=["'](\/(?!\/)[^"']+)["']/gi, (_match, attr, path) => {
     return `${attr}="${origin}${path}"`;
   });
 }

--- a/src/lib/extraction/detect-platform.ts
+++ b/src/lib/extraction/detect-platform.ts
@@ -31,6 +31,7 @@ const URL_PATTERNS: UrlPattern[] = [
   { pattern: /squarespace\.com/i, platform: 'squarespace' },
   { pattern: /webflow\.io|webflow\.com/i, platform: 'webflow' },
   { pattern: /myshopify\.com|shopify\.com/i, platform: 'shopify' },
+  { pattern: /weebly\.com/i, platform: 'weebly' },
 ];
 
 const HTTP_SIGNALS: HttpSignal[] = [
@@ -49,6 +50,8 @@ const SOURCE_SIGNALS: SourceSignal[] = [
   { pattern: /static\.squarespace\.com/i, platform: 'squarespace', signal: 'static.squarespace.com in page source' },
   { pattern: /data-wf-domain/i, platform: 'webflow', signal: 'data-wf-domain attribute in page source' },
   { pattern: /_shopify_s|_shopify_y|Shopify\.theme/i, platform: 'shopify', signal: 'Shopify markers in page source' },
+  { pattern: /editmysite\.com/i, platform: 'weebly', signal: 'editmysite.com CDN in page source' },
+  { pattern: /wsite-menu-item|wsite-content|_W\.configDomain\s*=\s*["'].*weebly/i, platform: 'weebly', signal: 'Weebly markers in page source' },
 ];
 
 export function detectFromUrl(url: string): string | null {

--- a/src/lib/extraction/detect-platform.ts
+++ b/src/lib/extraction/detect-platform.ts
@@ -42,6 +42,7 @@ const HTTP_SIGNALS: HttpSignal[] = [
   { header: 'x-wf-region', platform: 'webflow', signal: 'x-wf-region header (Webflow infrastructure)' },
   { header: 'x-shopid', platform: 'shopify', signal: 'X-ShopId header' },
   { header: 'powered-by', value: 'shopify', platform: 'shopify', signal: 'Powered-by: Shopify header' },
+  { header: 'x-host', value: 'weebly.net', platform: 'weebly', signal: 'X-Host: *.weebly.net header (Weebly backend)' },
 ];
 
 const SOURCE_SIGNALS: SourceSignal[] = [

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -18,7 +18,8 @@ import { wixAdapter } from './adapters/wix.js';
 import { squarespaceAdapter } from './adapters/squarespace.js';
 import { webflowAdapter } from './adapters/webflow.js';
 import { shopifyAdapter } from './adapters/shopify.js';
-const adapters: PlatformAdapter[] = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter];
+import { weeblyAdapter } from './adapters/weebly.js';
+const adapters: PlatformAdapter[] = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter, weeblyAdapter];
 
 function findAdapter(platform: string): PlatformAdapter | null {
   return adapters.find((a) => a.id === platform) || null;

--- a/src/ui/discover.tsx
+++ b/src/ui/discover.tsx
@@ -12,6 +12,7 @@ import { wixAdapter, type Inventory } from '../adapters/wix.js';
 import { squarespaceAdapter } from '../adapters/squarespace.js';
 import { webflowAdapter } from '../adapters/webflow.js';
 import { shopifyAdapter } from '../adapters/shopify.js';
+import { weeblyAdapter } from '../adapters/weebly.js';
 import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
 
@@ -67,7 +68,7 @@ interface ExtractionResult {
   wxrPath: string | null;
 }
 
-const adapters = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter];
+const adapters = [wixAdapter, squarespaceAdapter, webflowAdapter, shopifyAdapter, weeblyAdapter];
 
 function findAdapter(platform: string) {
   return adapters.find((a) => a.id === platform) || null;
@@ -364,14 +365,14 @@ function Liberate(props: LiberateProps & { onComplete?: (wxrPath: string | null)
       {phase === 'discovered' && (
         <Box flexDirection="column" marginTop={1}>
           <Text color="yellow">! {error}</Text>
-          <Text dimColor>Supported: Wix, Squarespace, Webflow, Shopify.</Text>
+          <Text dimColor>Supported: Wix, Squarespace, Webflow, Shopify, Weebly.</Text>
         </Box>
       )}
 
       {/* Unknown platform warning */}
       {phase === 'done' && detection?.platform === 'unknown' && (
         <Box marginTop={1}>
-          <Text color="yellow">! Supported platforms: Wix, Squarespace, Webflow, Shopify</Text>
+          <Text color="yellow">! Supported platforms: Wix, Squarespace, Webflow, Shopify, Weebly</Text>
         </Box>
       )}
 


### PR DESCRIPTION
The core of this work was done by @pmaiorana in #20 with some tweaks by me (specified after the break)

Add Weebly as the fifth supported platform for content extraction.

The adapter follows the established fetch-and-scrape pattern:
- Detection via weebly.com URL patterns and editmysite.com/wsite-
  markers in page source
- Discovery via sitemap + Weebly menu structure navigation extraction
- Content extraction from #wsite-content with relative URL resolution
  to absolute (required for WordPress media import URL matching)
- Product extraction from HTML (title, price, description, images)
  with WooCommerce CSV output
- Blog post classification for /blog/ URL paths
- HTTP error handling (non-200 responses logged as failures)

Tested against two live Weebly sites:
- E-commerce site (backwoodsbeersoap.com): pages, products, blog, media
- Content site (aksushiya.com): pages with image galleries

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

--

I added a couple of fixes on top of this work:

1. Stronger platform detection to move from medium confidence to high confidence
2. Improved CDN url handling for media files to reduce the chance of faulty URLs.
3. Constrain datetime detection for posts to the content area so we don't accidentally grab dates form footers
4. Updated the docs