### PR TITLE
feat(wix): classify Wix typed-blog feed pages with pageType field

### DIFF
--- a/src/adapters/wix.ts
+++ b/src/adapters/wix.ts
@@ -75,6 +75,14 @@ export interface PageData {
   // pages expose stable [data-hook] attributes that survive even when
   // JSON-LD is malformed and the products API call wasn't captured).
   pageHtml?: string;
+  // Classification when DLA can identify the page as a Wix-platform widget
+  // shell rather than a general-purpose page. Currently set only to
+  // "blog_archive" when the Wix typed-blog feed widget is detected (the
+  // listing page that shows multiple posts as cards). Absent when there's
+  // no strong signal — consumers should treat absence as "general page"
+  // and not infer extra meaning. Open enum so future widget classifications
+  // (product listings, forums, bookings) don't require breaking consumers.
+  pageType?: 'blog_archive' | string;
 }
 
 // ---------------------------------------------------------------------------
@@ -435,6 +443,23 @@ async function extractWixPage(
     // DOM extraction failed
   }
 
+  // Wix typed-blog feed pages (the post-listing page rendered by the Wix
+  // Blog widget) carry a stable [data-hook="feed-page-root"] container
+  // at the top of the feed. Verified across two independent Wix sites
+  // that diverge on theme; absent on regular pages and on custom-styled
+  // pages that look archive-like but don't use the typed-blog widget.
+  // High-precision signal — false negatives acceptable (sites not using
+  // the widget go untagged), false positives unlikely.
+  let pageType: string | null = null;
+  try {
+    const isBlogArchive = (await p.evaluate(
+      () => !!document.querySelector('[data-hook="feed-page-root"]')
+    )) as boolean;
+    if (isBlogArchive) pageType = 'blog_archive';
+  } catch {
+    // detection failed; leave pageType unset
+  }
+
   let accessibility: Array<{ role: string; name: string; description?: string }> | null =
     null;
   try {
@@ -506,6 +531,7 @@ async function extractWixPage(
     content,
     qualityScore,
     pageHtml,
+    ...(pageType ? { pageType } : {}),
   };
 }
 


### PR DESCRIPTION
## What this changes

Adds optional `pageType` to `PageData`, currently set to `"blog_archive"` when the page is a Wix typed-blog feed shell (the listing page that shows multiple posts as cards). Open enum so future widget classifications can be added without breaking consumers.

## How I found it

Wix sites can host blog feed pages via the Wix Blog widget — the main `/blog`, plus typed feeds like `/audio-blog`. DLA currently extracts these as generic pages with no signal that they're a typed-blog feed shell rather than a static page. Downstream consumers building anything dynamic (query loops, RSS, paginated archives) end up reinventing detection from slug heuristics + content shape, which has poor precision: custom-styled pages that look archive-like get false-positives, and custom-named feeds get false-negatives.

## Type of change

- [x] New Wix feature support

## The detection

Single high-precision signal: `[data-hook="feed-page-root"]` in the rendered DOM. The Wix Blog widget renders this stable container at the top of every typed-blog feed page.

Verified across two independent Wix sites — same `feed-page-root` data-hook on both feed pages, absent on home / about / custom-styled non-feed pages on the same sites. False negatives acceptable (sites not using the typed-blog widget go untagged); false positives unlikely (the data-hook value is widget-specific).

## Tested against

- [x] Real Wix sites — verified `pageType: "blog_archive"` fires on typed-blog feed pages across two independent Wix themes; absent on regular pages
- [x] Scripts run without errors
- [x] Output looks correct

## Discovery log

- [ ] Entry would be added to DISCOVERIES.md as part of merge if requested
