### PR TITLE
discovery: data-hook DOM fallback for Wix product extraction

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,52 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-28 — Wix product pages expose stable `data-hook` selectors
+
+**Found by:** Claude + human contributor
+**During:** Migrating Wix Stores sites where JSON-LD was malformed or
+missing AND the products API call hadn't been captured during navigation
+**Type:** platform quirk | content type
+
+### What I found
+Wix product pages tag key elements with `data-hook="..."` attributes
+that have been stable across every Wix Stores site we've tested. When
+JSON-LD is missing or malformed *and* the products API call hasn't
+been captured, the rendered DOM is still extractable via these hooks —
+no need to give up on the product.
+
+| Element | Selector |
+|---|---|
+| Product title | `[data-hook="product-title"]` |
+| Product price (clean) | `[data-hook="formatted-primary-price"]` |
+| Product price (wrapper, includes SR "Price") | `[data-hook="product-price"]` |
+| Product gallery root | `[data-hook="product-gallery-root"]` |
+| Main product image | `[data-hook="main-media-image-wrapper"] img` |
+| Thumbnail images | `[data-hook="thumbnail-image"] img` |
+| Product description | `[data-hook="product-description"]` |
+| Product options | `[data-hook="product-options"]` |
+
+The `[data-hook="product-price"]` wrapper contains a screen-reader span
+(`[data-hook="sr-formatted-primary-price"]`) with the literal word
+"Price" — use `[data-hook="formatted-primary-price"]` for the clean
+value.
+
+### How it works
+Added a third fallback path in `extractWixProduct()` after the
+JSON-LD and captured-API paths. When both upstream paths fail, parse
+the rendered HTML using the hooks above. Required adding an optional
+`pageHtml` field to `PageData` so the raw HTML (already captured for
+media-URL extraction) is available to the product extractor.
+
+### Why it's better than the previous approach
+Before: `extractWixProduct()` returned `null` whenever JSON-LD was
+missing AND the product API call wasn't captured (e.g. cached
+navigation, slow hydration, throttled requests). After: name, price,
+description, and gallery images recover from the rendered DOM —
+typically the worst-case path that still yields a usable product
+record.
+
+
 ## 2026-04-16 — Wix Tag Manager poisons content extraction
 
 **Found by:** Claude + human contributor

--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -71,6 +71,10 @@ export interface PageData {
   mediaUrls: string[];
   content: string;
   qualityScore: 'high' | 'medium' | 'low';
+  // Raw page HTML, kept for DOM-selector fallbacks (e.g. Wix product
+  // pages expose stable [data-hook] attributes that survive even when
+  // JSON-LD is malformed and the products API call wasn't captured).
+  pageHtml?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -491,6 +495,7 @@ async function extractWixPage(
     mediaUrls,
     content,
     qualityScore,
+    pageHtml,
   };
 }
 
@@ -563,6 +568,43 @@ function extractWixProduct(pageData: PageData): WooProduct | null {
         inStock: (product.stock as Record<string, unknown> | undefined)?.inventoryStatus
           ? (product.stock as Record<string, unknown>).inventoryStatus !== 'OUT_OF_STOCK'
           : undefined,
+      };
+    }
+  }
+
+  // 3. DOM fallback — Wix product pages tag elements with stable
+  //    [data-hook] attributes that survive even when JSON-LD is missing
+  //    or malformed AND the products API call wasn't captured. This is
+  //    the worst-case path that still yields a usable product record.
+  if (pageData.pageHtml) {
+    const html = pageData.pageHtml;
+    const pickByHook = (hook: string): string => {
+      const re = new RegExp(
+        `data-hook=["']${hook}["'][^>]*>([\\s\\S]*?)</`,
+        'i'
+      );
+      const m = html.match(re);
+      return m?.[1]?.replace(/<[^>]+>/g, '').trim() || '';
+    };
+    const name = pickByHook('product-title');
+    if (name) {
+      // [data-hook="formatted-primary-price"] is the clean value.
+      // [data-hook="product-price"] wraps a screen-reader "Price" prefix.
+      const price = pickByHook('formatted-primary-price').replace(/[^0-9.,]/g, '');
+      const description = pickByHook('product-description');
+      const imgRe = /data-hook=["'](?:main-media-image-wrapper|thumbnail-image)["'][^>]*>[\s\S]*?<img[^>]+src=["']([^"']+)["']/gi;
+      const images: string[] = [];
+      let match: RegExpExecArray | null;
+      while ((match = imgRe.exec(html)) !== null) {
+        if (!images.includes(match[1])) images.push(match[1]);
+      }
+      return {
+        name,
+        description,
+        regularPrice: price,
+        sku: '',
+        images,
+        inStock: true,
       };
     }
   }


### PR DESCRIPTION
## What this changes
Adds a `data-hook` DOM-selector fallback to `extractWixProduct()` in `src/adapters/wix.ts`, after the existing JSON-LD and captured-API paths. Required exposing the raw `pageHtml` on `PageData` (already captured locally for media-URL extraction).

## How I found it
Across a separate Wix migration tool's testing on multiple Wix Stores sites, JSON-LD was occasionally malformed (see existing 2026-04-16 discovery on `Offers` / `Availability` casing) AND the products API call sometimes wasn't captured before extraction completed. In both cases the DOM still has the data — Wix tags it with stable `data-hook` attributes that have been consistent across every Wix Stores site we've seen. Selector table is in the DISCOVERIES.md entry.

## Tested against
- [x] Real site (multiple live Wix Stores)
- [x] Tests pass (`npx vitest run` — 393 passing, 2 skipped)
- [x] Output looks correct

## Discovery log entry added to DISCOVERIES.md
- [x] Yes