### PR TITLE
fix: content-differ compares in wrong direction

### DIFF
--- a/src/lib/qa/content-differ.ts
+++ b/src/lib/qa/content-differ.ts
@@ -33,43 +33,43 @@ export function diffContent(origin: ContentModel, wxr: ContentModel, postTitle?:
     ? origin.headings.filter((h) => !(h.level === 1 && normalize(h.text) === normalize(postTitle)))
     : origin.headings;
 
-  // Headings: check that WXR headings exist in the origin (containment direction)
-  const originHeadingSet = new Set(originHeadings.map((h) => `${h.level}:${normalize(h.text)}`));
-  const missingHeadings = wxr.headings.filter(
-    (wh) => !originHeadingSet.has(`${wh.level}:${normalize(wh.text)}`),
+  // Headings: find origin headings missing from WXR (coverage direction)
+  const wxrHeadingSet = new Set(wxr.headings.map((h) => `${h.level}:${normalize(h.text)}`));
+  const missingHeadings = originHeadings.filter(
+    (oh) => !wxrHeadingSet.has(`${oh.level}:${normalize(oh.text)}`),
   );
 
-  // Images: check that WXR images exist in the origin (containment direction)
-  const originFilenames = new Set(origin.images.map((img) => extractFilename(img.src)));
-  const missingImages = wxr.images.filter(
-    (img) => !originFilenames.has(extractFilename(img.src)),
+  // Images: find origin images missing from WXR (coverage direction)
+  const wxrFilenames = new Set(wxr.images.map((img) => extractFilename(img.src)));
+  const missingImages = origin.images.filter(
+    (img) => !wxrFilenames.has(extractFilename(img.src)),
   );
 
-  // Links: check that WXR links exist in the origin (containment direction)
-  const originHrefs = new Set(origin.links.map((l) => l.href));
-  const missingLinks = wxr.links.filter((l) => !originHrefs.has(l.href));
+  // Links: find origin links missing from WXR (coverage direction)
+  const wxrHrefs = new Set(wxr.links.map((l) => l.href));
+  const missingLinks = origin.links.filter((l) => !wxrHrefs.has(l.href));
 
   const headingsMatch = {
     origin: originHeadings.length,
     wxr: wxr.headings.length,
-    missing: missingHeadings.length, // WXR headings NOT found in origin
+    missing: missingHeadings.length, // origin headings NOT found in WXR
   };
   const imagesMatch = {
     origin: origin.images.length,
     wxr: wxr.images.length,
-    missing: missingImages.length, // WXR images NOT found in origin
+    missing: missingImages.length, // origin images NOT found in WXR
   };
   const linksMatch = {
     origin: origin.links.length,
     wxr: wxr.links.length,
-    missing: missingLinks.length, // WXR links NOT found in origin
+    missing: missingLinks.length, // origin links NOT found in WXR
   };
 
   // Grade: weighted score — text 50%, headings 20%, images 20%, links 10%
-  // Scores measure containment: what fraction of WXR content is verified in origin
-  const headingsScore = wxr.headings.length === 0 ? 1 : 1 - missingHeadings.length / wxr.headings.length;
-  const imagesScore = wxr.images.length === 0 ? 1 : 1 - missingImages.length / wxr.images.length;
-  const linksScore = wxr.links.length === 0 ? 1 : 1 - missingLinks.length / wxr.links.length;
+  // Scores measure coverage: what fraction of origin elements were extracted
+  const headingsScore = originHeadings.length === 0 ? 1 : 1 - missingHeadings.length / originHeadings.length;
+  const imagesScore = origin.images.length === 0 ? 1 : 1 - missingImages.length / origin.images.length;
+  const linksScore = origin.links.length === 0 ? 1 : 1 - missingLinks.length / origin.links.length;
 
   const overall = isEmpty
     ? 1


### PR DESCRIPTION
## What this changes
Fixes diffContent() to compare in the coverage direction (origin
elements missing from WXR) instead of containment direction (WXR
elements not in origin). The QA runner can now correctly detect
missing images, headings, and links in extractions.

## How I found it
4 tests in content-differ.test.ts have been failing on main. The tests
expect coverage-direction comparison ("what did we miss from the
origin?") but the implementation checked containment ("is what we
extracted real?"). Flipped the comparison and grade scoring to match.

## Tested against
- [x] Tests pass — 242/242, including the 4 previously failing tests
- [x] No regressions

Filing as `fix:` rather than `discovery:` and without a DISCOVERIES.md
entry — this is a QA tooling bug, not a platform-extraction finding,
so adding a DISCOVERIES entry seemed more likely to pollute that file
than help future contributors. Happy to add one if you'd prefer.