### PR TITLE
fix(mcp): restore server boot and project-dev launch path

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "data-liberation": {
       "command": "npx",
-      "args": ["tsx", "${CLAUDE_PLUGIN_ROOT}/src/mcp-server.ts"],
-      "cwd": "${CLAUDE_PLUGIN_ROOT}"
+      "args": ["tsx", "${CLAUDE_PLUGIN_ROOT:-.}/src/mcp-server.ts"],
+      "cwd": "${CLAUDE_PLUGIN_ROOT:-.}"
     }
   }
 }

--- a/src/lib/detect-platform/index.ts
+++ b/src/lib/detect-platform/index.ts
@@ -1,1 +1,2 @@
-export { detect, detectFromHttp, detectFromUrl, DetectionResult, FullDetectionResult, PATH_PROBES } from './detect-platform.js';
+export { detect, detectFromHttp, detectFromUrl, PATH_PROBES } from './detect-platform.js';
+export type { DetectionResult, FullDetectionResult } from './detect-platform.js';

--- a/src/lib/resume-state/index.ts
+++ b/src/lib/resume-state/index.ts
@@ -1,3 +1,4 @@
 export { ExtractionLog } from './extraction-log.js';
 export { ImportSession } from './import-session.js';
-export { MediaStub, MediaStubStore, toRootRelativeUploadUrl } from './media-stubs.js';
+export { MediaStubStore, toRootRelativeUploadUrl } from './media-stubs.js';
+export type { MediaStub } from './media-stubs.js';

--- a/src/lib/woo-csv/index.ts
+++ b/src/lib/woo-csv/index.ts
@@ -1,1 +1,2 @@
-export { WooProduct, WooProductCsvBuilder } from './woo-product-csv.js';
+export { WooProductCsvBuilder } from './woo-product-csv.js';
+export type { WooProduct } from './woo-product-csv.js';

--- a/src/lib/wxr/index.ts
+++ b/src/lib/wxr/index.ts
@@ -1,3 +1,5 @@
-export { Category, Comment, MediaItem, MenuItem, PageItem, PostItem, Tag, Term, WxrBuilder, WxrBuilderOpts, WxrItem } from './wxr-builder.js';
-export { readWxr, WxrData } from './wxr-reader.js';
+export { WxrBuilder } from './wxr-builder.js';
+export type { Category, Comment, MediaItem, MenuItem, PageItem, PostItem, Tag, Term, WxrBuilderOpts, WxrItem } from './wxr-builder.js';
+export { readWxr } from './wxr-reader.js';
+export type { WxrData } from './wxr-reader.js';
 export { rehydrateBuilderFromWxr } from './wxr-rehydrate.js';

