### PR TITLE
discovery: strip " Main" suffix from Wix site title

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,45 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-28 — Wix appends " Main" to every site name
+
+**Found by:** Claude + human contributor
+**During:** Migrating multiple Wix sites; noticed every WordPress import
+ended up with a site title like "My Studio Main"
+**Type:** platform quirk
+
+### What I found
+Wix's editor appends a literal " Main" suffix to every site's name. It
+shows up in two places:
+
+- `<meta property="og:site_name">` content ends in " Main" (e.g.
+  "Gilded Carat Main")
+- `document.title` follows the pattern `Page Title | Site Name Main`
+
+The suffix is a Wix internal label (probably the default page-set
+name, "Main"). It is never part of the agency's actual site name.
+
+### How it works
+At the homepage `siteTitle` extraction site in `discover()`, take the
+substring after the last ` | ` and strip a trailing ` Main`:
+
+```js
+const t = document.title;
+const pipeIdx = t.lastIndexOf(' | ');
+const sitePart = pipeIdx > 0 ? t.slice(pipeIdx + 3).trim() : t;
+return sitePart.replace(/ Main$/, '').trim();
+```
+
+The per-page title stripping in `runExtractionLoop` (slice everything
+after ` | `) already handles per-page titles correctly — the trailing
+" Main" suffix goes with the site-name half. The bug was site-level
+only.
+
+### Why it's better than the previous approach
+Before: WordPress imports landed with site titles like
+"Home | Gilded Carat Main". After: clean "Gilded Carat".
+
+
 ## 2026-04-16 — Wix Tag Manager poisons content extraction
 
 **Found by:** Claude + human contributor

--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -664,10 +664,20 @@ export const wixAdapter: PlatformAdapter = {
       // nav extraction failed
     }
 
-    // 4. Extract site title
+    // 4. Extract site title.
+    //    Wix's editor sets document.title to "Page Title | Site Name Main".
+    //    Take the substring after the last " | " (the site-name half), then
+    //    drop the trailing " Main" suffix that Wix appends to every site
+    //    name. Without this the WordPress import lands with a site title
+    //    like "Home | Gilded Carat Main" instead of "Gilded Carat".
     let siteTitle = '';
     try {
-      siteTitle = (await p.evaluate(() => document.title)) as string;
+      siteTitle = (await p.evaluate(() => {
+        const t = document.title;
+        const pipeIdx = t.lastIndexOf(' | ');
+        const sitePart = pipeIdx > 0 ? t.slice(pipeIdx + 3).trim() : t;
+        return sitePart.replace(/ Main$/, '').trim();
+      })) as string;
     } catch {
       // title extraction failed
     }


### PR DESCRIPTION
## What this changes
The homepage `siteTitle` extraction in `src/adapters/wix.ts` now strips Wix's `" | Site Name Main"` pattern: take the substring after the last ` | `, then drop the trailing ` Main` suffix.

## How I found it
Migrating multiple Wix sites and noticing every WordPress import landed with a site title like "Home | Gilded Carat Main" instead of "Gilded Carat". Wix's editor appends a literal " Main" to every site's name (it's the default page-set label) and `document.title` always carries it on the homepage. Per-page titles already get stripped correctly by the existing pipe-split — this fixes the site-level title only.

## Tested against
- [x] Real site (multiple live Wix sites)
- [x] Tests pass (`npx vitest run` — 393 passing, 2 skipped)
- [x] Output looks correct

## Discovery log entry added to DISCOVERIES.md
- [x] Yes