### PR TITLE
feat(extraction): add AIMD adaptive tuner and concurrent page fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .DS_Store
 *.log
 dist/
+docs/superpowers/
 qa-screenshots/
 .claude/
 .liberation-lock

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -7,6 +7,8 @@ import { classifyUrl } from '../lib/extraction/sitemap.js';
 import { downloadMedia } from '../lib/extraction/media.js';
 import { MediaStubStore } from '../lib/extraction/media-stubs.js';
 import type { WooProductCsvBuilder, WooProduct } from '../lib/import/woo-product-csv.js';
+import { AdaptiveTuner, TUNER_DEFAULTS } from '../lib/extraction/adaptive-tuner.js';
+import type { AdaptiveTunerConfig, TunerState } from '../lib/extraction/adaptive-tuner.js';
 
 // ---------------------------------------------------------------------------
 // Strip non-content tags from HTML
@@ -242,6 +244,8 @@ export interface ExtractionLoopOpts {
    * implicit 3-URL cap.
    */
   limit?: number;
+  /** Optional per-adapter tuner configuration overrides */
+  tunerConfig?: AdaptiveTunerConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -271,6 +275,7 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     extractPage,
     extractProduct,
     limit,
+    tunerConfig,
   } = opts;
 
   // Seed discovered counts from the inventory so the session reflects
@@ -283,6 +288,9 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     session.setDiscovered(discoveredByType);
     session.setStage('extracting');
   }
+
+  const savedTunerState = session?.getCursor<TunerState>('adaptive-tuner');
+  const tuner = new AdaptiveTuner({ pageDelayStart: delay, config: tunerConfig }, savedTunerState);
 
   const mediaDir = outputDir ? `${outputDir}/media` : null;
 
@@ -363,19 +371,87 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     }
   };
 
