### PR TITLE
fix(wix): declare waitForTimeout on inline Page type narrowings

### DIFF
--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -259,6 +259,7 @@ async function extractWixPage(
     goto(url: string, opts: Record<string, unknown>): Promise<unknown>;
     evaluate(fn: () => unknown): Promise<unknown>;
     content(): Promise<string>;
+    waitForTimeout(ms: number): Promise<void>;
     context(): {
       newCDPSession(page: unknown): Promise<{
         send(method: string, params: Record<string, unknown>): Promise<unknown>;
@@ -642,6 +643,7 @@ export const wixAdapter: PlatformAdapter = {
       goto(url: string, opts?: Record<string, unknown>): Promise<{ ok(): boolean } | null>;
       content(): Promise<string>;
       evaluate(fn: (...args: unknown[]) => unknown, ...args: unknown[]): Promise<unknown>;
+      waitForTimeout(ms: number): Promise<void>;
     };
 
     // 1. Fetch sitemap via Playwright


### PR DESCRIPTION
## Summary
- PR #51 added `p.waitForTimeout(4000)` calls to `src/adapters/wix.ts`, but the two inline `const p = page as { ... }` type narrowings (around lines 256 and 641) don't declare `waitForTimeout`. `tsc` reports 3 errors:

```
src/adapters/wix.ts(307,13): error TS2339: Property 'waitForTimeout' does not exist on type '{ on(...); off(...); goto(...); evaluate(...); content(...); context(...); }'.
src/adapters/wix.ts(684,17): error TS2339: ...
src/adapters/wix.ts(709,15): error TS2339: ...
```

- Runtime is unaffected because Playwright's actual `Page` object has `waitForTimeout` — the narrowings just need the method declared.
- These errors slipped through because `tsc` emits JS by default even when type-checking fails, and there's no CI to surface the non-zero exit. (See companion PR adding `noEmitOnError: true`.)

## Test plan
- [x] `npm run build` exits 0 with no errors
- [x] `npm test` — 404 passed, 2 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)