### PR TITLE
fix(ui/import): crash in done view when iterating stages without results

### DIFF
--- a/src/ui/import.tsx
+++ b/src/ui/import.tsx
@@ -26,6 +26,10 @@ interface StageProgress {
 
 const STAGES = ['categories', 'tags', 'terms', 'media', 'pages', 'posts', 'comments', 'menus', 'products', 'variations'] as const;
 
+// Stages that appear in the final ImportResult. `variations` is reported via
+// progress callback only — Woo variations roll up under the `products` stage.
+const RESULT_STAGES = ['categories', 'tags', 'terms', 'media', 'pages', 'posts', 'comments', 'menus', 'products'] as const;
+
 function stageColor(current: number, total: number): string {
   if (total === 0) return 'gray';
   if (current === total) return 'green';
@@ -123,9 +127,9 @@ function Import(props: ImportProps) {
             <Text> Import complete{dryRun ? ' (dry run)' : ''}</Text>
           </Box>
           <Box flexDirection="column" marginLeft={2} marginTop={1}>
-            {STAGES.map((stage) => {
+            {RESULT_STAGES.map((stage) => {
               const s = result[stage];
-              if (s.total === 0) return null;
+              if (!s || s.total === 0) return null;
               return (
                 <Box key={stage}>
                   <Text>


### PR DESCRIPTION
## Summary
- The done view in `src/ui/import.tsx` crashed with `Cannot read properties of undefined (reading 'total')` after a successful import.
- `STAGES` includes `variations` for progress reporting, but WooCommerce variations roll up under the `products` stage in `ImportResult` — there's no `result.variations` key, so `result['variations'].total` threw.

## Fix
- Split the list: `STAGES` stays as-is for the in-progress view (which already guards with `if (!s) return null`), and a new `RESULT_STAGES` constant — the subset that actually appears in `ImportResult` — drives the done view.
- Added a defensive `!s ||` guard so any future shape drift fails closed instead of crashing the UI.

## Test plan
- [x] Run \`npx tsc --noEmit\` — passes cleanly (previously errored at \`src/ui/import.tsx:127\`).
- [ ] Run a full import end-to-end and confirm the done screen renders the per-stage summary without crashing.
- [ ] Dry-run import (\`--dry-run\`) should also render the done view correctly.