### PR TITLE
fix(replicate): scale non-responsive Wix mobile carry to fill viewport

### DIFF
--- a/src/lib/replicate/theme-scaffold-carry.test.ts
+++ b/src/lib/replicate/theme-scaffold-carry.test.ts
@@ -424,3 +424,64 @@ describe('buildCarryThemeFiles — WooCommerce store templates', () => {
     expect(find(files, 'templates/archive-product.html')).toBeUndefined();
   });
 });
+
+describe('buildCarryThemeFiles — mobile viewport scaling (non-responsive Wix only)', () => {
+  // Non-responsive (classic/adaptive) Wix mobile is a FIXED 320px canvas, carried as the
+  // .lib-carry-vp-mobile iframe (CarryPage.mobile is set). The live site scales that canvas
+  // to fill the phone via a width=320 viewport on mobile UAs; WordPress's default
+  // width=device-width leaves it un-scaled (white gap on wide phones). The theme must mirror
+  // Wix — but ONLY when a page actually carries that fixed mobile canvas (responsive sites and
+  // other platforms never set `mobile`, and forcing width=320 there would shrink/break them).
+  const scaffoldWithViewport = {
+    openWrap:
+      '<meta name="viewport" content="width=device-width, initial-scale=1" id="wixDesktopViewport">\n<div id="SITE_CONTAINER">',
+    midBefore: '<div id="inner">',
+    midAfter: '</div>',
+    closeWrap: '</div>',
+  };
+  const build = (withMobile: boolean) =>
+    buildCarryThemeFiles({
+      themeName: 'Acme Carry',
+      chromeVariants: oneVariant(
+        '<!-- wp:html --><header id="H">nav</header><!-- /wp:html -->',
+        '<!-- wp:html --><footer id="F">foot</footer><!-- /wp:html -->',
+      ),
+      siteCss: '',
+      pages: [
+        page({
+          slug: 'about',
+          isHome: false,
+          scaffold: scaffoldWithViewport,
+          pageCss: '',
+          ...(withMobile ? { mobile: { docUrl: '/wp-content/uploads/_carry-mobile/about.html', height: 4000 } } : {}),
+        }),
+      ],
+    });
+  const pick = (files: ReturnType<typeof build>, p: string) => files.find((f) => f.path === p)?.content ?? '';
+
+  it('functions.php swaps to a width=320 viewport on mobile UAs when a page carries a mobile canvas', () => {
+    const fn = pick(build(true), 'functions.php');
+    expect(fn).toContain('wp_is_mobile()');
+    expect(fn).toContain('width=320');
+    // Core registers _block_template_viewport_meta_tag during template-canvas setup (AFTER
+    // functions.php loads, priority 0), so it must be removed from INSIDE wp_head (priority -1).
+    expect(fn).toContain("remove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 )");
+  });
+
+  it('strips the carried <meta viewport> from the template when a page carries a mobile canvas (a later body meta would otherwise override ours)', () => {
+    const tpl = pick(build(true), 'templates/page-about.html');
+    expect(tpl).not.toContain('name="viewport"');
+    expect(tpl).not.toContain('wixDesktopViewport');
+    expect(tpl).toContain('id="SITE_CONTAINER"'); // the rest of the carried wrapper survives
+  });
+
+  it('does NOT touch the viewport (functions.php or templates) when no page carries a mobile canvas', () => {
+    const files = build(false);
+    const fn = pick(files, 'functions.php');
+    expect(fn).not.toContain('wp_is_mobile()');
+    expect(fn).not.toContain('width=320');
+    expect(fn).not.toContain('_block_template_viewport_meta_tag');
+    // a responsive / other-platform carry keeps its carried template byte-for-byte
+    expect(pick(files, 'templates/page-about.html')).toContain('name="viewport"');
+  });
+});

--- a/src/lib/replicate/theme-scaffold-carry.test.ts
+++ b/src/lib/replicate/theme-scaffold-carry.test.ts
@@ -484,4 +484,29 @@ describe('buildCarryThemeFiles — mobile viewport scaling (non-responsive Wix o
     // a responsive / other-platform carry keeps its carried template byte-for-byte
     expect(pick(files, 'templates/page-about.html')).toContain('name="viewport"');
   });
