### PR TITLE
discovery: Wix splits hosted media across three CDN hosts

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,39 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-04-28 — Wix splits hosted media across three CDN hosts
+
+**Found by:** Claude + human contributor
+**During:** Migrating Wix sites; noticed platform assets (icons,
+decorative imagery) weren't being downloaded
+**Type:** platform quirk
+
+### What I found
+All Wix-hosted media uses one of three CDN hostnames:
+
+- `static.wixstatic.com` — images, documents (the well-known one)
+- `static.parastorage.com` — platform assets: icons, decorative
+  imagery, pattern fills used by Wix templates
+- `video.wixstatic.com` — video content (already covered by the
+  existing `wixstatic.com` term)
+
+The image-CDN regex in `extractImageUrls()` only matched
+`wixstatic.com` / `wixmp.com`. `parastorage.com` was silently dropped
+during the "only keep image-looking URLs" filter, so platform
+decorative assets never made it into the media-download set.
+
+### How it works
+Add `parastorage\.com` to the `imageCdns` regex inside
+`extractImageUrls()` in `src/adapters/wix.ts`. Comment documents all
+three hosts so the next reader doesn't have to re-discover them.
+
+### Why it's better than the previous approach
+Before: any URL on `static.parastorage.com` was filtered out unless it
+also passed the file-extension check, missing extension-less or
+query-param-styled CDN URLs. After: all three Wix CDN hosts are
+recognised consistently.
+
+
 ## 2026-04-16 — Wix Tag Manager poisons content extraction
 
 **Found by:** Claude + human contributor

--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -130,9 +130,13 @@ function extractImageUrls(data: {
     }
   }
 
-  // Filter: only keep URLs that look like images
+  // Filter: only keep URLs that look like images.
+  // Wix-hosted media is split across three CDN hosts:
+  //   static.wixstatic.com   — images, documents
+  //   static.parastorage.com — platform assets (icons, decorative)
+  //   video.wixstatic.com    — video content (covered by `wixstatic.com`)
   const imageExtensions = IMAGE_EXTENSIONS;
-  const imageCdns = /wixstatic\.com|wixmp\.com|images\.unsplash\.com|cdn\.shopify\.com/i;
+  const imageCdns = /wixstatic\.com|wixmp\.com|parastorage\.com|images\.unsplash\.com|cdn\.shopify\.com/i;
   return [...urls].filter((u) => {
     try {
       const parsed = new URL(u);


### PR DESCRIPTION
## What this changes
Adds `parastorage\.com` to the `imageCdns` regex in `src/adapters/wix.ts` and documents all three Wix CDN hosts in a comment.

## How I found it
Migrating Wix sites and noticing platform assets (icons, decorative imagery, pattern fills) weren't being downloaded. Wix splits its hosted media across three CDNs — `static.wixstatic.com` (images, documents), `static.parastorage.com` (platform assets), `video.wixstatic.com` (video, already covered by the existing `wixstatic.com` match). The regex only matched the first two.

## Tested against
- [x] Real site (multiple live Wix sites)
- [x] Tests pass (`npx vitest run` — 393 passing, 2 skipped)
- [x] Output looks correct

## Discovery log entry added to DISCOVERIES.md
- [x] Yes