-  for (let i = 0; i < urls.length; i++) {
-    const url = urls[i];
-    const startMs = Date.now();
+  interface FetchResult {
+    url: string;
+    pageData: ExtractedPage | null;
+    elapsedMs: number;
+    error: string | null;
+  }
 
-    sendLog(`[${alreadyProcessed + i + 1}/${alreadyProcessed + urls.length}] Extracting: ${url}`);
+  let cursor = 0;
+  while (cursor < urls.length) {
+    const batchSize = tuner.getPageConcurrency();
+    const batch = urls.slice(cursor, cursor + batchSize);
 
-    try {
-      const pageData = await extractPage(url);
+    // Phase 1: Log what we're about to fetch
+    for (let j = 0; j < batch.length; j++) {
+      sendLog(`[${alreadyProcessed + cursor + j + 1}/${alreadyProcessed + urls.length}] Extracting: ${batch[j]}`);
+    }
 
-      // Download media for this page concurrently (up to 6 at a time)
+    // Phase 2: Concurrent page fetches
+    const fetchResults: FetchResult[] = await Promise.all(
+      batch.map(async (url): Promise<FetchResult> => {
+        const pageStart = Date.now();
+        try {
+          const pageData = await extractPage(url);
+          return { url, pageData, elapsedMs: Date.now() - pageStart, error: null };
+        } catch (err) {
+          return { url, pageData: null, elapsedMs: Date.now() - pageStart, error: err instanceof Error ? err.message : String(err) };
+        }
+      })
+    );
+
+    // Phase 3: Feed timing to tuner — treat batch errors as a single
+    // compound event to avoid multiplicative backoff (N errors in one
+    // batch would otherwise multiply the delay by 2^N).
+    const batchHasErrors = fetchResults.some((r) => r.error);
+    if (batchHasErrors) {
+      tuner.recordPageError();
+      if (verbose) {
+        const errorCount = fetchResults.filter((r) => r.error).length;
+        sendLog(`  [tuner] page delay: → ${tuner.getPageDelay()}ms (error backoff — ${errorCount}/${fetchResults.length} failed)`);
+      }
+    }
+    for (const result of fetchResults) {
+      if (!result.error) {
+        const pageElapsed = result.elapsedMs / 1000;
+        const pageDecision = tuner.recordPageResult({ elapsed: pageElapsed });
+        if (verbose && tuner.lastDebug) {
+          const d = tuner.lastDebug;
+          sendLog(`  [tuner:debug] page: elapsed=${d.elapsed.toFixed(2)}s throughput=${d.throughput.toFixed(2)} ema=${d.ema?.toFixed(2) ?? 'null'} ratio=${d.ratio?.toFixed(2) ?? 'n/a'} → ${d.decision}`);
+        }
+        if (verbose && (pageDecision === 'increase' || pageDecision === 'decrease')) {
+          sendLog(`  [tuner] page delay: → ${tuner.getPageDelay()}ms (${pageDecision})`);
+        }
+      }
+    }
+
+    // Phase 4: Process each page sequentially (media, WXR, logging)
+    for (let j = 0; j < fetchResults.length; j++) {
+      const { url, pageData, error: fetchError } = fetchResults[j];
+      const i = cursor + j; // running index for checkpoints
+      const startMs = Date.now();
+
+      if (fetchError || !pageData) {
+        failed++;
+        const errorMsg = fetchError || 'Unknown error';
+        log.logFailed({ url, error: errorMsg });
+        sendLog(`  FAILED: ${errorMsg}`);
+
+        if (session) {
+          const invEntry = inventoryUrls.find((u) => u.url === url);
+          const failType = invEntry?.type || classifyUrl(url);
+          const bumpType = failType === 'product' ? 'product' : (failType === 'post' || failType === 'blog-post') ? 'post' : 'page';
+          session.bumpProgress(bumpType, 'failed');
+          session.save();
+        }
+        continue;
+      }
+
+      // Download media for this page concurrently
       let featuredMediaId: number | undefined;
       if (!dryRun && mediaDir) {
-        const MEDIA_CONCURRENCY = 6;
+        const mediaConcurrency = tuner.getMediaConcurrency();
 
         // Filter to new URLs and mark them as seen immediately to prevent
         // duplicates from other pages queueing the same URL
@@ -412,13 +488,40 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
           newMediaUrls.push(mediaUrl);
         }
 
-        // Download in batches of MEDIA_CONCURRENCY
-        for (let batch = 0; batch < newMediaUrls.length; batch += MEDIA_CONCURRENCY) {
-          const chunk = newMediaUrls.slice(batch, batch + MEDIA_CONCURRENCY);
+        // Download media in batches
+        for (let mBatch = 0; mBatch < newMediaUrls.length; mBatch += mediaConcurrency) {
+          const chunk = newMediaUrls.slice(mBatch, mBatch + mediaConcurrency);
+          const mediaBatchStart = Date.now();
           const results = await Promise.all(
             chunk.map((mediaUrl) => downloadMedia(mediaUrl, mediaDir, seenMediaNames, seenMediaHashes)
               .then((r) => ({ mediaUrl, ...r })))
           );
+          const mediaBatchElapsed = (Date.now() - mediaBatchStart) / 1000;
+          // Exclude deduped files (bytes=0, no error) from throughput — they
+          // resolve instantly from the hash cache and would skew the EMA.
+          const mediaBatchBytes = results.reduce((sum, r) => sum + (r.bytes ?? 0), 0);
+          const mediaBatchErrors = results.filter((r) => r.error).length;
+          const mediaBatchActualDownloads = results.filter((r) => !r.error && (r.bytes ?? 0) > 0).length;
+          if (
+            mediaBatchErrors >= TUNER_DEFAULTS.mediaErrorMinCount &&
+            mediaBatchErrors > chunk.length * TUNER_DEFAULTS.mediaErrorRatio
+          ) {
+            tuner.recordMediaError();
+            if (verbose) {
+              sendLog(`  [tuner] media concurrency: → ${tuner.getMediaConcurrency()} (error — ${mediaBatchErrors}/${chunk.length} failed)`);
+            }
+          } else if (mediaBatchActualDownloads > 0) {
+            // Only feed throughput when real downloads occurred — skip
+            // all-dedup batches to avoid skewing the EMA with instant results.
+            const mediaDecision = tuner.recordMediaResult({ elapsed: mediaBatchElapsed, bytesDownloaded: mediaBatchBytes });
+            if (verbose && tuner.lastDebug) {
+              const d = tuner.lastDebug;
+              sendLog(`  [tuner:debug] media: elapsed=${d.elapsed.toFixed(2)}s bytes=${d.workDone} throughput=${d.throughput.toFixed(0)} ema=${d.ema?.toFixed(0) ?? 'null'} ratio=${d.ratio?.toFixed(2) ?? 'n/a'} → ${d.decision}`);
+            }
+            if (verbose && (mediaDecision === 'increase' || mediaDecision === 'decrease')) {
+              sendLog(`  [tuner] media concurrency: → ${tuner.getMediaConcurrency()} (${mediaDecision})`);
+            }
+          }
 
           // Process results sequentially — WXR builder and log are not concurrent-safe
           for (const result of results) {
@@ -553,6 +656,7 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
         const bumpType = isProduct ? 'product' : isPost ? 'post' : 'page';
         session.bumpProgress(bumpType, 'extracted');
         if ((i + 1) % 10 === 0) {
+          session.setCursor('adaptive-tuner', tuner.getState());
           session.save();
           mediaStubs?.flush();
         }
@@ -563,26 +667,22 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
           `  media: ${pageData.mediaUrls.length}, quality: ${pageData.qualityScore}, ${durationMs}ms`
         );
       }
-    } catch (err) {
-      failed++;
-      const errorMsg = err instanceof Error ? err.message : String(err);
-      log.logFailed({ url, error: errorMsg });
-      sendLog(`  FAILED: ${errorMsg}`);
-
-      if (session) {
-        const invEntry = inventoryUrls.find((u) => u.url === url);
-        const failType = invEntry?.type || classifyUrl(url);
-        const bumpType = failType === 'product' ? 'product' : (failType === 'post' || failType === 'blog-post') ? 'post' : 'page';
-        session.bumpProgress(bumpType, 'failed');
-        // Failures are rare — persist each one so resume reports are accurate
-        session.save();
-      }
     }
 
-    // Delay between pages (skip after last)
-    if (i < urls.length - 1 && delay > 0) {
-      await sleep(delay);
+    // Persist tuner state after each batch so short runs and crashes
+    // don't lose learned pacing. The every-10-items checkpoint inside
+    // Phase 4 covers long runs; this covers the tail.
+    if (session) {
+      session.setCursor('adaptive-tuner', tuner.getState());
     }
+
+    // Delay once per batch (skip after last batch)
+    const currentDelay = tuner.getPageDelay();
+    if (cursor + batch.length < urls.length && currentDelay > 0) {
+      await sleep(currentDelay);
+    }
+
+    cursor += batch.length;
   }
 
   // Add navigation as menu items
@@ -603,6 +703,8 @@ export async function runExtractionLoop(opts: ExtractionLoopOpts): Promise<{
     session.setStage('finalizing');
   }
   mediaStubs?.flush();
+
+  sendLog(`[tuner] Final state: page delay=${tuner.getPageDelay()}ms, media concurrency=${tuner.getMediaConcurrency()}`);
 
   return {
     pagesExtracted,

--- a/src/lib/extraction/adaptive-tuner.test.ts
+++ b/src/lib/extraction/adaptive-tuner.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from 'vitest';
+import { AdaptiveTuner } from './adaptive-tuner.js';
+
+describe('AdaptiveTuner', () => {
+  describe('constructor and getters', () => {
+    it('uses default delay and concurrency when no saved state', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      expect(tuner.getPageDelay()).toBe(500);
+      expect(tuner.getMediaConcurrency()).toBe(6);
+    });
+
+    it('uses pageDelayStart as the initial delay', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 1000 });
+      expect(tuner.getPageDelay()).toBe(1000);
+    });
+
+    it('restores from valid saved state', () => {
+      const saved = {
+        page: { currentValue: 200, throughputEma: 3.5, errorBackoffRemaining: 0 },
+        media: { currentValue: 10, throughputEma: 5000, errorBackoffRemaining: 1 },
+      };
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 }, saved);
+      expect(tuner.getPageDelay()).toBe(200);
+      expect(tuner.getMediaConcurrency()).toBe(10);
+    });
+
+    it('clamps restored values to valid ranges', () => {
+      const saved = {
+        page: { currentValue: 1, throughputEma: 3.5, errorBackoffRemaining: 0 },
+        media: { currentValue: 99, throughputEma: 5000, errorBackoffRemaining: 0 },
+      };
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 }, saved);
+      expect(tuner.getPageDelay()).toBe(50);
+      expect(tuner.getMediaConcurrency()).toBe(12);
+    });
+
+    it('falls back to defaults for NaN/Infinity in saved state', () => {
+      const saved = {
+        page: { currentValue: NaN, throughputEma: Infinity, errorBackoffRemaining: -1 },
+        media: { currentValue: 'banana' as unknown as number, throughputEma: null, errorBackoffRemaining: 0 },
+      };
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 }, saved);
+      expect(tuner.getPageDelay()).toBe(500);
+      expect(tuner.getMediaConcurrency()).toBe(6);
+    });
+
+    it('resets negative throughputEma to null', () => {
+      const saved = {
+        page: { currentValue: 300, throughputEma: -5, errorBackoffRemaining: 0 },
+        media: { currentValue: 6, throughputEma: 0, errorBackoffRemaining: 0 },
+      };
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 }, saved);
+      const decision = tuner.recordPageResult({ elapsed: 0.5 });
+      expect(decision).toBe('warmup');
+    });
+
+    it('accepts per-adapter config overrides', () => {
+      const tuner = new AdaptiveTuner({
+        pageDelayStart: 500,
+        config: { pageDelayMin: 100, mediaConcurrencyMax: 8 },
+      });
+      expect(tuner.getPageDelay()).toBe(500);
+      expect(tuner.getMediaConcurrency()).toBe(6);
+      for (let i = 0; i < 100; i++) {
+        tuner.recordPageResult({ elapsed: 0.1 });
+      }
+      expect(tuner.getPageDelay()).toBeGreaterThanOrEqual(100);
+    });
+  });
+
+  describe('AIMD — page track', () => {
+    it('returns warmup on first result and seeds EMA without changing delay', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      const initialDelay = tuner.getPageDelay();
+      const decision = tuner.recordPageResult({ elapsed: 0.5 });
+      expect(decision).toBe('warmup');
+      expect(tuner.getPageDelay()).toBe(initialDelay);
+    });
+
+    it('decreases delay on stable throughput (additive increase)', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordPageResult({ elapsed: 0.5 }); // warmup
+      const decision = tuner.recordPageResult({ elapsed: 0.5 });
+      expect(decision).toBe('increase');
+      expect(tuner.getPageDelay()).toBe(450); // 500 - 50
+    });
+
+    it('increases delay on throughput drop (multiplicative decrease)', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 300 });
+      tuner.recordPageResult({ elapsed: 0.1 }); // warmup with fast response
+      const decision = tuner.recordPageResult({ elapsed: 2.0 }); // sudden slowdown
+      expect(decision).toBe('decrease');
+      expect(tuner.getPageDelay()).toBeGreaterThan(300);
+    });
+
+    it('skips EMA update when elapsed is 0', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      const decision = tuner.recordPageResult({ elapsed: 0 });
+      expect(decision).toBe('skip');
+      expect(tuner.getPageDelay()).toBe(500);
+    });
+
+    it('skips EMA update when elapsed is negative', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      const decision = tuner.recordPageResult({ elapsed: -1 });
+      expect(decision).toBe('skip');
+      expect(tuner.getPageDelay()).toBe(500);
+    });
+
+    it('never decreases delay below pageDelayMin', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 100 });
+      tuner.recordPageResult({ elapsed: 0.1 });
+      for (let i = 0; i < 20; i++) {
+        tuner.recordPageResult({ elapsed: 0.1 });
+      }
+      expect(tuner.getPageDelay()).toBe(50);
+    });
+
+    it('never increases delay above pageDelayMax', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 9000 });
+      tuner.recordPageResult({ elapsed: 0.1 }); // warmup fast
+      tuner.recordPageResult({ elapsed: 100 }); // extreme slowdown
+      expect(tuner.getPageDelay()).toBeLessThanOrEqual(10_000);
+    });
+  });
+
+  describe('AIMD — media track', () => {
+    it('returns warmup on first result and seeds EMA without changing concurrency', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      const initial = tuner.getMediaConcurrency();
+      const decision = tuner.recordMediaResult({ elapsed: 1.0, bytesDownloaded: 1_000_000 });
+      expect(decision).toBe('warmup');
+      expect(tuner.getMediaConcurrency()).toBe(initial);
+    });
+
+    it('increases concurrency on stable throughput', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordMediaResult({ elapsed: 1.0, bytesDownloaded: 1_000_000 });
+      const decision = tuner.recordMediaResult({ elapsed: 1.0, bytesDownloaded: 1_000_000 });
+      expect(decision).toBe('increase');
+      expect(tuner.getMediaConcurrency()).toBe(7);
+    });
+
+    it('decreases concurrency on throughput drop', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordMediaResult({ elapsed: 1.0, bytesDownloaded: 10_000_000 });
+      const decision = tuner.recordMediaResult({ elapsed: 10.0, bytesDownloaded: 1_000_000 });
+      expect(decision).toBe('decrease');
+      expect(tuner.getMediaConcurrency()).toBeLessThan(6);
+    });
+
+    it('never drops concurrency below 1', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      for (let i = 0; i < 20; i++) {
+        tuner.recordMediaError();
+      }
+      expect(tuner.getMediaConcurrency()).toBe(1);
+    });
+
+    it('never increases concurrency above max', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordMediaResult({ elapsed: 0.1, bytesDownloaded: 10_000_000 });
+      for (let i = 0; i < 20; i++) {
+        tuner.recordMediaResult({ elapsed: 0.1, bytesDownloaded: 10_000_000 });
+      }
+      expect(tuner.getMediaConcurrency()).toBe(12);
+    });
+  });
+
+  describe('error backoff', () => {
+    it('doubles page delay on error', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordPageError();
+      expect(tuner.getPageDelay()).toBe(1000);
+    });
+
+    it('halves media concurrency on error', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordMediaError();
+      expect(tuner.getMediaConcurrency()).toBe(3);
+    });
+
+    it('suppresses tuning for errorBackoffRequests calls after error', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordPageError(); // delay → 1000, backoff = 3
+      const delayAfterError = tuner.getPageDelay();
+
+      // Next 3 calls should be warmup then error_backoff — no value change
+      for (let i = 0; i < 3; i++) {
+        const decision = tuner.recordPageResult({ elapsed: 0.5 });
+        expect(decision).toBe(i === 0 ? 'warmup' : 'error_backoff');
+      }
+      // 4th call should resume normal tuning
+      const decision = tuner.recordPageResult({ elapsed: 0.5 });
+      expect(decision).toBe('increase');
+      expect(tuner.getPageDelay()).toBeLessThan(delayAfterError);
+    });
+
+    it('resets throughputEma on error (re-warmup)', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordPageResult({ elapsed: 0.5 });
+      tuner.recordPageResult({ elapsed: 0.5 });
+      tuner.recordPageError();
+      const decision = tuner.recordPageResult({ elapsed: 0.5 });
+      expect(decision).toBe('warmup');
+    });
+  });
+
+  describe('track independence', () => {
+    it('page errors do not affect media track', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      const mediaBefore = tuner.getMediaConcurrency();
+      tuner.recordPageError();
+      expect(tuner.getMediaConcurrency()).toBe(mediaBefore);
+      expect(tuner.getPageDelay()).toBe(1000);
+    });
+
+    it('media errors do not affect page track', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      const pageBefore = tuner.getPageDelay();
+      tuner.recordMediaError();
+      expect(tuner.getPageDelay()).toBe(pageBefore);
+      expect(tuner.getMediaConcurrency()).toBe(3);
+    });
+  });
+
+  describe('state round-trip', () => {
+    it('restores exact behavior from saved state', () => {
+      const tuner1 = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner1.recordPageResult({ elapsed: 0.3 });
+      tuner1.recordPageResult({ elapsed: 0.3 });
+      tuner1.recordMediaResult({ elapsed: 1.0, bytesDownloaded: 2_000_000 });
+
+      const state = tuner1.getState();
+      const tuner2 = new AdaptiveTuner({ pageDelayStart: 500 }, state);
+
+      expect(tuner2.getPageDelay()).toBe(tuner1.getPageDelay());
+      expect(tuner2.getMediaConcurrency()).toBe(tuner1.getMediaConcurrency());
+
+      const d1 = tuner1.recordPageResult({ elapsed: 0.3 });
+      const d2 = tuner2.recordPageResult({ elapsed: 0.3 });
+      expect(d2).toBe(d1);
+      expect(tuner2.getPageDelay()).toBe(tuner1.getPageDelay());
+    });
+  });
+
+  describe('oscillation damping', () => {
+    it('consecutive delay changes are gradual, not extreme jumps', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordPageResult({ elapsed: 0.2 }); // warmup
+
+      const delays: number[] = [tuner.getPageDelay()];
+      for (let i = 0; i < 20; i++) {
+        const elapsed = i % 2 === 0 ? 0.1 : 1.0;
+        tuner.recordPageResult({ elapsed });
+        delays.push(tuner.getPageDelay());
+      }
+
+      // Each step-to-step change should be bounded — not jumping from
+      // min to max in a single step. The largest single-step change
+      // should be much less than the full range.
+      let maxStep = 0;
+      for (let i = 1; i < delays.length; i++) {
+        maxStep = Math.max(maxStep, Math.abs(delays[i] - delays[i - 1]));
+      }
+      // Additive increase is 50ms. Multiplicative decrease is ~1.43x.
+      // At pageDelayMax (10000), the largest decrease step would be
+      // 10000 * (1/0.7 - 1) ≈ 4286. Verify steps are sub-5000.
+      expect(maxStep).toBeLessThan(5000);
+    });
+  });
+
+  describe('error recovery', () => {
+    it('resumes normal increase after backoff expires', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      tuner.recordPageResult({ elapsed: 0.5 });
+      tuner.recordPageError();
+      const delayAfterError = tuner.getPageDelay();
+
+      tuner.recordPageResult({ elapsed: 0.5 }); // warmup
+      tuner.recordPageResult({ elapsed: 0.5 }); // error_backoff
+      tuner.recordPageResult({ elapsed: 0.5 }); // error_backoff
+
+      const decision = tuner.recordPageResult({ elapsed: 0.5 });
+      expect(decision).toBe('increase');
+      expect(tuner.getPageDelay()).toBeLessThan(delayAfterError);
+    });
+  });
+
+  describe('getPageConcurrency', () => {
+    it('returns 3 when delay is below 200ms', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 50 });
+      expect(tuner.getPageConcurrency()).toBe(3);
+    });
+
+    it('returns 3 at delay 199ms', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 199 });
+      expect(tuner.getPageConcurrency()).toBe(3);
+    });
+
+    it('returns 2 at delay 200ms', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 200 });
+      expect(tuner.getPageConcurrency()).toBe(2);
+    });
+
+    it('returns 2 at delay 499ms', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 499 });
+      expect(tuner.getPageConcurrency()).toBe(2);
+    });
+
+    it('returns 1 at delay 500ms', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 500 });
+      expect(tuner.getPageConcurrency()).toBe(1);
+    });
+
+    it('returns 1 at high delay (error backoff)', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 5000 });
+      expect(tuner.getPageConcurrency()).toBe(1);
+    });
+
+    it('decreases concurrency when tuner backs off', () => {
+      const tuner = new AdaptiveTuner({ pageDelayStart: 100 });
+      expect(tuner.getPageConcurrency()).toBe(3);
+      tuner.recordPageError(); // 100 → 200
+      expect(tuner.getPageConcurrency()).toBe(2);
+      tuner.recordPageError(); // 200 → 400
+      expect(tuner.getPageConcurrency()).toBe(2);
+      tuner.recordPageError(); // 400 → 800
+      expect(tuner.getPageConcurrency()).toBe(1);
+    });
+  });
+});

