### PR TITLE
discovery: Wix blog URL classification — /single-post/ and bare /blog

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,33 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-17 — Wix blog URL classification: `/single-post/` and bare `/blog` listings
+
+**Found by:** Claude + human contributor
+**During:** Testing the Wix adapter against a range of live Wix sites
+**Type:** bug fix
+
+### What I found
+
+Two separate URL-classification bugs in `classifyUrl()` in `src/lib/extraction/sitemap.ts`:
+
+1. **Older Wix Blog format** uses `/single-post/<slug>` URLs (distinct from newer `/post/<slug>` or `/blog-1/post/<slug>` patterns the classifier already matched). One sizeable Wix blog encountered during testing had ~1000 blog posts at `/single-post/*` URLs; every single one was written to the WXR as `wp:post_type=page` — the whole blog archive landed in WordPress as pages.
+
+2. **Bare `/blog`, `/news`, `/articles`** were classified as `post` because the regex `/\/(blog|post|posts|...)(\/|$)/` allowed end-of-string after the keyword. These URLs are the blog *listing* pages, not individual posts. They got written to WXR as authorless "posts" with titles like "Our blog" — polluting the post archive. Seen on multiple tested sites where the `/blog` URL was listed in both `pages-sitemap.xml` and `blog-categories-sitemap.xml`.
+
+### How it works
+
+Two changes to the classifier regex:
+
+- Added `if (/\/single-post\//.test(path)) return 'post';` for the older Wix Blog URL pattern.
+- Changed the main blog-keyword regex from `(\/|$)` to `\/[^/]` — require a non-slash character after the keyword's trailing slash. This means `/blog/my-post` still matches (post), but bare `/blog` and `/blog/` now fall through to the `page` default (listing page).
+
+### Why it's better than the previous approach
+
+Tested on the affected sites: blog archives now classify correctly (individual posts as `post`, bare `/blog` as `page`). The existing `classifies blog paths as post` test was updated to remove the now-wrong `/blog → post` expectation, and two unit tests were added covering both new patterns.
+
+---
+
 ## 2026-04-16 — Wix Product JSON-LD uses non-standard casing
 
 **Found by:** Claude + human contributor

--- a/src/lib/extraction/sitemap.ts
+++ b/src/lib/extraction/sitemap.ts
@@ -21,10 +21,13 @@ export function classifyUrl(url: string): UrlType {
 
   if (path === '/' || path === '') return 'homepage';
   // Match /blog/<slug>, /post/<slug>, /blogs/<handle>/<slug>, etc.
-  // Also match Wix patterns like /blog-1/post/<slug>
-  if (/\/(blog|post|posts|article|articles|news|journal)(\/|$)/.test(path)) return 'post';
+  // Also match Wix patterns like /blog-1/post/<slug> and older Wix /single-post/<slug>.
+  // Require a slug segment after the keyword — bare `/blog` is a listing page,
+  // not a blog post, so it should fall through to the `page` default.
+  if (/\/(blog|post|posts|article|articles|news|journal)\/[^/]/.test(path)) return 'post';
   if (/\/blogs\/[^/]+\/[^/]+/.test(path)) return 'post'; // Shopify /blogs/<blog>/<article>
   if (/\/blog-\d+\/post\//.test(path)) return 'post'; // Wix /blog-1/post/<slug>
+  if (/\/single-post\//.test(path)) return 'post'; // Older Wix Blog URL pattern
   if (/\/(products?|product-page|store|shop)\//.test(path)) return 'product';
   if (/\/(gallery|portfolio)/.test(path)) return 'gallery';
   if (/\/(event|events)/.test(path)) return 'event';

--- a/test/sitemap.test.ts
+++ b/test/sitemap.test.ts
@@ -40,11 +40,21 @@ describe('classifyUrl', () => {
   it('classifies blog paths as post', () => {
     expect(classifyUrl('https://example.com/blog/my-post')).toBe('post');
     expect(classifyUrl('https://example.com/post/my-post')).toBe('post');
-    expect(classifyUrl('https://example.com/blog')).toBe('post');
     expect(classifyUrl('https://example.com/news/breaking-story')).toBe('post');
     expect(classifyUrl('https://example.com/article/feature')).toBe('post');
     expect(classifyUrl('https://example.com/blogs/news/my-article')).toBe('post');
     expect(classifyUrl('https://example.com/blog-1/post/my-post')).toBe('post');
+    expect(classifyUrl('https://example.com/single-post/my-post')).toBe('post');
+  });
+
+  it('classifies bare blog/news paths as page (listing pages, not posts)', () => {
+    // Bare /blog, /news, /articles are blog *listing* pages, not individual
+    // posts. They should be classified as `page` so they are not written to
+    // WXR as authorless post items.
+    expect(classifyUrl('https://example.com/blog')).toBe('page');
+    expect(classifyUrl('https://example.com/blog/')).toBe('page');
+    expect(classifyUrl('https://example.com/news')).toBe('page');
+    expect(classifyUrl('https://example.com/articles')).toBe('page');
   });
 
   it('classifies product paths', () => {


### PR DESCRIPTION
## What this changes

Fixes two URL-classification bugs in `classifyUrl()` (`src/lib/extraction/sitemap.ts`):

1. Older Wix Blog `/single-post/<slug>` URLs now classify as `post` (were being written as `page` — an entire blog archive could land in WordPress as pages).
2. Bare `/blog`, `/news`, `/articles` now classify as `page` (they're listing pages, not individual posts — were being written to WXR as authorless "posts").

## How I found it

Testing the Wix adapter against a range of live Wix sites. One blog with ~1000 posts had all of them misclassified as pages; multiple other sites had authorless "posts" titled "Our blog" in their archive.

## Tested against

- [x] Real site (a Wix blog — dry-run discovery now classifies posts correctly)
- [x] Tests pass (`npx vitest run`) — note: 4 pre-existing failures in `test/content-differ.test.ts` are unrelated to this PR and addressed by unmerged #35
- [x] Output looks correct

## Discovery log entry added to DISCOVERIES.md

- [x] Yes