### PR TITLE
fix: WordPress.com app passwords are site-specific, not account-level

### DIFF
--- a/commands/setup.md
+++ b/commands/setup.md
@@ -17,7 +17,7 @@ If any step fails, the report includes specific guidance:
 
 - **Unreachable site** — check URL format, site accessibility, WordPress.com vs self-hosted
 - **REST API unavailable** — check for security plugins blocking the API, verify it's actually a WordPress site
-- **Auth failure** — how to create an Application Password (WordPress Admin > Users > Profile, or wordpress.com/me/security/application-passwords), common mistakes (using account password instead of app password, using email instead of username)
+- **Auth failure** — how to create an Application Password (WordPress Admin > Users > Profile). On WordPress.com / wpcomstaging.com hosts, the password MUST come from the site's own wp-admin — wordpress.com/me/security/application-passwords issues account-level passwords that only work for the public-api.wordpress.com namespace. Common mistakes: using account password instead of app password, using email instead of username, using account-level WP.com app password against site-native /wp-json/wp/v2/.
 
 ## Usage
 

--- a/prompts/shopify.md
+++ b/prompts/shopify.md
@@ -100,7 +100,7 @@ Then validate the WordPress connection:
 npm run setup -- --site [MY-WORDPRESS-SITE] --username [MY-USERNAME] --token [APP-PASSWORD]
 ```
 
-This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords (or wordpress.com/me/security/application-passwords for WordPress.com sites)).
+This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords). Note: on WordPress.com and wpcomstaging.com sites, the password must be generated from the site's own wp-admin, not from wordpress.com/me/security/application-passwords (account-level passwords only work for the WordPress.com public API).
 
 ## Step 5: Import everything
 

--- a/prompts/squarespace.md
+++ b/prompts/squarespace.md
@@ -109,7 +109,7 @@ Then validate the WordPress connection:
 npm run setup -- --site [MY-WORDPRESS-SITE] --username [MY-USERNAME] --token [APP-PASSWORD]
 ```
 
-This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords (or wordpress.com/me/security/application-passwords for WordPress.com sites)).
+This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords). Note: on WordPress.com and wpcomstaging.com sites, the password must be generated from the site's own wp-admin, not from wordpress.com/me/security/application-passwords (account-level passwords only work for the WordPress.com public API).
 
 ## Step 6: Import everything
 

--- a/prompts/webflow.md
+++ b/prompts/webflow.md
@@ -78,7 +78,7 @@ Then validate the WordPress connection:
 npm run setup -- --site [MY-WORDPRESS-SITE] --username [MY-USERNAME] --token [APP-PASSWORD]
 ```
 
-This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords (or wordpress.com/me/security/application-passwords for WordPress.com sites)).
+This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords). Note: on WordPress.com and wpcomstaging.com sites, the password must be generated from the site's own wp-admin, not from wordpress.com/me/security/application-passwords (account-level passwords only work for the WordPress.com public API).
 
 ## Step 5: Import everything
 

--- a/prompts/wix.md
+++ b/prompts/wix.md
@@ -78,7 +78,7 @@ Then validate the WordPress connection:
 npm run setup -- --site [MY-WORDPRESS-SITE] --username [MY-USERNAME] --token [APP-PASSWORD]
 ```
 
-This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords (or wordpress.com/me/security/application-passwords for WordPress.com sites)).
+This checks site reachability, REST API availability, and authentication. If anything fails, it shows step-by-step guidance (how to create an Application Password at WordPress Admin > Users > Profile > Application Passwords). Note: on WordPress.com and wpcomstaging.com sites, the password must be generated from the site's own wp-admin, not from wordpress.com/me/security/application-passwords (account-level passwords only work for the WordPress.com public API).
 
 ## Step 5: Import everything
 

--- a/skills/liberate/SKILL.md
+++ b/skills/liberate/SKILL.md
@@ -77,7 +77,7 @@ If no environment import skill is available, use the built-in REST API import. V
 
 If the user doesn't have a WordPress site yet, guide them:
 1. Create a WordPress site (wordpress.com, self-hosted, or WordPress Studio for local development)
-2. Generate an Application Password (WordPress Admin > Users > Profile > Application Passwords, or wordpress.com/me/security/application-passwords for WordPress.com)
+2. Generate an Application Password (WordPress Admin > Users > Profile > Application Passwords). On WordPress.com / wpcomstaging.com sites, generate it from the site's own wp-admin — the account-level one at wordpress.com/me/security/application-passwords only works for the WordPress.com public API, not the site-native /wp-json/wp/v2/ endpoint we use.
 3. Run `liberate_setup` to validate the connection
 
 ## Platform-specific notes

