### PR TITLE
feat(wix): expose blog post cover image as PageData.featuredImage

### DIFF
--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -75,6 +75,13 @@ export interface PageData {
   // pages expose stable [data-hook] attributes that survive even when
   // JSON-LD is malformed and the products API call wasn't captured).
   pageHtml?: string;
+  // Author-set cover image for blog posts, recovered from the page's
+  // BlogPosting JSON-LD (a Wix-platform standard regardless of theme).
+  // Set only on Article/BlogPosting/NewsArticle pages where JSON-LD
+  // exposes an `image` field; absent otherwise. Lets consumers wire the
+  // post's hero image to a featured-image field without having to parse
+  // it out of body content (or invent inference from leading <img> tags).
+  featuredImage?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -149,6 +156,50 @@ function extractImageUrls(data: {
       return false;
     }
   });
+}
+
+/**
+ * Extract a blog post's featured image from BlogPosting JSON-LD. Returns
+ * the URL of the first matching image (schema.org-defined as the post's
+ * primary image) or null if no BlogPosting/Article JSON-LD is present.
+ *
+ * Handles all three image-field shapes the schema allows:
+ *   - string                                       → URL directly
+ *   - { @type: 'ImageObject', url: '...' }         → nested url property
+ *   - [ImageObject, ImageObject, ...]              → first item's URL
+ *
+ * Verified across two independent Wix Blog themes that diverge on DOM
+ * markup but both emit BlogPosting JSON-LD with image populated. Source-
+ * level (server-rendered) so detection doesn't depend on JS hydration.
+ */
+function extractFeaturedImageFromJsonLd(jsonLd: unknown[]): string | null {
+  for (const ld of jsonLd) {
+    const obj = ld as Record<string, unknown>;
+    const type = obj['@type'];
+    const isPostType =
+      type === 'BlogPosting' ||
+      type === 'Article' ||
+      type === 'NewsArticle' ||
+      (Array.isArray(type) && type.some((t) => t === 'BlogPosting' || t === 'Article' || t === 'NewsArticle'));
+    if (!isPostType) continue;
+
+    const image = obj.image;
+    if (typeof image === 'string') return image;
+    if (image && typeof image === 'object' && !Array.isArray(image)) {
+      const url = (image as Record<string, unknown>).url;
+      if (typeof url === 'string') return url;
+    }
+    if (Array.isArray(image)) {
+      for (const item of image) {
+        if (typeof item === 'string') return item;
+        if (item && typeof item === 'object') {
+          const url = (item as Record<string, unknown>).url;
+          if (typeof url === 'string') return url;
+        }
+      }
+    }
+  }
+  return null;
 }
 
 /** Walk a JSON value tree looking for HTML content in known field names. */
@@ -493,6 +544,10 @@ async function extractWixPage(
     meta: browserData.meta,
   });
 
+  // Recover the post's author-set cover image from BlogPosting JSON-LD.
+  // Set only when the page is actually a post; absent on regular pages.
+  const featuredImage = extractFeaturedImageFromJsonLd(browserData.jsonLd);
+
   return {
     sourceUrl: url,
     slug: slugify(url),
@@ -506,6 +561,7 @@ async function extractWixPage(
     content,
     qualityScore,
     pageHtml,
+    ...(featuredImage ? { featuredImage } : {}),
   };
 }
 


### PR DESCRIPTION
## What this changes

Adds optional `featuredImage` to `PageData`, populated from BlogPosting JSON-LD when present. Lets downstream consumers wire the post's author-set cover image to a featured-image field without parsing it out of body content or inferring heuristically from leading inline `<img>` tags.

## How I found it

Wix's blog widget exposes an explicit cover image set per-post by the author — drives the hero on single-post views, the card image on the feed, and the OG share image. DLA currently doesn't surface this field anywhere on `PageData`, so consumers either render it duplicated inline or invent inference heuristics that go wrong on posts that lead with prose before the hero.

## Type of change

- [x] New Wix feature support

## The approach

Recovered from the page's BlogPosting / Article / NewsArticle JSON-LD — a Wix-platform standard emitted regardless of theme. Server-rendered, so detection doesn't depend on JS hydration. Set only on post pages where JSON-LD exposes an `image`; absent otherwise.

Helper handles all three image-field shapes the schema allows: bare URL string, ImageObject (nested url), or array of either.

## Tested against

- [x] Real Wix sites — verified `featuredImage` populates correctly on two independent Wix Blog themes that diverge entirely on body DOM markup but both emit BlogPosting JSON-LD with `image`
- [x] Scripts run without errors
- [x] Output looks correct

## Discovery log

- [ ] Entry would be added to DISCOVERIES.md as part of merge if requested
