### PR TITLE
build(deps): auto-install chromium on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "qa": "tsx src/cli.ts qa",
     "verify": "tsx src/cli.ts verify",
     "setup": "tsx src/cli.ts setup",
-    "liberate": "tsx src/cli.ts"
+    "liberate": "tsx src/cli.ts",
+    "postinstall": "playwright install chromium"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- Adds a `postinstall` script that runs `playwright install chromium` so the browser binary is fetched automatically after `npm install`.
- Removes the manual `npx playwright install chromium` step adapters previously required.

## Test plan
- [ ] Fresh clone + `npm install` pulls chromium automatically
- [ ] Playwright-backed adapters (Squarespace, shared CDP probes) run without a separate install step