### PR TITLE
feat(detect-platform): add PathProbe signal for path-based fingerprinting

### DIFF
--- a/src/lib/extraction/detect-platform.ts
+++ b/src/lib/extraction/detect-platform.ts
@@ -140,6 +140,10 @@ export async function detectFromHttp(url: string): Promise<DetectionResult> {
             redirect: 'manual',
           });
           if (!probe.expectedStatus.includes(probeResp.status)) continue;
+          if (probe.locationContains) {
+            const loc = probeResp.headers.get('location') || '';
+            if (!loc.includes(probe.locationContains)) continue;
+          }
           platform = probe.platform;
           confidence = 'high';
           signals.push(probe.signal);

--- a/src/lib/extraction/detect-platform.ts
+++ b/src/lib/extraction/detect-platform.ts
@@ -16,6 +16,31 @@ interface SourceSignal {
   signal: string;
 }
 
+/**
+ * Active path-probe signal — issues an HTTP HEAD request to a platform-specific
+ * path and matches on the response status (and optionally the Location header).
+ *
+ * Use for platforms that expose a stable admin or API path that can be detected
+ * even when the homepage HTML has been heavily themed and emits no source markers.
+ * Probes only fire when URL_PATTERNS, HTTP_SIGNALS, and SOURCE_SIGNALS all fail
+ * to identify the platform — they pay an extra HTTP round-trip, so they're a
+ * fallback, not a primary detection mechanism.
+ */
+interface PathProbe {
+  /** Path relative to site root, e.g. "/_emdash/admin" */
+  path: string;
+  /** Status codes that indicate a match (e.g. [302, 401]) */
+  expectedStatus: number[];
+  /**
+   * Optional substring that must appear in the response Location header.
+   * Tightens probe against false-positives from wildcard redirects on
+   * non-platform sites that happen to return the same status code.
+   */
+  locationContains?: string;
+  platform: string;
+  signal: string;
+}
+
 export interface DetectionResult {
   platform: string;
   confidence: 'high' | 'medium' | 'low';
@@ -59,6 +84,10 @@ const SOURCE_SIGNALS: SourceSignal[] = [
   { pattern: /<meta[^>]+name=["']generator["'][^>]+content=["']HubSpot["']/i, platform: 'hubspot', signal: 'HubSpot generator meta tag' },
   { pattern: /Go Daddy Website Builder|Starfield Technologies/i, platform: 'godaddy-wm', signal: 'GoDaddy Website Builder generator meta in page source' },
   { pattern: /img1\.wsimg\.com\/isteam/i, platform: 'godaddy-wm', signal: 'img1.wsimg.com/isteam CDN reference in page source' },
+];
+
+export const PATH_PROBES: PathProbe[] = [
+  // PR 2 adds the EmDash entry. Keeping this PR pure-infrastructure.
 ];
 
 export function detectFromUrl(url: string): string | null {

--- a/src/lib/extraction/detect-platform.ts
+++ b/src/lib/extraction/detect-platform.ts
@@ -129,6 +129,26 @@ export async function detectFromHttp(url: string): Promise<DetectionResult> {
         }
       }
     }
+
+    if (platform === 'unknown') {
+      for (const probe of PATH_PROBES) {
+        try {
+          const probeUrl = new URL(probe.path, normalized).toString();
+          const probeResp = await fetch(probeUrl, {
+            method: 'HEAD',
+            signal: AbortSignal.timeout(10000),
+            redirect: 'manual',
+          });
+          if (!probe.expectedStatus.includes(probeResp.status)) continue;
+          platform = probe.platform;
+          confidence = 'high';
+          signals.push(probe.signal);
+          break;
+        } catch {
+          // Probe fetch failed (network error, timeout, etc.) — try next probe.
+        }
+      }
+    }
   } catch {
     // Network error — return unknown
   }

--- a/src/lib/extraction/detect-platform.ts
+++ b/src/lib/extraction/detect-platform.ts
@@ -86,6 +86,15 @@ const SOURCE_SIGNALS: SourceSignal[] = [
   { pattern: /img1\.wsimg\.com\/isteam/i, platform: 'godaddy-wm', signal: 'img1.wsimg.com/isteam CDN reference in page source' },
 ];
 
+/**
+ * Registry of path probes. Iterated by the probe tier in `detectFromHttp`
+ * when URL/header/source-pattern detection all return 'unknown'.
+ *
+ * **Exported only for test injection.** Tests may push probe entries via
+ * `PATH_PROBES.push(...)` and clean up via `PATH_PROBES.length = 0` (typically
+ * in an `afterEach` hook). Production code must NOT mutate this array — define
+ * platform-specific probes here at module load time, not at runtime.
+ */
 export const PATH_PROBES: PathProbe[] = [
   // PR 2 adds the EmDash entry. Keeping this PR pure-infrastructure.
 ];
@@ -120,7 +129,13 @@ export async function detectFromHttp(url: string): Promise<DetectionResult> {
     }
 
     if (platform === 'unknown') {
-      const html = await response.text();
+      let html = '';
+      try {
+        html = await response.text();
+      } catch {
+        // Body read failed (truncation, encoding, mid-stream network error).
+        // Fall through to source-pattern (no matches) and probe tier.
+      }
       for (const sig of SOURCE_SIGNALS) {
         if (sig.pattern.test(html)) {
           platform = sig.platform;
@@ -133,7 +148,9 @@ export async function detectFromHttp(url: string): Promise<DetectionResult> {
     if (platform === 'unknown') {
       for (const probe of PATH_PROBES) {
         try {
-          const probeUrl = new URL(probe.path, normalized).toString();
+          const probeUrlObj = new URL(probe.path, normalized);
+          if (probeUrlObj.origin !== new URL(normalized).origin) continue;
+          const probeUrl = probeUrlObj.toString();
           const probeResp = await fetch(probeUrl, {
             method: 'HEAD',
             signal: AbortSignal.timeout(10000),

--- a/test/detect-platform.test.ts
+++ b/test/detect-platform.test.ts
@@ -271,4 +271,51 @@ describe('PATH_PROBES infrastructure', () => {
     expect(result.platform).toBe('wix');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('skips probe when path resolves to a different origin', async () => {
+    PATH_PROBES.push({
+      path: '//attacker.example/admin',  // Protocol-relative — would resolve to attacker.example
+      expectedStatus: [302],
+      platform: 'testplatform',
+      signal: '/_test/admin probe',
+    });
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      headers: new Map(),
+      text: () => Promise.resolve('<html></html>'),
+    });
+    global.fetch = fetchMock;
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('unknown');
+    // Critical: only ONE fetch call (the homepage). Cross-origin probe never fired.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still runs probe tier when homepage body read throws', async () => {
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302],
+      platform: 'testplatform',
+      signal: '/_test/admin probe',
+    });
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(),
+        // Body read throws (e.g. truncated stream)
+        text: () => Promise.reject(new Error('truncated')),
+      })
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: new Map([['location', 'https://example.com/_test/admin/login']]),
+      });
+
+    const result = await detectFromHttp('https://example.com');
+    // Probe tier runs despite body read failure, identifies platform
+    expect(result.platform).toBe('testplatform');
+    expect(result.confidence).toBe('high');
+  });
 });

--- a/test/detect-platform.test.ts
+++ b/test/detect-platform.test.ts
@@ -156,4 +156,52 @@ describe('PATH_PROBES infrastructure', () => {
     const result = await detectFromHttp('https://example.com');
     expect(result.platform).toBe('unknown');
   });
+
+  it('matches when Location header contains expected substring', async () => {
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302],
+      locationContains: '/_test/admin/login',
+      platform: 'testplatform',
+      signal: '/_test/admin probe with location check',
+    });
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(),
+        text: () => Promise.resolve('<html></html>'),
+      })
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: new Map([['location', 'https://example.com/_test/admin/login?redirect=%2F_test%2Fadmin']]),
+      });
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('testplatform');
+  });
+
+  it('does NOT match when Location header lacks expected substring', async () => {
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302],
+      locationContains: '/_test/admin/login',
+      platform: 'testplatform',
+      signal: '/_test/admin probe with location check',
+    });
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(),
+        text: () => Promise.resolve('<html></html>'),
+      })
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: new Map([['location', 'https://example.com/somewhere-else']]),  // Wrong location
+      });
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('unknown');  // Status matched but Location didn't
+  });
 });