+
+  it('scopes the width=320 viewport to the mobile-canvas pages (native/non-canvas pages stay device-width)', () => {
+    // Hybrid carry: one page carries a mobile canvas, another (scaffolded) does not. The
+    // viewport swap must gate on the canvas page, so native blog contexts (is_single/is_home/
+    // is_archive) and non-canvas pages fall through to device-width — matching VP_TOGGLE_CSS's
+    // :has() scope (otherwise native blog pages render zoomed at a 320 viewport on mobile).
+    const files = buildCarryThemeFiles({
+      themeName: 'Acme Carry',
+      chromeVariants: oneVariant(
+        '<!-- wp:html --><header id="H">n</header><!-- /wp:html -->',
+        '<!-- wp:html --><footer id="F">f</footer><!-- /wp:html -->',
+      ),
+      siteCss: '',
+      pages: [
+        page({ slug: 'about', scaffold: scaffoldWithViewport, pageCss: '', mobile: { docUrl: '/m/about.html', height: 4000 } }),
+        page({ slug: 'plain', scaffold: { openWrap: '<div id="x">', midBefore: '', midAfter: '', closeWrap: '</div>' }, pageCss: '' }),
+      ],
+    });
+    const fn = pick(files, 'functions.php');
+    const vp = fn.slice(fn.indexOf('}, 10, 2 );')); // the viewport block, after the KSES filter
+    expect(vp).toContain('wp_is_mobile() && (');   // scoped, not global
+    expect(vp).toContain("is_page( 'about' )");     // the mobile-canvas page is in the gate
+    expect(vp).not.toContain("'plain'");            // the non-canvas page is excluded
+    expect(vp).toContain('width=device-width');     // non-matching pages fall to device-width
+  });
 });

