### PR TITLE
fix(wix): probe sub-sitemaps that the index omits (blog-posts, store-products, forum-posts)

### DIFF
--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -673,6 +673,18 @@ export const wixAdapter: PlatformAdapter = {
 
     await fetchSitemapPw(`${baseUrl}/sitemap.xml`);
 
+    // Wix's sitemap index typically only references pages-sitemap.xml,
+    // even when blog/store/forum content exists. Probe the well-known
+    // sub-sitemap paths so blog posts and storefront items don't get
+    // silently dropped.
+    for (const subSitemap of [
+      'blog-posts-sitemap.xml',
+      'store-products-sitemap.xml',
+      'forum-posts-sitemap.xml',
+    ]) {
+      await fetchSitemapPw(`${baseUrl}/${subSitemap}`);
+    }
+
     // 2. If sitemap is empty, crawl homepage for same-origin links
     let allUrls = sitemapUrls;
     if (allUrls.length === 0) {


### PR DESCRIPTION
## What this changes

After fetching the main `/sitemap.xml` index, also probe three well-known Wix sub-sitemap paths so blog posts, store products, and forum posts aren't silently dropped from URL discovery.

## How I found it

Wix's `/sitemap.xml` index typically only references `pages-sitemap.xml`, even when the site has blog/store/forum content. The blog-posts, store-products, and forum-posts sub-sitemaps live at predictable paths but are invisible to the index. Result: discovery returns 0 blog posts on a site that clearly has them.

## Type of change

- [x] Bug fix (something broke)

## The fix

Probe `blog-posts-sitemap.xml`, `store-products-sitemap.xml`, and `forum-posts-sitemap.xml` unconditionally after the index walk. `fetchSitemapPw` is no-op-safe on 404, so probing a sub-sitemap that doesn't exist on a particular site costs only a single fetch attempt.

## Tested against

- [x] Real Wix site (sitemap.xml omitted blog-posts; previously 0 posts discovered, now all 30+ picked up)
- [x] Scripts run without errors
- [x] Output looks correct

## Discovery log

- [ ] Entry would be added to DISCOVERIES.md as part of merge if requested