--- a/test/detect-platform.test.ts
+++ b/test/detect-platform.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { detectFromUrl, detectFromHttp, PATH_PROBES } from '../src/lib/extraction/detect-platform.js';
 
@@ -94,6 +94,10 @@ describe('detectFromHttp (fingerprinting)', () => {
 });
 
 describe('PATH_PROBES infrastructure', () => {
+  afterEach(() => {
+    PATH_PROBES.length = 0;
+  });
+
   it('exports PATH_PROBES as an array', () => {
     expect(Array.isArray(PATH_PROBES)).toBe(true);
   });
@@ -128,9 +132,6 @@ describe('PATH_PROBES infrastructure', () => {
     expect(result.platform).toBe('testplatform');
     expect(result.confidence).toBe('high');
     expect(result.signals).toContain('/_test/admin probe');
-
-    // Cleanup: remove injected probe so other tests aren't affected
-    PATH_PROBES.length = 0;
   });
 
   it('does NOT match when probe returns wrong status', async () => {
@@ -154,7 +155,5 @@ describe('PATH_PROBES infrastructure', () => {
 
     const result = await detectFromHttp('https://example.com');
     expect(result.platform).toBe('unknown');
-
-    PATH_PROBES.length = 0;
   });
 });

--- a/test/detect-platform.test.ts
+++ b/test/detect-platform.test.ts
@@ -228,4 +228,47 @@ describe('PATH_PROBES infrastructure', () => {
     const result = await detectFromHttp('https://example.com');
     expect(result.platform).toBe('unknown');
   });
+
+  it('skips probes when SOURCE_SIGNALS already identified the platform', async () => {
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302],
+      platform: 'testplatform',
+      signal: '/_test/admin probe',
+    });
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      headers: new Map(),
+      // HTML matches Wix SOURCE_SIGNAL (wixstatic.com). Wix wins on tier 3,
+      // so the probe should never fire.
+      text: () => Promise.resolve('<html><img src="https://static.wixstatic.com/media/x.jpg"></html>'),
+    });
+    global.fetch = fetchMock;
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('wix');
+    // Critical: only ONE fetch call (the homepage). Probe never fired.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips probes when HTTP_SIGNALS already identified the platform', async () => {
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302],
+      platform: 'testplatform',
+      signal: '/_test/admin probe',
+    });
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      headers: new Map([['x-wix-request-id', 'abc123']]),  // HTTP_SIGNAL match
+      text: () => Promise.resolve('<html></html>'),
+    });
+    global.fetch = fetchMock;
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('wix');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/test/detect-platform.test.ts
+++ b/test/detect-platform.test.ts
@@ -101,4 +101,60 @@ describe('PATH_PROBES infrastructure', () => {
   it('PATH_PROBES is empty (no consumers in this PR)', () => {
     expect(PATH_PROBES).toEqual([]);
   });
+
+  it('matches a path probe when source signals fail (status only)', async () => {
+    // Inject a test probe by mutating PATH_PROBES (vitest tests share module state)
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302, 401],
+      platform: 'testplatform',
+      signal: '/_test/admin probe',
+    });
+
+    // Mock chain: first fetch (homepage) returns generic HTML (forces probe),
+    // second fetch (probe HEAD) returns 302.
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(),
+        text: () => Promise.resolve('<html><body>Generic</body></html>'),
+      })
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: new Map([['location', 'https://example.com/_test/admin/login']]),
+      });
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('testplatform');
+    expect(result.confidence).toBe('high');
+    expect(result.signals).toContain('/_test/admin probe');
+
+    // Cleanup: remove injected probe so other tests aren't affected
+    PATH_PROBES.length = 0;
+  });
+
+  it('does NOT match when probe returns wrong status', async () => {
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302, 401],
+      platform: 'testplatform',
+      signal: '/_test/admin probe',
+    });
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(),
+        text: () => Promise.resolve('<html></html>'),
+      })
+      .mockResolvedValueOnce({
+        status: 404,  // Wrong status
+        headers: new Map(),
+      });
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('unknown');
+
+    PATH_PROBES.length = 0;
+  });
 });