--- a/src/lib/replicate/theme-scaffold-carry.ts
+++ b/src/lib/replicate/theme-scaffold-carry.ts
@@ -436,17 +436,23 @@ function functionsPhp(pages: CarryPage[], bodyClasses: string[], mobileViewport:
   // Non-responsive (classic/adaptive) source mobile layout is a FIXED-width canvas (carried
   // as the .lib-carry-vp-mobile iframe). The source scales it to fill via a width=320 viewport
   // on mobile user-agents; WordPress's default width=device-width leaves it un-scaled (gap on
-  // wide phones). Mirror the source ONLY for these carries: width=320 on mobile, else
-  // device-width. Core registers _block_template_viewport_meta_tag during template-canvas setup
-  // (AFTER this file loads), so a top-level remove_action misses it — remove it from inside
-  // wp_head at priority -1 (before core's 0), then emit ours.
+  // wide phones). Mirror the source — but SCOPE width=320 to the mobile-canvas pages (those
+  // with a captured mobile DOM), so native blog contexts (is_single/is_home/is_archive) and
+  // non-canvas pages stay device-width, matching VP_TOGGLE_CSS's :has(.lib-carry-vp-mobile)
+  // scope. Core registers _block_template_viewport_meta_tag during template-canvas setup (AFTER
+  // this file loads), so a top-level remove_action misses it — remove it from inside wp_head at
+  // priority -1 (before core's 0), then emit ours.
+  const mobileCanvasCond = pages
+    .filter((p) => p.mobile)
+    .map(pageCondition)
+    .join(' || ');
   const mobileViewportBlock = mobileViewport
     ? `
 add_action( 'wp_head', function () {
     remove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 );
 }, -1 );
 add_action( 'wp_head', function () {
-    echo wp_is_mobile()
+    echo ( wp_is_mobile() && ( ${mobileCanvasCond} ) )
         ? '<meta name="viewport" content="width=320, user-scalable=yes" id="libCarryMobileViewport">' . "\\n"
         : '<meta name="viewport" content="width=device-width, initial-scale=1">' . "\\n";
 }, 1 );

--- a/src/lib/replicate/theme-scaffold-carry.ts
+++ b/src/lib/replicate/theme-scaffold-carry.ts
@@ -403,7 +403,17 @@ function sanitizeBodyClass(cls: string): string | null {
   return /^[a-zA-Z][\w-]{0,60}$/.test(cls) ? cls : null;
 }
 
-function functionsPhp(pages: CarryPage[], bodyClasses: string[]): string {
+/**
+ * Strip any carried `<meta name="viewport">` — a `<head>` element wrongly carried into the
+ * page BODY via the scaffold's openWrap. Left in, a later in-body viewport meta overrides
+ * the theme's own head viewport (browsers apply the last one), defeating the mobile-canvas
+ * viewport swap. Only applied to mobile-canvas carries (see buildCarryThemeFiles).
+ */
+function stripViewportMeta(html: string): string {
+  return html.replace(/<meta\b[^>]*\bname=["']viewport["'][^>]*>\s*/gi, '');
+}
+
+function functionsPhp(pages: CarryPage[], bodyClasses: string[], mobileViewport: boolean): string {
   // body_class filter: always add lib-carry-site; replicate the source body classes
   // (so body-state-gated carried rules behave like the source); add per-page class.
   const sourceBodyCases = bodyClasses
@@ -422,6 +432,26 @@ function functionsPhp(pages: CarryPage[], bodyClasses: string[]): string {
         `    if ( ${pageCondition(p)} ) { wp_enqueue_style( 'lib-carry-page-${p.slug}', get_stylesheet_directory_uri() . '/assets/css/page-${p.slug}.css', array( 'lib-carry-site' ), '1.0.0' ); }`,
     )
     .join('\n');
+
+  // Non-responsive (classic/adaptive) source mobile layout is a FIXED-width canvas (carried
+  // as the .lib-carry-vp-mobile iframe). The source scales it to fill via a width=320 viewport
+  // on mobile user-agents; WordPress's default width=device-width leaves it un-scaled (gap on
+  // wide phones). Mirror the source ONLY for these carries: width=320 on mobile, else
+  // device-width. Core registers _block_template_viewport_meta_tag during template-canvas setup
+  // (AFTER this file loads), so a top-level remove_action misses it — remove it from inside
+  // wp_head at priority -1 (before core's 0), then emit ours.
+  const mobileViewportBlock = mobileViewport
+    ? `
+add_action( 'wp_head', function () {
+    remove_action( 'wp_head', '_block_template_viewport_meta_tag', 0 );
+}, -1 );
+add_action( 'wp_head', function () {
+    echo wp_is_mobile()
+        ? '<meta name="viewport" content="width=320, user-scalable=yes" id="libCarryMobileViewport">' . "\\n"
+        : '<meta name="viewport" content="width=device-width, initial-scale=1">' . "\\n";
+}, 1 );
+`
+    : '';
 
   return `<?php
 add_filter( 'body_class', function( $classes ) {
@@ -443,7 +473,7 @@ add_filter( 'wp_kses_allowed_html', function( $tags, $context ) {
     }
     return $tags;
 }, 10, 2 );
-`;
+${mobileViewportBlock}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -455,6 +485,17 @@ add_filter( 'wp_kses_allowed_html', function( $tags, $context ) {
  * Returns an array of `{path, content}` — the caller writes them to disk.
  */
 export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
+  // Non-responsive (classic/adaptive) Wix carries a FIXED-width mobile canvas as a
+  // .lib-carry-vp-mobile iframe (CarryPage.mobile). Only such carries need the width=320
+  // mobile-viewport swap + the carried-viewport-meta strip; a responsive or non-Wix carry
+  // never sets `mobile`, so its theme stays byte-identical (the "only when necessary" gate).
+  const hasMobileCanvas = input.pages.some((p) => p.mobile);
+  const pages = hasMobileCanvas
+    ? input.pages.map((p) =>
+        p.scaffold ? { ...p, scaffold: { ...p.scaffold, openWrap: stripViewportMeta(p.scaffold.openWrap) } } : p,
+      )
+    : input.pages;
+
   // Block themes do NOT auto-enqueue style.css on the front end — it's only the
   // theme-header file. So the reset must ride the enqueued site.css instead, and
   // it goes FIRST so the carried source CSS overrides it (the reset must lose the
@@ -473,7 +514,7 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
   // otherwise become a grid/flex item of the source layout and displace the
   // carried chrome. `display:contents` makes that wrapper box-less so the real
   // <header>/<footer> stay where the source put them. (No-op when no parts.)
-  const usesScaffold = input.pages.some((p) => p.scaffold);
+  const usesScaffold = pages.some((p) => p.scaffold);
   const CHROME_RESCUE = usesScaffold ? '.wp-block-template-part{display:contents}\n' : '';
 
   // Wix paints every section/page background as DECORATIVE layers — `[data-hook="bgLayers"]`
@@ -588,7 +629,7 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
 
   // index.html (required fallback) reuses the home page's scaffold + chrome so it
   // renders correctly; falls back to the legacy shell when no scaffold exists.
-  const homePage = input.pages.find((p) => p.isHome);
+  const homePage = pages.find((p) => p.isHome);
   const homeSlugs = slugsFor(homePage?.chromeKey ?? input.chromeVariants[0]?.key ?? '');
   const indexTemplate = homePage?.scaffold
     ? scaffoldedTemplate(homePage.scaffold, homeSlugs, homePage.mobile)
@@ -597,7 +638,7 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
   const files: ThemeFile[] = [
     { path: 'style.css', content: styleCssHeader(input.themeName) },
     { path: 'theme.json', content: JSON.stringify(themeJson, null, 2) },
-    { path: 'functions.php', content: functionsPhp(input.pages, input.bodyClasses ?? []) },
+    { path: 'functions.php', content: functionsPhp(pages, input.bodyClasses ?? [], hasMobileCanvas) },
     // Site-wide CSS — reset first (so source rules win the cascade), then the
     // chrome-wrapper rescue, then EVERY variant's carried chrome CSS (concatenated
     // upstream into siteCss; comp-id-scoped so variants never collide).
@@ -615,7 +656,7 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
   // Per-page CSS + template files. Posts share ONE single.html; the per-post body
   // class + enqueued page-<slug>.css still scope each post's carried CSS.
   let emittedSingle = false;
-  for (const p of input.pages) {
+  for (const p of pages) {
     files.push({ path: `assets/css/page-${p.slug}.css`, content: p.pageCss });
     const slugs = slugsFor(p.chromeKey);
     if (p.isHome) {
@@ -636,7 +677,7 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
   // posts (single.html), the posts page (home.html) and date/term archives (archive.html)
   // render properly. index.html is left as the homepage fallback. The carried-post case
   // (posts in the carry set) keeps its own single.html via the loop above.
-  const nativeBlog = input.nativeBlog ?? !input.pages.some((p) => p.postType === 'post');
+  const nativeBlog = input.nativeBlog ?? !pages.some((p) => p.postType === 'post');
   if (nativeBlog) {
     const sc = homePage?.scaffold;
     files.push({ path: 'templates/single.html', content: nativeBlogTemplate(NATIVE_SINGLE_MIDDLE, homeSlugs, sc) });


### PR DESCRIPTION
## What
The carry-and-scope theme reconstruction now reproduces Wix's mobile viewport behavior for **non-responsive (classic/adaptive) Wix** sources, so the carried mobile layout fills the phone instead of leaving a white gap on the right.

## Background
Non-responsive Wix mobile is a fixed **320px canvas**. The live Wix site scales it to fill the screen via a swapped `width=320` viewport (`wixMobileViewport`) plus a `device-mobile-optimized` body class, both driven by Wix's user-agent detection. The carry path renders that canvas as the `.lib-carry-vp-mobile` iframe (`width=320`) but kept WordPress's default `width=device-width`, so on a wider phone the 320px iframe sat un-scaled and left-aligned — a white gap on the right. (Reported on corneliusholmes.com.)

## Change
`buildCarryThemeFiles` now, **only when a page carries the fixed mobile canvas** (`hasMobileCanvas = pages.some(p => p.mobile)`):
- emits a `width=320` viewport on `wp_is_mobile()` (else `width=device-width`), removing core's `_block_template_viewport_meta_tag` from inside `wp_head` at priority `-1` (core registers it during template-canvas setup, after `functions.php` loads, so a top-level `remove_action` misses it);
- strips the carried `<meta name="viewport">` from the scaffold's `openWrap`, since a later in-body meta would otherwise override ours (browsers apply the last one).

## Only when necessary
`CarryPage.mobile` is set exclusively for non-responsive Wix pages that carry the fixed mobile-DOM iframe. Responsive Wix, Shopify, Squarespace, and every other carry never set it, so their generated theme is **byte-identical to before** — locked in by a guard test.

## Testing
- 3 new unit tests in `theme-scaffold-carry.test.ts` (written RED→GREEN): swap emitted + carried meta stripped when a page has a mobile canvas; neither when it does not.
- `npx tsc --noEmit` clean; full `src/lib/replicate` suite (678 tests) and the carry-handler tests pass.
- Verified live on a non-responsive Wix carry (corneliusholmes.com) under real iPhone emulation: mobile viewport is now 320 and the page fills edge-to-edge; desktop unchanged (device-width, 1440 layout).