--- a/src/lib/extraction/adaptive-tuner.ts
+++ b/src/lib/extraction/adaptive-tuner.ts
@@ -1,0 +1,248 @@
+export interface AdaptiveTunerConfig {
+  pageDelayMin?: number;
+  pageDelayMax?: number;
+  pageDelayIncrease?: number;
+  mediaConcurrencyMin?: number;
+  mediaConcurrencyMax?: number;
+  mediaConcurrencyIncrease?: number;
+}
+
+export interface TunerTrackState {
+  currentValue: number;
+  throughputEma: number | null;
+  errorBackoffRemaining: number;
+}
+
+export interface TunerState {
+  page: TunerTrackState;
+  media: TunerTrackState;
+}
+
+export type TunerDecision = 'warmup' | 'error_backoff' | 'increase' | 'decrease' | 'skip';
+
+const TUNER_DEFAULTS = {
+  throughputEmaAlpha: 0.2,
+  aimdDropRatio: 0.9,
+  aimdDecreaseFactor: 0.7,
+  errorDecreaseFactor: 0.5,
+  errorBackoffRequests: 3,
+
+  pageDelayMin: 50,
+  pageDelayMax: 10_000,
+  pageDelayIncrease: 50,
+
+  mediaConcurrencyMin: 1,
+  mediaConcurrencyMax: 12,
+  mediaConcurrencyIncrease: 1,
+  mediaConcurrencyStart: 6,
+
+  mediaErrorMinCount: 2,
+  mediaErrorRatio: 0.5,
+} as const;
+
+export { TUNER_DEFAULTS };
+
+interface Track {
+  currentValue: number;
+  throughputEma: number | null;
+  errorBackoffRemaining: number;
+  min: number;
+  max: number;
+  additiveIncrease: number;
+  invertDirection: boolean;
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function restoreTrackState(
+  saved: TunerTrackState | undefined,
+  defaultValue: number,
+  min: number,
+  max: number,
+  additiveIncrease: number,
+  invertDirection: boolean,
+): Track {
+  const track: Track = {
+    currentValue: defaultValue,
+    throughputEma: null,
+    errorBackoffRemaining: 0,
+    min,
+    max,
+    additiveIncrease,
+    invertDirection,
+  };
+
+  if (!saved) return track;
+
+  if (isFiniteNumber(saved.currentValue)) {
+    track.currentValue = Math.max(min, Math.min(max, saved.currentValue));
+  }
+  if (saved.throughputEma === null) {
+    track.throughputEma = null;
+  } else if (isFiniteNumber(saved.throughputEma) && saved.throughputEma > 0) {
+    track.throughputEma = saved.throughputEma;
+  }
+
+  if (isFiniteNumber(saved.errorBackoffRemaining)) {
+    track.errorBackoffRemaining = Math.max(
+      0,
+      Math.min(TUNER_DEFAULTS.errorBackoffRequests, Math.floor(saved.errorBackoffRemaining)),
+    );
+  }
+
+  return track;
+}
+
+export class AdaptiveTuner {
+  private page: Track;
+  private media: Track;
+  lastDebug: {
+    track: string;
+    elapsed: number;
+    workDone: number;
+    throughput: number;
+    ema: number | null;
+    ratio: number | null;
+    decision: TunerDecision;
+  } | null = null;
+
+  constructor(
+    opts: { pageDelayStart: number; config?: AdaptiveTunerConfig },
+    savedState?: TunerState,
+  ) {
+    const c = opts.config ?? {};
+    const pageMin = c.pageDelayMin ?? TUNER_DEFAULTS.pageDelayMin;
+    const pageMax = c.pageDelayMax ?? TUNER_DEFAULTS.pageDelayMax;
+    const pageInc = c.pageDelayIncrease ?? TUNER_DEFAULTS.pageDelayIncrease;
+    const mediaMin = c.mediaConcurrencyMin ?? TUNER_DEFAULTS.mediaConcurrencyMin;
+    const mediaMax = c.mediaConcurrencyMax ?? TUNER_DEFAULTS.mediaConcurrencyMax;
+    const mediaInc = c.mediaConcurrencyIncrease ?? TUNER_DEFAULTS.mediaConcurrencyIncrease;
+
+    this.page = restoreTrackState(
+      savedState?.page,
+      opts.pageDelayStart,
+      pageMin,
+      pageMax,
+      pageInc,
+      true,
+    );
+
+    this.media = restoreTrackState(
+      savedState?.media,
+      TUNER_DEFAULTS.mediaConcurrencyStart,
+      mediaMin,
+      mediaMax,
+      mediaInc,
+      false,
+    );
+  }
+
+  getPageDelay(): number {
+    return Math.round(this.page.currentValue);
+  }
+
+  getMediaConcurrency(): number {
+    return Math.round(this.media.currentValue);
+  }
+
+  getPageConcurrency(): number {
+    const delay = this.getPageDelay();
+    if (delay < 200) return 3;
+    if (delay < 500) return 2;
+    return 1;
+  }
+
+  getState(): TunerState {
+    return {
+      page: {
+        currentValue: this.page.currentValue,
+        throughputEma: this.page.throughputEma,
+        errorBackoffRemaining: this.page.errorBackoffRemaining,
+      },
+      media: {
+        currentValue: this.media.currentValue,
+        throughputEma: this.media.throughputEma,
+        errorBackoffRemaining: this.media.errorBackoffRemaining,
+      },
+    };
+  }
+
+  private updateTrack(track: Track, elapsed: number, workDone: number, trackName: string): TunerDecision {
+    if (elapsed <= 0) {
+      this.lastDebug = { track: trackName, elapsed, workDone, throughput: 0, ema: track.throughputEma, ratio: null, decision: 'skip' };
+      return 'skip';
+    }
+
+    const throughput = workDone / elapsed;
+
+    if (track.throughputEma === null) {
+      track.throughputEma = throughput;
+      if (track.errorBackoffRemaining > 0) {
+        track.errorBackoffRemaining--;
+      }
+      this.lastDebug = { track: trackName, elapsed, workDone, throughput, ema: throughput, ratio: null, decision: 'warmup' };
+      return 'warmup';
+    }
+
+    const ratio = throughput / track.throughputEma;
+    track.throughputEma =
+      track.throughputEma * (1 - TUNER_DEFAULTS.throughputEmaAlpha) +
+      throughput * TUNER_DEFAULTS.throughputEmaAlpha;
+
+    if (track.errorBackoffRemaining > 0) {
+      track.errorBackoffRemaining--;
+      this.lastDebug = { track: trackName, elapsed, workDone, throughput, ema: track.throughputEma, ratio, decision: 'error_backoff' };
+      return 'error_backoff';
+    }
+
+    let decision: TunerDecision;
+    if (ratio < TUNER_DEFAULTS.aimdDropRatio) {
+      if (track.invertDirection) {
+        track.currentValue *= 1 / TUNER_DEFAULTS.aimdDecreaseFactor;
+      } else {
+        track.currentValue *= TUNER_DEFAULTS.aimdDecreaseFactor;
+      }
+      decision = 'decrease';
+    } else {
+      if (track.invertDirection) {
+        track.currentValue -= track.additiveIncrease;
+      } else {
+        track.currentValue += track.additiveIncrease;
+      }
+      decision = 'increase';
+    }
+
+    track.currentValue = Math.max(track.min, Math.min(track.max, track.currentValue));
+    this.lastDebug = { track: trackName, elapsed, workDone, throughput, ema: track.throughputEma, ratio, decision };
+    return decision;
+  }
+
+  private applyError(track: Track): void {
+    if (track.invertDirection) {
+      track.currentValue *= 1 / TUNER_DEFAULTS.errorDecreaseFactor;
+    } else {
+      track.currentValue *= TUNER_DEFAULTS.errorDecreaseFactor;
+    }
+    track.currentValue = Math.max(track.min, Math.min(track.max, track.currentValue));
+    track.errorBackoffRemaining = TUNER_DEFAULTS.errorBackoffRequests;
+    track.throughputEma = null;
+  }
+
+  recordPageResult(result: { elapsed: number }): TunerDecision {
+    return this.updateTrack(this.page, result.elapsed, 1, 'page');
+  }
+
+  recordPageError(): void {
+    this.applyError(this.page);
+  }
+
+  recordMediaResult(result: { elapsed: number; bytesDownloaded: number }): TunerDecision {
+    return this.updateTrack(this.media, result.elapsed, result.bytesDownloaded, 'media');
+  }
+
+  recordMediaError(): void {
+    this.applyError(this.media);
+  }
+}

--- a/src/lib/extraction/media.ts
+++ b/src/lib/extraction/media.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, mkdirSync, readFileSync, unlinkSync } from 'fs';
+import { createWriteStream, mkdirSync, readFileSync, statSync, unlinkSync } from 'fs';
 import { createHash } from 'crypto';
 import { basename, extname, join, resolve } from 'path';
 import { pipeline } from 'stream/promises';
