### PR TITLE
fix: use ${CLAUDE_PLUGIN_ROOT} in .mcp.json so plugin loads from any cwd

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,8 @@
   "mcpServers": {
     "data-liberation": {
       "command": "npx",
-      "args": ["tsx", "src/mcp-server.ts"]
+      "args": ["tsx", "${CLAUDE_PLUGIN_ROOT}/src/mcp-server.ts"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT}"
     }
   }
 }


### PR DESCRIPTION
## What this changes

`.mcp.json` now uses `${CLAUDE_PLUGIN_ROOT}` substitution and sets `cwd`, so Claude Code can spawn the DLA MCP server from any session cwd — not only from inside the plugin install directory. Mirrors the pattern `gemini-extension.json` already uses (`${extensionPath}`).

## How I found it

Running the agent-PR contribution loop from CONTRIBUTING.md on a fresh Claude Code session during the Automattic A4A team's DLA test rollout. `claude plugin install data-liberation`, restart, ask the agent for `liberate_*` tools — none appeared. MCP log:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'/Users/<me>/<some-other-dir>/src/mcp-server.ts'
```

Claude Code spawns the MCP server from the user's session cwd, not the plugin install dir, so the relative path `src/mcp-server.ts` can't resolve. Claude Code's docs explicitly call this out under "MCP server fails — Missing `${CLAUDE_PLUGIN_ROOT}`" (https://code.claude.com/docs/en/plugins-reference).

Reproduced both failure (from `/tmp`) and success (with the patched config, from any cwd) locally.

## Tested against

- [x] Local reproduction — server fails to start with current main from an unrelated cwd, starts successfully with this change from the same cwd
- [x] Plugin loads in Claude Code and `liberate_*` tools appear
- [x] `npx vitest run` — no new failures introduced (4 pre-existing failures in `test/content-differ.test.ts` are on `main` and unrelated to this change)

## Note on CONTRIBUTING.md

Filing as `fix:` rather than `discovery:` and without a DISCOVERIES.md entry — this is a plugin-manifest bug, not a platform-extraction finding, so adding a DISCOVERIES entry seemed more likely to pollute that file than help future contributors. Happy to add one if you'd prefer.