--- a/src/lib/setup/wp-setup.ts
+++ b/src/lib/setup/wp-setup.ts
@@ -99,12 +99,29 @@ export async function validateWpConnection(input: WpSetupInput): Promise<WpSetup
   }
 
   if (!report.authenticated) {
-    report.guidance.push(
-      'Create an Application Password at: WordPress Admin > Users > Profile > Application Passwords',
-      'For WordPress.com: go to wordpress.com/me/security/application-passwords',
-      'The token should be the Application Password (with spaces), not your account password',
-      'Username should be your WordPress login username, not your email',
-    );
+    const host = (() => {
+      try { return new URL(baseUrl).hostname.toLowerCase(); } catch { return ''; }
+    })();
+    const isWpcomHost =
+      host.endsWith('.wpcomstaging.com') ||
+      host.endsWith('.wordpress.com') ||
+      host === 'wordpress.com';
+
+    if (isWpcomHost) {
+      report.guidance.push(
+        'This is a WordPress.com-hosted site. WordPress.com has TWO kinds of application passwords — only the site-specific one works for /wp-json/wp/v2/ Basic Auth:',
+        `  → Generate one at ${baseUrl}/wp-admin/profile.php (Users > Profile > Application Passwords)`,
+        'Account-level app passwords from wordpress.com/me/security/application-passwords only authenticate against the public-api.wordpress.com namespace (OAuth-style); they will 401 against the site-native REST API.',
+        'The token should be the Application Password (with spaces), not your account password',
+        'Username should be your WordPress.com login username, not your email',
+      );
+    } else {
+      report.guidance.push(
+        'Create an Application Password at: WordPress Admin > Users > Profile > Application Passwords',
+        'The token should be the Application Password (with spaces), not your account password',
+        'Username should be your WordPress login username, not your email',
+      );
+    }
   }
 
   return report;

--- a/src/ui/discover.tsx
+++ b/src/ui/discover.tsx
@@ -457,7 +457,7 @@ export function runDiscover(url: string, opts: Partial<LiberateProps> = {}): voi
         console.log('\n  To import, you need a WordPress site. Here\'s how to get started:\n');
         console.log('  1. Create a WordPress site (wordpress.com, self-hosted, or WordPress Studio for local development)');
         console.log('  2. Create an Application Password at WordPress Admin > Users > Profile > Application Passwords');
-        console.log('     (WordPress.com: wordpress.com/me/security/application-passwords)');
+        console.log('     (WordPress.com / wpcomstaging.com sites: generate it from the site\'s own wp-admin, NOT wordpress.com/me/security)');
         console.log('  3. Save the generated token\n');
         console.log('  Once you have your site, username, and application password, continue below.\n');
       }


### PR DESCRIPTION
## What this changes

Fixes the auth-failure guidance shown by `liberate_setup` (and the matching skill / prompt / CLI text) so it points WordPress.com users at the right Application Password screen.

WordPress.com issues two kinds of Application Passwords:

| Type | Generated at | Authenticates against |
|---|---|---|
| **Site-specific** | `<site>/wp-admin/profile.php` → Users → Profile | `<site>/wp-json/wp/v2/...` (Basic Auth) ✅ |
| **Account-level** | `wordpress.com/me/security/application-passwords` | `public-api.wordpress.com/...` (OAuth2 token endpoint only) ❌ |

`liberate_setup` and `liberate_import` hit `<site>/wp-json/wp/v2/users/me`, i.e. the site-native API. Only the site-specific kind works there. The old guidance recommended the account-level page for WordPress.com sites, which produced silent 401s with no clear path to remediation.

This affects WP.com Simple sites, Business-plan staging (`*.wpcomstaging.com`), and Atomic sites on Business / Commerce / Enterprise plans.

## How I found it

Migrating a Wix interior design site to a wpcomstaging.com Business-plan staging target. First app password was generated from `wordpress.com/me/security/application-passwords` — got HTTP 401. Generated a second one from `<staging>/wp-admin/profile.php` — worked immediately.

## What's in the diff

- **`src/lib/setup/wp-setup.ts`** — runtime change: detect `*.wpcomstaging.com` / `*.wordpress.com` hosts and surface site-specific instructions first, with an explicit note about why account-level passwords don't work.
- **`src/ui/discover.tsx`**, **`skills/liberate/SKILL.md`**, **`commands/setup.md`**, **`prompts/{wix,squarespace,shopify,webflow}.md`** — text-only changes so the message is consistent across every entry point that mentions Application Passwords.

## Why no DISCOVERIES.md entry

`DISCOVERIES.md` is for platform-extraction findings (how Wix / Squarespace / Shopify / etc. work). This is a bug fix in our own auth/setup guidance — same category as a fix to a CLI prompt. The rationale lives here in the PR description; happy to add a DISCOVERIES.md entry if maintainers prefer that convention.

## Tested against

- [x] Tests pass (`npx vitest run` — 404 passed, 2 skipped)
- [x] Real site — reproduced the 401 with an account-level password and the 200 with a site-specific password against `dlaimporttarget.wpcomstaging.com`
- [x] No behavioural change for non-WP.com hosts (the new branch only fires when the hostname matches `*.wpcomstaging.com`, `*.wordpress.com`, or `wordpress.com`)