--- a/test/detect-platform.test.ts
+++ b/test/detect-platform.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'fs';
-import { detectFromUrl, detectFromHttp } from '../src/lib/extraction/detect-platform.js';
+import { detectFromUrl, detectFromHttp, PATH_PROBES } from '../src/lib/extraction/detect-platform.js';
 
 describe('detectFromUrl (heuristics)', () => {
   it('detects wixsite.com', () => {
@@ -90,5 +90,15 @@ describe('detectFromHttp (fingerprinting)', () => {
     const result = await detectFromHttp('https://skywaydiner.com');
     expect(result.platform).toBe('godaddy-wm');
     expect(result.confidence).toBe('high');
+  });
+});
+
+describe('PATH_PROBES infrastructure', () => {
+  it('exports PATH_PROBES as an array', () => {
+    expect(Array.isArray(PATH_PROBES)).toBe(true);
+  });
+
+  it('PATH_PROBES is empty (no consumers in this PR)', () => {
+    expect(PATH_PROBES).toEqual([]);
   });
 });

--- a/test/detect-platform.test.ts
+++ b/test/detect-platform.test.ts
@@ -204,4 +204,28 @@ describe('PATH_PROBES infrastructure', () => {
     const result = await detectFromHttp('https://example.com');
     expect(result.platform).toBe('unknown');  // Status matched but Location didn't
   });
+
+  it('does NOT match when Location header is missing entirely', async () => {
+    PATH_PROBES.push({
+      path: '/_test/admin',
+      expectedStatus: [302],
+      locationContains: '/_test/admin/login',
+      platform: 'testplatform',
+      signal: '/_test/admin probe with location check',
+    });
+
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Map(),
+        text: () => Promise.resolve('<html></html>'),
+      })
+      .mockResolvedValueOnce({
+        status: 302,
+        headers: new Map(),  // No Location header
+      });
+
+    const result = await detectFromHttp('https://example.com');
+    expect(result.platform).toBe('unknown');
+  });
 });