@@ -8,6 +8,7 @@ export interface DownloadResult {
   localPath: string | null;
   filename: string | null;
   error: string | null;
+  bytes: number;
 }
 
 export function safeFilename(filename: string, seenNames: Map<string, number>): string {
@@ -116,13 +117,14 @@ export async function downloadMedia(
       if (existing) {
         // Duplicate — remove the new file and return the existing path
         try { unlinkSync(destPath); } catch { /* ignore */ }
-        return { url, localPath: existing, filename: basename(existing), error: null };
+        return { url, localPath: existing, filename: basename(existing), error: null, bytes: 0 };
       }
       seenHashes.set(hash, destPath);
     }
 
-    return { url, localPath: destPath, filename, error: null };
+    const bytes = statSync(destPath).size;
+    return { url, localPath: destPath, filename, error: null, bytes };
   } catch (err) {
-    return { url, localPath: null, filename: null, error: (err as Error).message };
+    return { url, localPath: null, filename: null, error: (err as Error).message, bytes: 0 };
   }
 }


### PR DESCRIPTION
## Summary

Adds an adaptive tuner that dynamically adjusts page extraction delay and media download concurrency based on observed server behavior, plus concurrent page fetching that parallelizes HTML fetches when the server is responsive.

## Why

The extraction loop used fixed request pacing — a hardcoded delay between page fetches and a hardcoded media concurrency of 6. Fast servers were throttled unnecessarily, and struggling servers got no automatic recovery beyond per-URL error handling. Inspired by reprint's battle-tested AdaptiveTuner.

## How

New `AdaptiveTuner` module with two independent AIMD tracks:

- **Page delay track** — starts at the user's `--delay` value, decreases on stable throughput (additive, -50ms), increases on errors or throughput drops (multiplicative, 1.43x). Range: 50ms–10s.
- **Media concurrency track** — starts at 6, increases on stable throughput (+1), decreases on errors or drops (×0.7). Range: 1–12. Error threshold requires ≥2 failures AND >50% of batch.

Both tracks use EMA-based throughput measurement (alpha=0.2) with error backoff (3-request cooldown after errors). State persists via ImportSession cursors for resume support.

The extraction loop now fetches 1–3 pages concurrently based on the tuner's page delay (< 200ms → 3, < 500ms → 2, otherwise 1). Pages are fetched in parallel via Promise.all, then processed sequentially for media downloads, WXR writes, and logging.

Per-adapter tuner profiles are supported via `tunerConfig` in ExtractionLoopOpts. Verbose logging shows tuner decisions and debug internals; final tuner state is always logged at extraction completion.