### PR TITLE
feat: add --limit flag for capped extractions with full WXR output 

### DIFF
--- a/src/adapters/hostinger.ts
+++ b/src/adapters/hostinger.ts
@@ -394,6 +394,7 @@ export const hostingerAdapter: PlatformAdapter = {
       dryRun: !!hoOpts.dryRun,
       resume: !!hoOpts.resume,
       verbose: hoOpts.verbose,
+      limit: hoOpts.limit,
       server: context.server,
       csvBuilder,
       extractPage: async (url: string) => {

--- a/src/adapters/hubspot.ts
+++ b/src/adapters/hubspot.ts
@@ -655,6 +655,7 @@ export const hubspotAdapter: PlatformAdapter = {
       dryRun: !!hsOpts.dryRun,
       resume: !!hsOpts.resume,
       verbose: hsOpts.verbose,
+      limit: hsOpts.limit,
       server: context.server,
       csvBuilder,
       extractPage: async (url: string) => {

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -226,6 +226,13 @@ export interface ExtractionLoopOpts {
   extractPage: (url: string) => Promise<ExtractedPage>;
   /** Optional platform-specific product extractor — called before the generic JSON-LD fallback */
   extractProduct?: (url: string, html: string) => WooProduct | null;
+  /**
+   * Cap the number of URLs to process. Useful for sampling a real extraction
+   * (with full WXR output) without committing to the entire site. When unset,
+   * processes all URLs in the inventory. Takes precedence over dryRun's
+   * implicit 3-URL cap.
+   */
+  limit?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -253,6 +260,7 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     csvBuilder,
     extractPage,
     extractProduct,
+    limit,
   } = opts;
 
   const mediaDir = outputDir ? `${outputDir}/media` : null;
@@ -303,8 +311,11 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     alreadyProcessed = processed.size;
     urls = urls.filter((u) => !processed.has(u));
   }
-  if (dryRun) {
-    urls = urls.slice(0, 3);
+  // Apply URL cap. Explicit `limit` wins over dryRun's implicit 3-URL cap so
+  // a `--limit N` (with or without --dry-run) processes exactly N URLs.
+  const effectiveLimit = limit ?? (dryRun ? 3 : undefined);
+  if (effectiveLimit !== undefined && effectiveLimit >= 0) {
+    urls = urls.slice(0, effectiveLimit);
   }
 
   if (urls.length === 0) {

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -347,7 +347,7 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     const url = urls[i];
     const startMs = Date.now();
 
-    sendLog(`[${alreadyProcessed + i + 1}/${totalUrls}] Extracting: ${url}`);
+    sendLog(`[${alreadyProcessed + i + 1}/${alreadyProcessed + urls.length}] Extracting: ${url}`);
 
     try {
       const pageData = await extractPage(url);

--- a/src/adapters/shopify.ts
+++ b/src/adapters/shopify.ts
@@ -19,6 +19,7 @@ export interface ShopifyAdapterOpts extends Record<string, unknown> {
   verbose?: boolean;
   outputDir?: string;
   cdpPort?: number;
+  limit?: number;
 }
 
 export interface ShopifyInventory {
@@ -706,6 +707,7 @@ export const shopifyAdapter: PlatformAdapter = {
       dryRun: !!shopifyOpts.dryRun,
       resume: !!shopifyOpts.resume,
       verbose: shopifyOpts.verbose,
+      limit: shopifyOpts.limit,
       server: context.server,
       csvBuilder,
       extractPage: async (url: string) => {

--- a/src/adapters/squarespace.ts
+++ b/src/adapters/squarespace.ts
@@ -19,6 +19,7 @@ export interface SquarespaceAdapterOpts extends Record<string, unknown> {
   dryRun?: boolean;
   verbose?: boolean;
   outputDir?: string;
+  limit?: number;
 }
 
 export interface SquarespaceInventory {
@@ -709,6 +710,7 @@ export const squarespaceAdapter: PlatformAdapter = {
         dryRun: !!sqOpts.dryRun,
         resume: !!sqOpts.resume,
         verbose: sqOpts.verbose,
+        limit: sqOpts.limit,
         server: context.server,
         csvBuilder,
         extractPage: async (url: string) => {

--- a/src/adapters/webflow.ts
+++ b/src/adapters/webflow.ts
@@ -17,6 +17,7 @@ export interface WebflowAdapterOpts extends Record<string, unknown> {
   dryRun?: boolean;
   verbose?: boolean;
   outputDir?: string;
+  limit?: number;
 }
 
 export interface WebflowInventory {
@@ -242,6 +243,7 @@ export const webflowAdapter: PlatformAdapter = {
       dryRun: !!wfOpts.dryRun,
       resume: !!wfOpts.resume,
       verbose: wfOpts.verbose,
+      limit: wfOpts.limit,
       server: context.server,
       csvBuilder,
       extractPage: async (url: string) => {

--- a/src/adapters/weebly.ts
+++ b/src/adapters/weebly.ts
@@ -494,6 +494,7 @@ export const weeblyAdapter: PlatformAdapter = {
       dryRun: !!wbOpts.dryRun,
       resume: !!wbOpts.resume,
       verbose: wbOpts.verbose,
+      limit: wbOpts.limit,
       server: context.server,
       csvBuilder,
       extractPage: async (url: string) => {

--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -29,6 +29,7 @@ export interface WixAdapterOpts extends Record<string, unknown> {
   dryRun?: boolean;
   verbose?: boolean;
   outputDir?: string;
+  limit?: number;
 }
 
 export interface Inventory {
@@ -723,6 +724,7 @@ export const wixAdapter: PlatformAdapter = {
         dryRun: !!wixOpts.dryRun,
         resume: !!wixOpts.resume,
         verbose: wixOpts.verbose,
+        limit: wixOpts.limit,
         server: context.server,
         csvBuilder,
         extractPage: async (url: string) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ if (args[0] === 'mcp') {
   Extract options:
     --output <dir>    Output directory (default: ./output)
     --dry-run         Extract 2-3 pages and report without writing WXR
+    --limit <N>       Cap extraction to the first N URLs (writes a real WXR)
     --resume          Resume a previous extraction
     --token <token>   API token for platforms requiring auth
     --delay <ms>      Delay between requests (default: 500)
@@ -138,10 +139,12 @@ if (args[0] === 'mcp') {
   const verbose = args.includes('--verbose');
   const rawDelay = getArg('--delay') ? parseInt(getArg('--delay')!, 10) : 500;
   const delay = Number.isNaN(rawDelay) ? 500 : rawDelay;
+  const rawLimit = getArg('--limit') ? parseInt(getArg('--limit')!, 10) : null;
+  const limit = rawLimit !== null && !Number.isNaN(rawLimit) ? rawLimit : null;
   const token = getArg('--token') || process.env.LIBERATION_TOKEN || null;
   const cdpPort = getArg('--cdp-port') ? parseInt(getArg('--cdp-port')!, 10) : null;
   const nonInteractive = args.includes('--non-interactive');
 
   const { runDiscover } = await import('./ui/discover.js');
-  runDiscover(url, { outputDir, dryRun, resume, verbose, delay, token, cdpPort, nonInteractive });
+  runDiscover(url, { outputDir, dryRun, resume, verbose, delay, limit, token, cdpPort, nonInteractive });
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -93,6 +93,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
           delay: { type: 'number', description: 'Delay between requests in ms (default: 500)' },
           resume: { type: 'boolean', description: 'Resume a previous extraction' },
           dryRun: { type: 'boolean', description: 'Extract 2-3 pages and report without writing WXR' },
+          limit: { type: 'number', description: 'Cap extraction to the first N URLs and write a real WXR for them' },
           verbose: { type: 'boolean', description: 'Enable detailed per-page logging' },
         },
         required: ['url', 'outputDir'],
@@ -303,6 +304,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           delay: typedArgs.delay,
           resume: typedArgs.resume,
           dryRun: typedArgs.dryRun,
+          limit: typedArgs.limit,
           verbose: typedArgs.verbose,
           outputDir,
         };

--- a/src/ui/discover.tsx
+++ b/src/ui/discover.tsx
@@ -42,6 +42,8 @@ export interface LiberateProps {
   token: string | null;
   cdpPort: number | null;
   nonInteractive: boolean;
+  /** Cap extraction at the first N URLs (writes a real WXR for those N). */
+  limit: number | null;
 }
 
 type Phase =
@@ -75,7 +77,7 @@ function findAdapter(platform: string) {
 
 
 function Liberate(props: LiberateProps & { onComplete?: (wxrPath: string | null) => void }) {
-  const { url, outputDir, dryRun, resume, delay, verbose, token, cdpPort, onComplete } = props;
+  const { url, outputDir, dryRun, resume, delay, verbose, token, cdpPort, limit, onComplete } = props;
   const app = useApp();
   const [phase, setPhase] = useState<Phase>('detecting');
   const [detection, setDetection] = useState<FullDetectionResult | null>(null);
@@ -147,6 +149,7 @@ function Liberate(props: LiberateProps & { onComplete?: (wxrPath: string | null)
           token: token ?? undefined,
           delay,
           verbose,
+          limit: limit ?? undefined,
         };
         const inv = await adapter.discover(url, opts) as Inventory;
         setInventory(inv);
@@ -172,8 +175,11 @@ function Liberate(props: LiberateProps & { onComplete?: (wxrPath: string | null)
             language: inv.siteMeta?.language || 'en-US',
           });
 
-          // Set up a fake server context that captures progress for the UI
-          const total = dryRun ? Math.min(3, inv.urls.length) : inv.urls.length;
+          // Set up a fake server context that captures progress for the UI.
+          // Effective cap mirrors shared.ts: explicit `limit` wins over
+          // dryRun's implicit 3-URL cap; otherwise process all inventory URLs.
+          const cap = limit ?? (dryRun ? 3 : inv.urls.length);
+          const total = Math.min(cap, inv.urls.length);
           setProgress({ current: 0, total, currentUrl: '' });
           let progressCount = 0;
 
@@ -408,6 +414,7 @@ export function runDiscover(url: string, opts: Partial<LiberateProps> = {}): voi
     token: opts.token || null,
     cdpPort: opts.cdpPort || null,
     nonInteractive: opts.nonInteractive || false,
+    limit: opts.limit ?? null,
   };
   const { waitUntilExit } = render(
     <Liberate {...props} onComplete={(path) => { wxrPath = path; }} />,


### PR DESCRIPTION
This is an edited version of #24 that adds the `--limit` argument to a couple of other providers as well as constraining the count of the total number of pages to just the limit in the progress output.

Here's the original PR description:

`--dry-run` extracts only 2-3 URLs and skips WXR generation entirely,
which is useful for quick smoke-tests but offers no path to sample a
real extraction without committing to the full site. Adapter authors
iterating on a new platform end up either running full extractions
(slow, especially with media) or working blind from dry-run summaries.

Add `--limit N` as an independent flag that caps the URL count and
writes a real WXR + media for those N URLs. Useful for:

- Iterating on adapter changes against a manageable sample (e.g.
  `--limit 10` instead of 200+ URL sites)
- Spot-checking content quality before committing to a full extract
- Test-importing a small batch into WordPress to validate behavior

Precedence:
- `--limit N` alone → process N URLs, write full output
- `--dry-run` alone → unchanged (3 URLs, no output, console summary)
- `--limit N --dry-run` → process N URLs, suppress output (sample run)

Implementation:
- Add `limit?: number` to `ExtractionLoopOpts` in `shared.ts`
- Replace hardcoded `urls.slice(0, 3)` with explicit limit that wins
  over dryRun's implicit 3
- Add `limit?: number` to all four adapter opts (wix, squarespace,
  webflow, shopify) and pass through to runExtractionLoop
- Add `--limit <N>` CLI flag in `cli.ts`
- Wire through `LiberateProps` and progress-display total in
  `ui/discover.tsx`
- Add `limit` to the MCP `liberate_extract` input schema

Verified end-to-end against franklygoodcoffee.com:
- `--limit 5` processed exactly 5 URLs and wrote a 1.4MB WXR
- `--dry-run` unchanged: 3 URLs, no WXR