### PR TITLE
discovery: Wix networkidle never resolves; use domcontentloaded + delay

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,34 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-28 — Wix's `networkidle` never resolves; use `domcontentloaded` + delay
+
+**Found by:** Claude + human contributor
+**During:** Building a Wix → WordPress.com migration tool against ~12 live Wix sites
+**Type:** platform quirk | bug fix
+
+### What I found
+Using `page.goto(url, { waitUntil: 'networkidle' })` against Wix sites
+times out on roughly half of product pages. Wix's analytics, chat
+widgets, and tracking pixels keep firing requests indefinitely, so the
+network never goes idle inside the 30s budget.
+
+### How it works
+Switch the wait strategy from `networkidle` to `domcontentloaded` and
+add a fixed `await p.waitForTimeout(4000)` afterwards. The 4s delay
+covers Wix's client-side hydration of lazy content (Thunderbolt
+rendering engine). Applied at all three navigation sites in the Wix
+adapter (page extraction, homepage crawl fallback, navigation
+extraction).
+
+### Why it's better than the previous approach
+Validated empirically across multiple live Wix sites: with
+`networkidle`, ~50% of product pages timed out and emitted partial or
+empty extractions. With `domcontentloaded` + 4s delay, the same pages
+extract reliably and the 30s budget is no longer exhausted by
+background telemetry.
+
+
 ## 2026-04-16 — Wix Tag Manager poisons content extraction
 
 **Found by:** Claude + human contributor

--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -290,7 +290,13 @@ async function extractWixPage(
   p.on('response', responseHandler);
 
   try {
-    await p.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+    // Wix's analytics, chat widgets, and tracking pixels keep firing
+    // requests indefinitely, so `networkidle` never resolves on many
+    // pages — especially product pages — and the 30s budget is
+    // exhausted by background telemetry. `domcontentloaded` + a short
+    // fixed delay catches Wix's lazy hydration without hanging.
+    await p.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await p.waitForTimeout(4000);
   } catch {
     // Navigation may timeout on heavy Wix pages
   }
@@ -625,7 +631,11 @@ export const wixAdapter: PlatformAdapter = {
     let allUrls = sitemapUrls;
     if (allUrls.length === 0) {
       try {
-        await p.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+        // See comment at the page-extraction goto above — Wix's
+        // background telemetry prevents `networkidle` from ever
+        // resolving.
+        await p.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
+        await p.waitForTimeout(4000);
         const origin = new URL(url).origin;
         allUrls = (await p.evaluate((orig: unknown) => {
           const o = orig as string;
@@ -645,7 +655,12 @@ export const wixAdapter: PlatformAdapter = {
     // 3. Extract navigation from homepage
     let navigation: NavLink[] = [];
     try {
-      await p.goto(url, { waitUntil: 'networkidle', timeout: 30000 }).catch(() => {});
+      // See comment at the page-extraction goto above for why we
+      // avoid `networkidle` on Wix sites.
+      await p
+        .goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 })
+        .catch(() => {});
+      await p.waitForTimeout(4000);
       navigation = (await p.evaluate(() => {
         const navLinks: Array<{ text: string; href: string }> = [];
         document


### PR DESCRIPTION
## What this changes
Switches the Wix adapter's three Playwright `goto` calls in `src/adapters/wix.ts` from `waitUntil: 'networkidle'` to `'domcontentloaded'` plus a 4s `waitForTimeout` afterwards.

## How I found it
Built a separate Wix → WordPress migration tool that initially used the same `networkidle` pattern. ~50% of product pages timed out in a 30s budget. Wix's Thunderbolt rendering engine emits indefinite analytics, chat, and tracking traffic, so the network is never "idle." Switched to `domcontentloaded` + a fixed 4s delay (covers Wix's lazy-content hydration); reliability went from ~50% to ~100% on the same set.

## Tested against
- [x] Real site (multiple live Wix sites including ecommerce + content)
- [x] Tests pass (`npx vitest run` — 393 passing, 2 skipped)
- [x] Output looks correct

## Discovery log entry added to DISCOVERIES.md
- [x] Yes