### PR DESCRIPTION
## Summary

Adds a fourth detection tier to `detectFromHttp` that issues an HTTP HEAD against known platform-specific paths when URL pattern, HTTP header, and HTML source-pattern detection all return `'unknown'`.

This is a dependency for the EmDash CMS adapter coming next, in a separate PR.

## Why

Cloudflare's EmDash CMS (launched 2026-04-01) has no reliable HTTP header fingerprint — its distinctive `Server-Timing` header is stripped in production — and custom themes can strip every HTML source marker. The one universal signal across every production EmDash site tested is that `/_emdash/admin` returns `302` to `/_emdash/admin/login`. This PR adds the infrastructure to detect that signal. The same mechanism works for any future CMS exposing a stable admin/API path (Ghost has `/ghost/`, Strapi has `/admin`, etc.).

Probes only fire when earlier tiers return `'unknown'`, so already-detected platforms pay zero extra HTTP cost. `PATH_PROBES` ships empty in this PR.

## Test plan

- [x] `npx vitest run test/detect-platform.test.ts` → 23/23 green
- [x] Full suite: 393/404 passing. The 9 failures are pre-existing in `test/legacy-scripts.test.ts`, unchanged from `main`.
- [x] `npx tsc --noEmit` clean
- [x] Real EmDash site: `curl -sI https://yurulog.liberogic.jp/_emdash/admin` returns `302` with `Location: https://yurulog.liberogic.jp/_emdash/admin/login?redirect=%2F_emdash%2Fadmin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)