--- a/src/mcp-server.boot.test.ts
+++ b/src/mcp-server.boot.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Boots the MCP server EXACTLY as production does — `tsx src/mcp-server.ts` in a
+// child process, with cwd = repo root — and asserts it links and serves its tools.
+//
+// Why a subprocess and not an in-process import: the failure mode this guards
+// against is a barrel re-exporting a TYPE with value `export {}` syntax (e.g.
+// `export { DetectionResult } from './detect-platform.js'`). That crashes Node's
+// native ESM linker at boot (which is how `tsx` runs the server) with
+// "does not provide an export named ...". It is invisible to `tsc` (even with
+// noEmitOnError) and silently erased by vitest's own esbuild transform — so a
+// same-process `import('./mcp-server.js')` would NOT reproduce it. Only a real
+// `tsx` launch links the barrel graph the way production does. Regression guard
+// for the four barrels fixed alongside this test (detect-platform, woo-csv,
+// resume-state, wxr) and any future barrel that makes the same mistake.
+//
+// Self-locating via import.meta.url so a worktree copy boots its own server from
+// its own path (no shared cwd state, no cross-copy collision).
+
+const here = dirname(fileURLToPath(import.meta.url));
+const serverEntry = join(here, 'mcp-server.ts');
+const repoRoot = join(here, '..');
+
+interface Tool {
+  name: string;
+}
+
+describe('mcp-server boots under tsx/native-ESM', () => {
+  it('links the barrel graph and serves the tool list', async () => {
+    const child = spawn('npx', ['tsx', serverEntry], {
+      cwd: repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+
+    const send = (msg: unknown) => child.stdin.write(`${JSON.stringify(msg)}\n`);
+    send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'boot-smoke', version: '0' },
+      },
+    });
+    send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+
+    try {
+      const tools = await new Promise<Tool[]>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`timed out waiting for tools/list\nstderr:\n${stderr}`)),
+          60_000,
+        );
+        child.stdout.on('data', (d) => {
+          stdout += d.toString();
+          for (const line of stdout.split('\n')) {
+            if (!line.trim()) continue;
+            try {
+              const msg = JSON.parse(line);
+              if (msg.id === 2 && msg.result?.tools) {
+                clearTimeout(timer);
+                resolve(msg.result.tools as Tool[]);
+              }
+            } catch {
+              // partial line — wait for the rest
+            }
+          }
+        });
+        child.on('exit', (code) => {
+          clearTimeout(timer);
+          reject(new Error(`server exited (code ${code}) before tools/list\nstderr:\n${stderr}`));
+        });
+      });
+
+      // No ESM-linker crash leaked to stderr (the original boot failure).
+      expect(stderr).not.toMatch(/SyntaxError|does not provide an export/);
+      // Tools actually registered — a real list, with stable core tools present.
+      const names = tools.map((t) => t.name);
+      expect(names.length).toBeGreaterThan(0);
+      expect(names).toContain('liberate_paths');
+      expect(names).toContain('liberate_detect');
+      expect(names).toContain('liberate_extract');
+    } finally {
+      child.stdin.end();
+      child.kill();
+    }
+  }, 70_000);
+});


### PR DESCRIPTION
## Summary

The data-liberation MCP server failed to start. Two independent defects stacked up:

1. **Boot crash (ESM linking).** Four lib barrels introduced during the Tier-1/2 lib extraction re-exported TypeScript interfaces and type aliases with value `export {}` syntax. The server runs via `npx tsx src/mcp-server.ts`, where Node's native ESM linker rejects re-exporting a name the target module never exports as a value — so it died at boot with `SyntaxError: The requested module './detect-platform.js' does not provide an export named 'DetectionResult'`. `tsc` does not flag this, even with the recently added `noEmitOnError`.
2. **Unresolvable launch path.** `.mcp.json` referenced `${CLAUDE_PLUGIN_ROOT}`, which Claude Code only sets when the repo is loaded as an installed plugin. Running it as a project `.mcp.json` left the path unresolved (`Missing environment variables: CLAUDE_PLUGIN_ROOT`).

The net effect: the MCP server did not run on `main` for anyone launching it via `tsx` (its only launch path), and could not be used at all in a project-dev (non-plugin) context.

## Changes

- **`detect-platform`, `woo-csv`, `resume-state`, `wxr` barrels** — split each combined re-export into a value re-export (`export {}`) and a type-only re-export (`export type {}`). `verbatimModuleSyntax`-correct and invisible to the public API surface.
- **`.mcp.json`** — `${CLAUDE_PLUGIN_ROOT:-.}` for both `args` and `cwd`. Identical behavior when the variable is set (plugin install); falls back to the repo root when it is not (project dev), matching the codebase's own `cwd = project root` launch assumption in `src/cli/agent-invoker.ts`.

## Test plan

Verified locally:

- `npx tsx src/mcp-server.ts` boots with empty stderr (no linker `SyntaxError`).
- MCP `initialize` + `tools/list` handshake returns all **34** `liberate_*` tools.
- Reproduced the project-dev launch exactly — `CLAUDE_PLUGIN_ROOT` unset, `cwd` = repo root, relative `./src/mcp-server.ts` — and confirmed the full tool list.

## Notes

- The `.mcp.json` change is backward-compatible with the installed-plugin path (when `CLAUDE_PLUGIN_ROOT` is set, expansion is unchanged).
- Consumers using this repo as a project `.mcp.json` also need it un-rejected in their local settings (`disabledMcpjsonServers`) and a full Claude Code restart to re-read MCP config — these are local-environment steps, not part of this diff.
