### PR TITLE
fix(cli): skip auto-preview after liberate (temporarily)

### DIFF
--- a/src/ui/discover.tsx
+++ b/src/ui/discover.tsx
@@ -17,8 +17,8 @@ import { webflowAdapter } from '../adapters/webflow.js';
 import { weeblyAdapter } from '../adapters/weebly.js';
 import { wixAdapter, type Inventory } from '../adapters/wix.js';
 import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { autoPreview } from './preview.js';
+import { join } from 'path';
+// TEMPORARY: preview temporarily disabled — autoPreview import removed. See fix/skip-preview-temporarily.
 
 function siteOutputDir(baseDir: string, url: string): string {
   let host: string;
@@ -433,12 +433,11 @@ export function runDiscover(url: string, opts: Partial<LiberateProps> = {}): voi
   waitUntilExit()
     .then(async () => {
       if (!wxrPath) return;
-      // Post-extract: always boot a local site (Studio if installed, else
-      // Playground) so the user can verify content before importing anywhere
-      // real. autoPreview honors nonInteractive internally — it still boots
-      // the site but skips browser/app auto-open so scripts get a URL.
-      const outputDir = dirname(wxrPath);
-      await autoPreview(outputDir, { nonInteractive: props.nonInteractive });
+      // TEMPORARY: preview temporarily disabled (see fix/skip-preview-temporarily).
+      // Restore by reverting this commit; the original block was:
+      //   const outputDir = dirname(wxrPath);
+      //   await autoPreview(outputDir, { nonInteractive: props.nonInteractive });
+      console.log(`\n  Preview skipped (temporarily disabled). WXR at: ${wxrPath}`);
       if (props.nonInteractive) return;
       const answer = await ask('\nReady to import to WordPress? (y/N) ');
       if (answer.toLowerCase() !== 'y') {


### PR DESCRIPTION
## Summary
- Removes the `autoPreview()` call that fires after `data-liberation <url>` extraction and replaces it with a `console.log` pointing at the emitted WXR path.
- Scope is intentionally narrow: the `data-liberation preview <outputDir>` CLI subcommand and the `liberate_preview` / `liberate_preview_stop` MCP tools are **unchanged** and remain fully functional for explicit invocation.
- Why: auto-preview (Studio / Playground boot after extraction) isn't reliable right now — Studio auto-import hits the 120s WP-CLI IPC no-activity timeout on large sites, and downstream issues surfaced in recent maus.com runs. Skipping only the auto-invocation kills the spurious end-of-run failure without taking away the escape hatches.

## Revert path
Single `git revert ebf9c36` when preview is fixed. `// TEMPORARY:` markers are left in `src/ui/discover.tsx` so the restoration point is trivial to find.

## Test plan
- [ ] `npx tsc --noEmit` is clean
- [ ] `npx vitest run` passes (379/381; the 2 skipped are unrelated Playground integration tests)
- [ ] Run `data-liberation <url>` against a small site and confirm it completes without attempting to boot Studio/Playground and prints the "Preview skipped ... WXR at: ..." line
- [ ] Run `data-liberation preview <outputDir>` explicitly and confirm it still boots a preview site as before
- [ ] Confirm `liberate_preview` / `liberate_preview_stop` MCP tools still function (unchanged surface)