### PR TITLE
discovery: emit Gutenberg block markup for Squarespace 7.1 sqs-block HTML

### DIFF
--- a/DISCOVERIES.md
+++ b/DISCOVERIES.md
@@ -6,6 +6,58 @@ AI agents: when you contribute an improvement, add an entry here. See [CONTRIBUT
 
 ---
 
+## 2026-05-28 — Squarespace 7.1 `sqs-block` HTML imports as one Classic block instead of editable Gutenberg blocks
+
+**Found by:** Claude + Davi
+**During:** Migrating walkaboutchronicles.com — a 1,500+ post Squarespace 7.1 photo blog. After import, every post body opened as a single Classic block in the editor; users couldn't reorder images, swap individual photos, or toggle the gallery lightbox without first running "Convert to blocks" (which produced ugly, broken-up output that lost gallery semantics).
+**Type:** content type
+
+### What I found
+Squarespace 7.1's per-post `item.body` HTML is a deeply-nested layout — `<div class="sqs-layout"><div class="row"><div class="col"><div class="sqs-block image-block">…` — with content wrapped inside class-named block containers. The current Squarespace adapter passes this HTML straight into `<content:encoded>`. WordPress's import has no way to know those `sqs-block` divs map to Gutenberg blocks, so the entire body lands as a single Classic block in the editor.
+
+The Squarespace class names are stable and easy to map deterministically:
+
+| Squarespace class                                | Gutenberg block                                   |
+| ------------------------------------------------ | ------------------------------------------------- |
+| `sqs-block image-block`                          | `core/image`                                      |
+| `sqs-block gallery-block`                        | `core/gallery` (`linkTo:media` → core lightbox)   |
+| `sqs-block html-block` (h1–h6, p, ul/ol, blockquote, hr) | `core/heading` / `core/paragraph` / `core/list` / `core/quote` / `core/separator` |
+| `sqs-block embed-block` / `video-block`          | `core/embed` (with provider slug for YouTube/Vimeo/etc.) |
+| `sqs-block quote-block`                          | `core/quote`                                      |
+| `sqs-block horizontal-rule-block` / `line-block` | `core/separator`                                  |
+| `sqs-block spacer-block`                         | dropped (Gutenberg handles spacing natively)      |
+| unrecognised `sqs-block …`                       | `core/html` (lossless fallback)                   |
+
+Two gotchas worth noting:
+
+- **Lazy-loaded image URLs.** Squarespace 7.1 puts the real CDN URL in `data-image=` and uses a placeholder for `src=` until JS hydrates. Block emission has to read `data-image` first or every image lands as a placeholder. (Same fix as the DOM-fallback discovery; the helper reuses the pattern.)
+- **Gallery lightbox.** Emitting `<!-- wp:gallery {"linkTo":"media"} -->` with each inner `wp:image` wrapped in `<a href="…">` triggers core's native click-to-zoom lightbox when the theme enables it, which is the closest match to Squarespace's gallery click-to-enlarge behaviour. No third-party plugin needed.
+
+### How it works
+A new module `src/adapters/squarespace-blocks.ts` exposes `squarespaceHtmlToGutenberg(html)`:
+
+- No-op when the input doesn't contain `sqs-block` markers (safe to call on every body, including DOM-fallback output).
+- Loads the HTML with cheerio (already a project dependency).
+- Walks every top-level `sqs-block` element (children of one are skipped to avoid double-emission).
+- Dispatches on the block class via a small regex table, emitting the matching Gutenberg block markup with the right block JSON.
+- Preserves block order; preserves inline formatting (`<em>`, `<strong>`, `<a>`) inside paragraphs; preserves figure captions on images.
+- Lossless fallback to `core/html` for any unrecognised `sqs-block` variant so future Squarespace block types don't drop content.
+
+```ts
+// In squarespace.ts → extract() → extractPage()
+body = squarespaceHtmlToGutenberg(body);
+```
+
+12 new unit tests cover image (with `data-image` preference), captioned image, multi-image gallery (with lightbox link), heading + paragraph + list, ordered lists, YouTube embed with provider slug, spacer drop, horizontal rule, unrecognised block fallback, and block-order preservation.
+
+### Why it's better than the previous approach
+Before: every imported Squarespace post landed as one Classic block. Editing was awkward, gallery lightbox didn't work (because there was no gallery block), images couldn't be swapped individually, and "Convert to blocks" produced messy intermediate HTML that lost the gallery grouping entirely.
+
+After: posts land as the same proper Gutenberg blocks the user would have built by hand on a fresh WordPress site. Galleries trigger the core lightbox without a plugin. Images carry their alt text + caption. Embeds get their oEmbed provider slug. Unknown future Squarespace block types degrade to `core/html` instead of breaking the import.
+
+
+---
+
 ## 2026-04-30 — `--resume` overwrites the existing WXR with only newly-extracted items
 
 **Found by:** Claude + James

--- a/src/adapters/squarespace-blocks.ts
+++ b/src/adapters/squarespace-blocks.ts
@@ -1,0 +1,204 @@
+/**
+ * Convert Squarespace 7.1 block HTML to Gutenberg block markup.
+ *
+ * Squarespace's per-post `item.body` is a deeply-nested layout of
+ * `<div class="sqs-layout"><div class="row"><div class="col"><div class="sqs-block …">`
+ * containing the actual content. When this HTML is dropped into a WordPress
+ * post body as-is, the block editor wraps the whole thing in a single Classic
+ * block: the user can read the post but can't edit individual images, can't
+ * use core's gallery lightbox, and can't reorder blocks without first
+ * "Converting to blocks" (which produces messy output).
+ *
+ * This module walks the Squarespace HTML, recognises each `sqs-block` variant,
+ * and emits the equivalent Gutenberg block markup so the import lands as
+ * proper, editable blocks. Recognised mappings:
+ *
+ *   | Squarespace class                                | Emitted Gutenberg block             |
+ *   | ------------------------------------------------ | ----------------------------------- |
+ *   | `sqs-block image-block`                          | `core/image`                        |
+ *   | `sqs-block gallery-block`                        | `core/gallery` (linkTo:media)       |
+ *   | `sqs-block html-block`                           | `core/paragraph` / `core/heading` / |
+ *   |                                                  | `core/list` / `core/quote`          |
+ *   | `sqs-block embed-block` / `video-block`          | `core/embed`                        |
+ *   | `sqs-block quote-block`                          | `core/quote`                        |
+ *   | `sqs-block horizontal-rule-block` / `line-block` | `core/separator`                    |
+ *   | `sqs-block spacer-block`                         | dropped (Gutenberg handles spacing) |
+ *   | unrecognised `sqs-block …`                       | `core/html` (lossless fallback)     |
+ *
+ * The output is safe to drop into `<content:encoded>` in a WXR file: WordPress
+ * will recognise the `<!-- wp:* -->` delimiters during import and create
+ * editable blocks. When the input doesn't contain any `sqs-block` markers the
+ * function returns the input unchanged so this is safe to call on every body.
+ */
+
+import * as cheerio from 'cheerio';
+import type { CheerioAPI, Cheerio } from 'cheerio';
+import type { Element } from 'domhandler';
+
+const SQS_BLOCK_MARKER = /\bsqs-block\b/;
+
+/** Public entry point. */
+export function squarespaceHtmlToGutenberg(html: string): string {
+  if (!html || !SQS_BLOCK_MARKER.test(html)) return html;
+  const $ = cheerio.load(html, null, false);
+  const out: string[] = [];
+
+  // Walk every top-level `sqs-block` element in document order. A "top-level"
+  // sqs-block is one whose ancestor chain has no other sqs-block — i.e. it
+  // doesn't sit inside another block.
+  $('.sqs-block').each((_, el) => {
+    const node = $(el);
+    if (node.parents('.sqs-block').length > 0) return;
+    const block = convertSqsBlock($, node);
+    if (block) out.push(block);
+  });
+
+  if (out.length === 0) return html;
+  return out.join('\n\n');
+}
+
+function convertSqsBlock($: CheerioAPI, node: Cheerio<Element>): string | null {
+  const classAttr = node.attr('class') || '';
+  if (/\bimage-block\b/.test(classAttr)) return emitImage($, node);
+  if (/\bgallery-block\b/.test(classAttr)) return emitGallery($, node);
+  if (/\b(?:embed-block|video-block)\b/.test(classAttr)) return emitEmbed($, node);
+  if (/\bquote-block\b/.test(classAttr)) return emitQuote($, node);
+  if (/\b(?:horizontal-rule-block|line-block)\b/.test(classAttr)) {
+    return '<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->';
+  }
+  if (/\bspacer-block\b/.test(classAttr)) return null;
+  if (/\bhtml-block\b/.test(classAttr)) return emitHtmlBlock($, node);
+  return emitFallback($, node);
+}
+
+function pickImage(node: Cheerio<Element>): { src: string; alt: string; caption: string } | null {
+  const img = node.find('img').first();
+  if (img.length === 0) return null;
+  const dataImage = img.attr('data-image') || img.attr('data-src') || '';
+  const src = /^https?:\/\//.test(dataImage) ? dataImage : (img.attr('src') || '');
+  if (!src) return null;
+  const alt = (img.attr('alt') || '').trim();
+  const figcap = node.find('figcaption, .image-caption-wrapper').first();
+  const caption = figcap.length ? figcap.text().trim() : '';
+  return { src, alt, caption };
+}
+
+function emitImage(_$: CheerioAPI, node: Cheerio<Element>): string | null {
+  const pick = pickImage(node);
+  if (!pick) return null;
+  const inner = pick.caption
+    ? `<figure class="wp-block-image size-large"><img src="${escapeAttr(pick.src)}" alt="${escapeAttr(pick.alt)}"/><figcaption class="wp-element-caption">${escapeHtml(pick.caption)}</figcaption></figure>`
+    : `<figure class="wp-block-image size-large"><img src="${escapeAttr(pick.src)}" alt="${escapeAttr(pick.alt)}"/></figure>`;
+  return `<!-- wp:image {"sizeSlug":"large","linkDestination":"none"} -->\n${inner}\n<!-- /wp:image -->`;
+}
+
+function emitGallery($: CheerioAPI, node: Cheerio<Element>): string | null {
+  const items: Array<{ src: string; alt: string }> = [];
+  node.find('img').each((_, im) => {
+    const img = $(im);
+    const dataImage = img.attr('data-image') || img.attr('data-src') || '';
+    const src = /^https?:\/\//.test(dataImage) ? dataImage : (img.attr('src') || '');
+    if (!src) return;
+    items.push({ src, alt: (img.attr('alt') || '').trim() });
+  });
+  if (items.length === 0) return null;
+
+  const inner: string[] = [];
+  for (const it of items) {
+    inner.push(
+      `<!-- wp:image {"sizeSlug":"large","linkDestination":"media"} -->\n` +
+      `<figure class="wp-block-image size-large"><a href="${escapeAttr(it.src)}"><img src="${escapeAttr(it.src)}" alt="${escapeAttr(it.alt)}"/></a></figure>\n` +
+      `<!-- /wp:image -->`
+    );
+  }
+  return `<!-- wp:gallery {"linkTo":"media"} -->\n<figure class="wp-block-gallery has-nested-images">\n${inner.join('\n')}\n</figure>\n<!-- /wp:gallery -->`;
+}
+
+function emitEmbed(_$: CheerioAPI, node: Cheerio<Element>): string | null {
+  const iframe = node.find('iframe').first();
+  const url = iframe.attr('src') || node.find('a[href]').first().attr('href') || '';
+  if (!/^https?:\/\//.test(url)) return null;
+  const provider = guessEmbedProvider(url);
+  const attrs = provider
+    ? `{"url":"${escapeAttr(url)}","type":"video","providerNameSlug":"${provider}","responsive":true}`
+    : `{"url":"${escapeAttr(url)}","responsive":true}`;
+  return (
+    `<!-- wp:embed ${attrs} -->\n` +
+    `<figure class="wp-block-embed${provider ? ` is-provider-${provider} wp-block-embed-${provider}` : ''} wp-embed-aspect-16-9 wp-has-aspect-ratio">` +
+    `<div class="wp-block-embed__wrapper">\n${url}\n</div></figure>\n` +
+    `<!-- /wp:embed -->`
+  );
+}
+
+function guessEmbedProvider(url: string): string | null {
+  if (/youtube\.com|youtu\.be/i.test(url)) return 'youtube';
+  if (/vimeo\.com/i.test(url)) return 'vimeo';
+  if (/twitter\.com|x\.com/i.test(url)) return 'twitter';
+  if (/instagram\.com/i.test(url)) return 'instagram';
+  if (/soundcloud\.com/i.test(url)) return 'soundcloud';
+  if (/spotify\.com/i.test(url)) return 'spotify';
+  return null;
+}
+
+function emitQuote(_$: CheerioAPI, node: Cheerio<Element>): string | null {
+  const text = node.find('blockquote, .quote-content, p').first().text().trim();
+  if (!text) return null;
+  const cite = node.find('cite, .source').first().text().trim();
+  const inner = cite
+    ? `<blockquote class="wp-block-quote"><p>${escapeHtml(text)}</p><cite>${escapeHtml(cite)}</cite></blockquote>`
+    : `<blockquote class="wp-block-quote"><p>${escapeHtml(text)}</p></blockquote>`;
+  return `<!-- wp:quote -->\n${inner}\n<!-- /wp:quote -->`;
+}
+
+function emitHtmlBlock($: CheerioAPI, node: Cheerio<Element>): string | null {
+  const inner = node.find('.html-block-html').first().length
+    ? node.find('.html-block-html').first()
+    : node;
+  const out: string[] = [];
+  inner.children().each((_, el) => {
+    const tag = (el.tagName || '').toLowerCase();
+    const $el = $(el);
+    if (/^h[1-6]$/.test(tag)) {
+      const level = parseInt(tag.slice(1), 10);
+      const text = $el.html() || '';
+      out.push(`<!-- wp:heading {"level":${level}} -->\n<${tag}>${text}</${tag}>\n<!-- /wp:heading -->`);
+    } else if (tag === 'ul' || tag === 'ol') {
+      const ordered = tag === 'ol';
+      const items: string[] = [];
+      $el.children('li').each((_, li) => {
+        items.push(`<!-- wp:list-item -->\n<li>${$(li).html() || ''}</li>\n<!-- /wp:list-item -->`);
+      });
+      const wrapper = ordered ? '<ol>' : '<ul>';
+      const closer  = ordered ? '</ol>' : '</ul>';
+      out.push(`<!-- wp:list${ordered ? ' {"ordered":true}' : ''} -->\n${wrapper}\n${items.join('\n')}\n${closer}\n<!-- /wp:list -->`);
+    } else if (tag === 'blockquote') {
+      out.push(`<!-- wp:quote -->\n<blockquote class="wp-block-quote">${$el.html() || ''}</blockquote>\n<!-- /wp:quote -->`);
+    } else if (tag === 'hr') {
+      out.push('<!-- wp:separator -->\n<hr class="wp-block-separator has-alpha-channel-opacity"/>\n<!-- /wp:separator -->');
+    } else if (tag === 'p') {
+      const innerHtml = ($el.html() || '').trim();
+      if (innerHtml) out.push(`<!-- wp:paragraph -->\n<p>${innerHtml}</p>\n<!-- /wp:paragraph -->`);
+    } else {
+      out.push(`<!-- wp:html -->\n${$.html(el)}\n<!-- /wp:html -->`);
+    }
+  });
+  if (out.length === 0) {
+    const text = inner.text().trim();
+    if (text) out.push(`<!-- wp:paragraph -->\n<p>${escapeHtml(text)}</p>\n<!-- /wp:paragraph -->`);
+  }
+  return out.length ? out.join('\n\n') : null;
+}
+
+function emitFallback($: CheerioAPI, node: Cheerio<Element>): string | null {
+  const inner = $.html(node);
+  if (!inner.trim()) return null;
+  return `<!-- wp:html -->\n${inner}\n<!-- /wp:html -->`;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}

--- a/src/adapters/squarespace.ts
+++ b/src/adapters/squarespace.ts
@@ -4,6 +4,7 @@ import type { ExtractionLog } from '../lib/extraction/extraction-log.js';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { fetchSitemap, classifyUrl } from '../lib/extraction/sitemap.js';
 import { slugify, launchBrowser, getPlaywright, runExtractionLoop, IMAGE_EXTENSIONS } from './shared.js';
+import { squarespaceHtmlToGutenberg } from './squarespace-blocks.js';
 import type { InventoryUrl, NavLink } from './shared.js';
 import { WooProductCsvBuilder } from '../lib/import/woo-product-csv.js';
 import type { WooProduct } from '../lib/import/woo-product-csv.js';
@@ -757,6 +758,12 @@ export const squarespaceAdapter: PlatformAdapter = {
               // Playwright not available or DOM extraction failed — continue with what we have
             }
           }
+
+          // Convert Squarespace's sqs-block markup into Gutenberg block markup so
+          // the imported post lands as proper editable blocks (image, gallery,
+          // paragraph, heading, …) instead of one Classic blob. No-op when the
+          // body doesn't contain sqs-block markers (e.g. DOM-fallback output).
+          body = squarespaceHtmlToGutenberg(body);
 
           const bodyText = body.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
           let qualityScore: 'high' | 'medium' | 'low' = 'low';

--- a/test/adapters/squarespace-blocks.test.ts
+++ b/test/adapters/squarespace-blocks.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { squarespaceHtmlToGutenberg } from '../../src/adapters/squarespace-blocks.js';
+
+describe('squarespaceHtmlToGutenberg', () => {
+  it('returns input unchanged when no sqs-block markers present', () => {
+    const input = '<p>Just plain HTML.</p>';
+    expect(squarespaceHtmlToGutenberg(input)).toBe(input);
+  });
+
+  it('returns input unchanged for empty string', () => {
+    expect(squarespaceHtmlToGutenberg('')).toBe('');
+  });
+
+  it('converts a single image-block, preferring data-image over src', () => {
+    const html = `
+      <div class="sqs-layout"><div class="row"><div class="col">
+        <div class="sqs-block image-block">
+          <div class="sqs-block-content">
+            <img src="https://example.com/placeholder.svg"
+                 data-image="https://images.squarespace-cdn.com/content/v1/real.jpg"
+                 alt="A summit" />
+          </div>
+        </div>
+      </div></div></div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('<!-- wp:image');
+    expect(out).toContain('images.squarespace-cdn.com/content/v1/real.jpg');
+    expect(out).toContain('alt="A summit"');
+    expect(out).not.toContain('placeholder.svg');
+  });
+
+  it('preserves image captions inside wp:image', () => {
+    const html = `
+      <div class="sqs-block image-block">
+        <figure>
+          <img src="https://example.com/x.jpg" alt="x"/>
+          <figcaption>Late afternoon, north face.</figcaption>
+        </figure>
+      </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('Late afternoon, north face.');
+    expect(out).toContain('wp-element-caption');
+  });
+
+  it('converts gallery-block with multiple images and linkTo:media for lightbox', () => {
+    const html = `
+      <div class="sqs-block gallery-block">
+        <div class="sqs-gallery">
+          <img src="https://example.com/a.jpg" alt="A"/>
+          <img src="https://example.com/b.jpg" alt="B"/>
+          <img src="https://example.com/c.jpg" alt="C"/>
+        </div>
+      </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('<!-- wp:gallery {"linkTo":"media"} -->');
+    // Each gallery item should be a wp:image with linkDestination:media (anchor wrapper).
+    expect((out.match(/<!-- wp:image/g) || []).length).toBe(3);
+    expect(out).toContain('href="https://example.com/a.jpg"');
+    expect(out).toContain('alt="C"');
+  });
+
+  it('converts an html-block heading + paragraph + list into three wp blocks', () => {
+    const html = `
+      <div class="sqs-block html-block">
+        <div class="html-block-html">
+          <h2>Section one</h2>
+          <p>An opening paragraph with <em>emphasis</em>.</p>
+          <ul>
+            <li>Item A</li>
+            <li>Item B</li>
+          </ul>
+        </div>
+      </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('<!-- wp:heading {"level":2} -->');
+    expect(out).toContain('<h2>Section one</h2>');
+    expect(out).toContain('<!-- wp:paragraph -->');
+    expect(out).toContain('<em>emphasis</em>');
+    expect(out).toContain('<!-- wp:list -->');
+    expect(out).toContain('<!-- wp:list-item -->');
+    expect(out).toContain('<li>Item A</li>');
+  });
+
+  it('emits an ordered list with the ordered attribute', () => {
+    const html = `
+      <div class="sqs-block html-block">
+        <div class="html-block-html">
+          <ol><li>First</li><li>Second</li></ol>
+        </div>
+      </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('<!-- wp:list {"ordered":true} -->');
+    expect(out).toContain('<ol>');
+  });
+
+  it('converts an embed-block YouTube iframe into wp:embed with provider slug', () => {
+    const html = `
+      <div class="sqs-block embed-block">
+        <iframe src="https://www.youtube.com/embed/abc123"></iframe>
+      </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('<!-- wp:embed');
+    expect(out).toContain('"providerNameSlug":"youtube"');
+    expect(out).toContain('wp-block-embed-youtube');
+  });
+
+  it('drops spacer-block entirely', () => {
+    const html = `
+      <div class="sqs-block image-block">
+        <img src="https://example.com/x.jpg" alt=""/>
+      </div>
+      <div class="sqs-block spacer-block"><div class="sqs-block-content"></div></div>
+      <div class="sqs-block image-block">
+        <img src="https://example.com/y.jpg" alt=""/>
+      </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).not.toContain('spacer-block');
+    expect((out.match(/<!-- wp:image/g) || []).length).toBe(2);
+  });
+
+  it('emits a wp:separator for horizontal-rule-block', () => {
+    const html = `<div class="sqs-block horizontal-rule-block"><hr/></div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('<!-- wp:separator -->');
+    expect(out).toContain('wp-block-separator');
+  });
+
+  it('falls back to core/html for an unrecognised sqs-block class', () => {
+    const html = `<div class="sqs-block weird-future-block-2050">
+      <div class="sqs-block-content"><p>preserved content</p></div>
+    </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    expect(out).toContain('<!-- wp:html -->');
+    expect(out).toContain('preserved content');
+  });
+
+  it('preserves block order when multiple sqs-blocks appear', () => {
+    const html = `
+      <div class="sqs-layout">
+        <div class="sqs-block image-block"><img src="https://example.com/a.jpg" alt="a"/></div>
+        <div class="sqs-block html-block"><div class="html-block-html"><p>middle</p></div></div>
+        <div class="sqs-block image-block"><img src="https://example.com/b.jpg" alt="b"/></div>
+      </div>`;
+    const out = squarespaceHtmlToGutenberg(html);
+    const idxA = out.indexOf('a.jpg');
+    const idxMid = out.indexOf('middle');
+    const idxB = out.indexOf('b.jpg');
+    expect(idxA).toBeGreaterThan(-1);
+    expect(idxMid).toBeGreaterThan(idxA);
+    expect(idxB).toBeGreaterThan(idxMid);
+  });
+});


### PR DESCRIPTION
## What this changes

Squarespace 7.1's per-post `item.body` is a deeply-nested layout of
`<div class="sqs-layout"><div class="row"><div class="col"><div class="sqs-block ...">…`.
Passed straight into `<content:encoded>`, WordPress wraps the entire body in
a single Classic block during import: the editor can't reorder images, can't
swap individuals, can't toggle the native gallery lightbox.

New `src/adapters/squarespace-blocks.ts` exposes
`squarespaceHtmlToGutenberg(html)` which walks every top-level `sqs-block`
element and emits the matching Gutenberg block markup:

| Squarespace class                                | Gutenberg block                                   |
| ------------------------------------------------ | ------------------------------------------------- |
| `sqs-block image-block`                          | `core/image`                                      |
| `sqs-block gallery-block`                        | `core/gallery` (`linkTo:media` → core lightbox)   |
| `sqs-block html-block`                           | `core/heading` / `core/paragraph` / `core/list` / `core/quote` |
| `sqs-block embed-block` / `video-block`          | `core/embed` (with provider slug)                 |
| `sqs-block quote-block`                          | `core/quote`                                      |
| `sqs-block horizontal-rule-block` / `line-block` | `core/separator`                                  |
| `sqs-block spacer-block`                         | dropped (Gutenberg handles spacing)               |
| unrecognised `sqs-block …`                       | `core/html` (lossless fallback)                   |

Prefers `data-image` over `src` for lazy-loaded images (same root cause as
the DOM-fallback fix in the other PR). Gallery items get an `<a href>` wrapper
and `linkTo:media` so core's native click-to-zoom lightbox triggers without a
third-party plugin.

Wired into `squarespace.ts` `extract()` → `extractPage()` right before the
bodyText quality scoring. No-op when input has no `sqs-block` markers, so
the DOM-fallback path is unaffected.

## How I found it

While migrating walkaboutchronicles.com — every imported post body was a
single uneditable Classic block. We first built a PHP version of this
mapping inside our migration plugin (https://github.com/davipontesblog/sqs71-to-gutenberg)
and ported the learnings here.

## Tested against

- [x] Real site (analogous PHP port; 1,570 posts emitted as proper Gutenberg
      blocks on a Studio site)
- [x] Tests pass (`npx vitest run` — 416 passed, 2 skipped)
- [x] `npx tsc --noEmit` clean
- [x] 12 new unit tests for `squarespaceHtmlToGutenberg`
- [x] No new dependencies (uses existing cheerio)

## Discovery log entry added to DISCOVERIES.md

- [x] Yes
