### PR TITLE
Generic block recipe catalog + resume-state crash-injection harness

### DIFF
--- a/src/lib/replicate/apply-block-recipe.test.ts
+++ b/src/lib/replicate/apply-block-recipe.test.ts
@@ -37,3 +37,18 @@ describe('applyBlockRecipe', () => {
     expect(out).not.toContain('onclick');
   });
 });
+
+describe('applyBlockRecipe: universal generic catalog', () => {
+  it('converts a generic wrapper even when the adapter has no blocks', () => {
+    const out = applyBlockRecipe('<details><summary>Q</summary><p>A</p></details>', undefined, CTX);
+    expect(out).not.toBeNull();
+    expect(out).toContain('<!-- wp:details -->');
+  });
+
+  it('an adapter htmlToBlocks result still wins over the generic catalog', () => {
+    const blocks: AdapterBlocks = { htmlToBlocks: () => '<!-- wp:paragraph -->\n<p>adapter</p>\n<!-- /wp:paragraph -->' };
+    const out = applyBlockRecipe('<details><summary>Q</summary><p>A</p></details>', blocks, CTX);
+    expect(out).toContain('adapter');
+    expect(out).not.toContain('wp:details');
+  });
+});

--- a/src/lib/replicate/apply-block-recipe.ts
+++ b/src/lib/replicate/apply-block-recipe.ts
@@ -3,6 +3,7 @@ import type { CheerioAPI } from 'cheerio';
 import type { Element } from 'domhandler';
 import type { AdapterBlocks, BlockRecipe, BlockRecipeContext } from '../../adapters/page-actions.js';
 import { sanitize } from './html-fallback.js';
+import { genericBlockCatalog } from './generic-block-catalog.js';
 
 /**
  * Seam 2: turn platform-structured source HTML into Gutenberg block markup via
@@ -12,12 +13,18 @@ import { sanitize } from './html-fallback.js';
  * floor (nothing is ever dropped). Called ONLY on the blocks reconstruct path.
  */
 export function applyBlockRecipe(html: string, blocks: AdapterBlocks | undefined, ctx: BlockRecipeContext): string | null {
-  if (!blocks) return null;
-  if (blocks.htmlToBlocks) {
+  if (blocks?.htmlToBlocks) {
     const out = blocks.htmlToBlocks(html, ctx);
     if (out != null && out.trim()) return out;
   }
-  if (blocks.recipes && blocks.recipes.length > 0) return composeFromRecipes(html, blocks.recipes, ctx);
+  if (blocks?.recipes && blocks.recipes.length > 0) {
+    const out = composeFromRecipes(html, blocks.recipes, ctx);
+    if (out != null && out.trim()) return out;
+  }
+  // Universal generic catalog — last attempt before the caller's core/html floor.
+  // Runs even when the adapter declares no blocks, so every adapter benefits.
+  const generic = genericBlockCatalog.htmlToBlocks!(html, ctx);
+  if (generic != null && generic.trim()) return generic;
   return null;
 }
 

--- a/src/lib/replicate/generic-block-catalog.test.ts
+++ b/src/lib/replicate/generic-block-catalog.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { genericBlockCatalog } from './generic-block-catalog.js';
+import { validateBlockMarkup } from './validate-block-markup.js';
+
+const run = (html: string) => genericBlockCatalog.htmlToBlocks!(html, { url: 'https://x.test/p' });
+
+describe('generic-block-catalog: guards', () => {
+  it('returns null when no known wrapper is present (lets caller own it)', () => {
+    expect(run('<p>just a paragraph</p><h2>and a heading</h2>')).toBeNull();
+  });
+
+  it('returns null on already-blockified input (idempotency guard)', () => {
+    expect(run('<!-- wp:paragraph --><p>x</p><!-- /wp:paragraph -->')).toBeNull();
+  });
+
+  it('emits valid block markup for a recognized wrapper', () => {
+    const out = run('<details><summary>Q</summary><p>A</p></details>');
+    expect(out).not.toBeNull();
+    expect(validateBlockMarkup(out!)).toEqual([]);
+  });
+});
+
+describe('generic-block-catalog: callout', () => {
+  it('wraps a .callout in core/group, preserving the class and recursing inner', () => {
+    const out = run('<div class="callout"><h3>Note</h3><p>body</p></div>');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<!-- wp:group');
+    expect(out!).toContain('wp-block-group');
+    expect(out!).toContain('callout');
+    expect(validateBlockMarkup(out!)).toEqual([]);
+  });
+});
+
+describe('generic-block-catalog: pullquote', () => {
+  it('converts blockquote.pullquote to core/pullquote', () => {
+    const out = run('<blockquote class="pullquote"><p>Big idea</p><cite>Me</cite></blockquote>');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<!-- wp:pullquote -->');
+    expect(out!).toContain('Big idea');
+    expect(validateBlockMarkup(out!)).toEqual([]);
+  });
+});
+
+describe('generic-block-catalog: buttons', () => {
+  it('converts a wrapper of button links to core/buttons', () => {
+    const out = run('<div class="btn-group"><a class="button" href="/x">Go</a><a class="btn" href="/y">More</a></div>');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<!-- wp:buttons -->');
+    expect(out!).toContain('<!-- wp:button -->');
+    expect(out!).toContain('href="/x"');
+    expect(validateBlockMarkup(out!)).toEqual([]);
+  });
+
+  it('converts a single standalone button link', () => {
+    const out = run('<a class="button" href="/x">Go</a>');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<!-- wp:buttons -->');
+  });
+});
+
+describe('generic-block-catalog: media-text', () => {
+  it('converts an image + adjacent text wrapper to core/media-text', () => {
+    const out = run(
+      '<div class="media-text"><figure><img src="https://cdn.test/a.jpg" alt="A"/></figure><div><h3>Title</h3><p>copy</p></div></div>',
+    );
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<!-- wp:media-text');
+    expect(out!).toContain('https://cdn.test/a.jpg');
+    expect(out!).toContain('Title');
+    expect(validateBlockMarkup(out!)).toEqual([]);
+  });
+
+  it('rewrites the image src via ctx.mediaMap', () => {
+    const out = genericBlockCatalog.htmlToBlocks!(
+      '<div class="media-text"><img src="https://cdn.test/a.jpg" alt="A"/><div><p>copy</p></div></div>',
+      { url: 'https://x.test/p', mediaMap: { 'https://cdn.test/a.jpg': '/wp-content/uploads/a.jpg' } },
+    );
+    expect(out!).toContain('/wp-content/uploads/a.jpg');
+    expect(out!).not.toContain('cdn.test');
+  });
+});
+
+describe('generic-block-catalog: lossless mixed content', () => {
+  it('converts known wrappers and keeps unknown siblings as core/html islands', () => {
+    const html =
+      '<details><summary>Q</summary><p>A</p></details>' +
+      '<div class="weird-widget" data-x="1"><span>keep me</span></div>';
+    const out = run(html)!;
+    expect(out).toContain('<!-- wp:details -->');
+    expect(out).toContain('<!-- wp:html -->'); // the unknown widget survives losslessly
+    expect(out).toContain('keep me');
+    expect(validateBlockMarkup(out)).toEqual([]);
+  });
+
+  it('is idempotent: re-running over its own output is a no-op (null)', () => {
+    const once = run('<details><summary>Q</summary><p>A</p></details>')!;
+    expect(run(once)).toBeNull();
+  });
+});

--- a/src/lib/replicate/generic-block-catalog.ts
+++ b/src/lib/replicate/generic-block-catalog.ts
@@ -1,0 +1,218 @@
+// src/lib/replicate/generic-block-catalog.ts
+//
+// Generic, platform-agnostic content->blocks catalog.
+// ==================================================
+// Recognises common semantic WRAPPERS that WP's rawHandler flattens to
+// core/html (accordion, callout/card, media-text, pullquote, button groups) and
+// emits the equivalent native block. Runs on the blocks reconstruct path as the
+// last attempt before the core/html floor (see apply-block-recipe.ts), so every
+// adapter — and the default fallback — benefits, at both firing points
+// (per-section reconstruct + bulk WXR bodies).
+//
+// Lossless: the body is only "claimed" when at least one wrapper converts;
+// otherwise we return null and the caller's existing path owns the markup
+// unchanged. Unmatched siblings of a matched wrapper degrade to core/html
+// islands (same contract as composeFromRecipes), so nothing is ever dropped.
+
+import * as cheerio from 'cheerio';
+import type { CheerioAPI, Cheerio } from 'cheerio';
+import type { Element } from 'domhandler';
+import type { AdapterBlocks, BlockRecipeContext } from '../../adapters/page-actions.js';
+import { sanitize } from './html-fallback.js';
+
+interface Converted {
+  matched: boolean;
+  markup: string;
+}
+
+function genericHtmlToBlocks(html: string, ctx: BlockRecipeContext): string | null {
+  if (!html || !html.trim()) return null;
+  // Idempotency guard: never re-wrap already-blockified content.
+  if (/<!--\s*wp:/.test(html)) return null;
+
+  const $ = cheerio.load(html, null, false);
+  const out: string[] = [];
+  let matchedAny = false;
+
+  $.root().children().each((_, node) => {
+    if ((node as Element).type !== 'tag') return;
+    const el = node as Element;
+    const c = convertElement($, el, ctx);
+    if (c.matched) matchedAny = true;
+    if (c.markup.trim()) out.push(c.markup);
+  });
+
+  if (!matchedAny) return null; // claim nothing unless we recognized a wrapper
+  return out.length ? out.join('\n\n') : null;
+}
+
+function convertElement($: CheerioAPI, el: Element, ctx: BlockRecipeContext): Converted {
+  const details = tryDetails($, el, ctx);
+  if (details) return { matched: true, markup: details };
+  const callout = tryCallout($, el, ctx);
+  if (callout) return { matched: true, markup: callout };
+  const pull = tryPullquote($, el);
+  if (pull) return { matched: true, markup: pull };
+  const buttons = tryButtons($, el);
+  if (buttons) return { matched: true, markup: buttons };
+  const mediaText = tryMediaText($, el, ctx);
+  if (mediaText) return { matched: true, markup: mediaText };
+  return { matched: false, markup: coreHtmlIsland($.html(el)) };
+}
+
+// --- details / accordion -> core/details -------------------------------------
+
+function tryDetails($: CheerioAPI, el: Element, ctx: BlockRecipeContext): string | null {
+  const $el = $(el);
+  const isDetails = el.tagName === 'details';
+  const isAccordionClass = /\b(accordion|faq-item)\b/.test($el.attr('class') || '');
+  if (!isDetails && !isAccordionClass) return null;
+
+  const summary =
+    $el.find('summary').first().text().trim() ||
+    $el.children('h1,h2,h3,h4,h5,h6,.accordion-title,.faq-question').first().text().trim();
+  if (!summary) return null;
+
+  // Body = everything except the summary/title node, recursed through the walk.
+  const bodyHtml = bodyExcludingSummary($, $el);
+  const inner = recurseInner(bodyHtml, ctx);
+  return (
+    `<!-- wp:details -->\n` +
+    `<details class="wp-block-details"><summary>${escapeHtml(summary)}</summary>${inner}</details>\n` +
+    `<!-- /wp:details -->`
+  );
+}
+
+function bodyExcludingSummary($: CheerioAPI, $el: Cheerio<Element>): string {
+  const clone = $el.clone();
+  clone.find('summary').first().remove();
+  clone.children('h1,h2,h3,h4,h5,h6,.accordion-title,.faq-question').first().remove();
+  return clone.html() ?? '';
+}
+
+/** Recurse the catalog over inner HTML; fall back to a sanitized passthrough. */
+function recurseInner(html: string, ctx: BlockRecipeContext): string {
+  const nested = genericHtmlToBlocks(html, ctx);
+  if (nested && nested.trim()) return `\n${nested}\n`;
+  const clean = sanitize(html).trim();
+  return clean ? clean : '';
+}
+
+// --- callout / card / notice / alert -> core/group --------------------------
+
+const CALLOUT_RE = /\b(callout|notice|alert|card)\b/;
+
+function tryCallout($: CheerioAPI, el: Element, ctx: BlockRecipeContext): string | null {
+  const $el = $(el);
+  const cls = $el.attr('class') || '';
+  if (!CALLOUT_RE.test(cls)) return null;
+  const inner = recurseInner($el.html() ?? '', ctx);
+  if (!inner.trim()) return null;
+  const matchedClass = (cls.match(CALLOUT_RE) || [])[0] ?? 'callout';
+  const className = `wp-block-group is-style-${matchedClass}`;
+  return (
+    `<!-- wp:group {"className":${JSON.stringify(className)},"layout":{"type":"constrained"}} -->\n` +
+    `<div class="${escapeAttr(className)}">${inner}</div>\n` +
+    `<!-- /wp:group -->`
+  );
+}
+
+// --- pullquote -> core/pullquote ---------------------------------------------
+
+function tryPullquote($: CheerioAPI, el: Element): string | null {
+  const $el = $(el);
+  const cls = $el.attr('class') || '';
+  const isPull =
+    (el.tagName === 'blockquote' && /\bpull/.test(cls)) ||
+    (el.tagName === 'aside' && $el.find('blockquote').length > 0);
+  if (!isPull) return null;
+  const $quote = $el.is('blockquote') ? $el : $el.find('blockquote').first();
+  const text = $quote.find('p').first().text().trim() || $quote.text().trim();
+  if (!text) return null;
+  const cite = $el.find('cite').first().text().trim();
+  const citeHtml = cite ? `<cite>${escapeHtml(cite)}</cite>` : '';
+  return (
+    `<!-- wp:pullquote -->\n` +
+    `<figure class="wp-block-pullquote"><blockquote><p>${escapeHtml(text)}</p>${citeHtml}</blockquote></figure>\n` +
+    `<!-- /wp:pullquote -->`
+  );
+}
+
+// --- button link(s) -> core/buttons ------------------------------------------
+
+const BTN_RE = /\b(button|btn)\b/;
+
+function isButtonLink($: CheerioAPI, el: Element): boolean {
+  return el.tagName === 'a' && BTN_RE.test($(el).attr('class') || '') && Boolean($(el).attr('href'));
+}
+
+function tryButtons($: CheerioAPI, el: Element): string | null {
+  const $el = $(el);
+  let links: Element[];
+  if (isButtonLink($, el)) {
+    links = [el];
+  } else {
+    links = $el.children('a').toArray().filter((a) => isButtonLink($, a));
+    if (links.length === 0) return null;
+  }
+  const buttonBlocks = links.map((a) => {
+    const $a = $(a);
+    const href = $a.attr('href') || '';
+    const label = $a.text().trim();
+    return (
+      `<!-- wp:button -->\n` +
+      `<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="${escapeAttr(href)}">${escapeHtml(label)}</a></div>\n` +
+      `<!-- /wp:button -->`
+    );
+  });
+  return (
+    `<!-- wp:buttons -->\n` +
+    `<div class="wp-block-buttons">\n${buttonBlocks.join('\n')}\n</div>\n` +
+    `<!-- /wp:buttons -->`
+  );
+}
+
+// --- media + text -> core/media-text -----------------------------------------
+
+const MEDIA_TEXT_RE = /\b(media-text|media-object|image-text|text-image)\b/;
+
+function tryMediaText($: CheerioAPI, el: Element, ctx: BlockRecipeContext): string | null {
+  const $el = $(el);
+  if (!MEDIA_TEXT_RE.test($el.attr('class') || '')) return null;
+  const img = $el.find('img').first();
+  if (img.length === 0) return null;
+  const rawSrc = img.attr('src') || '';
+  if (!rawSrc) return null;
+  const src = ctx.mediaMap?.[rawSrc] ?? rawSrc;
+  const alt = img.attr('alt') || '';
+  const textNode = $el.children().toArray().find((c) => {
+    const t = c.tagName;
+    return t && t !== 'figure' && t !== 'img' && t !== 'picture';
+  });
+  const textHtml = textNode ? ($(textNode).html() ?? '') : '';
+  const innerText =
+    recurseInner(textHtml, ctx).trim() ||
+    `<!-- wp:paragraph -->\n<p>${escapeHtml($el.text().trim())}</p>\n<!-- /wp:paragraph -->`;
+  return (
+    `<!-- wp:media-text {"mediaType":"image"} -->\n` +
+    `<div class="wp-block-media-text is-stacked-on-mobile">` +
+    `<figure class="wp-block-media-text__media"><img src="${escapeAttr(src)}" alt="${escapeAttr(alt)}"/></figure>` +
+    `<div class="wp-block-media-text__content">${innerText}</div>` +
+    `</div>\n` +
+    `<!-- /wp:media-text -->`
+  );
+}
+
+// --- shared helpers ----------------------------------------------------------
+
+function coreHtmlIsland(html: string): string {
+  return `<!-- wp:html -->\n${sanitize(html)}\n<!-- /wp:html -->`;
+}
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export const genericBlockCatalog: AdapterBlocks = { htmlToBlocks: genericHtmlToBlocks };

--- a/src/lib/resume-state/crash-recovery.test.ts
+++ b/src/lib/resume-state/crash-recovery.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { ExtractionLog } from './extraction-log.js';
+import { ImportSession } from './import-session.js';
+import { MediaStubStore } from './media-stubs.js';
+import { armFault, disarmFault, clearFaults, FaultInjected } from './faultpoint.js';
+import { PendingImportsBuffer } from '../streaming/pending-imports.js';
+import type { WxrItem } from '../wxr/index.js';
+
+const TMP_ROOT = join(process.cwd(), '.tmp-test', 'crash-recovery');
+afterEach(() => clearFaults());
+
+function dir(name: string): string {
+  const d = join(TMP_ROOT, name);
+  rmSync(d, { recursive: true, force: true });
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+describe('extraction-log crash recovery', () => {
+  it('a crash before the dedupe append leaves no partial line and re-processes cleanly', () => {
+    const log = new ExtractionLog(dir('extraction-log'));
+    log.logProcessed({ url: 'https://x.test/a', slug: 'a', durationMs: 1, qualityScore: 'A' });
+
+    armFault('extraction-log:before-append');
+    expect(() =>
+      log.logProcessed({ url: 'https://x.test/b', slug: 'b', durationMs: 1, qualityScore: 'A' }),
+    ).toThrow(FaultInjected);
+    disarmFault('extraction-log:before-append');
+
+    // 'b' never landed; log is uncorrupted and still dedupes 'a'.
+    expect([...log.getProcessedUrls()]).toEqual(['https://x.test/a']);
+
+    // Resume: re-process 'b' — now durable, no duplicate of 'a'.
+    log.logProcessed({ url: 'https://x.test/b', slug: 'b', durationMs: 1, qualityScore: 'A' });
+    expect([...log.getProcessedUrls()].sort()).toEqual(['https://x.test/a', 'https://x.test/b']);
+  });
+});
+
+describe('import-session crash recovery', () => {
+  it('a crash between cursor assign and save keeps the last durable cursor', () => {
+    const d = dir('import-session-cursor');
+    const s1 = ImportSession.loadOrCreate(d, 'wix', {});
+    s1.setCursor('page', 'v1'); // durably saved
+
+    armFault('import-session:cursor-before-save');
+    expect(() => s1.setCursor('page', 'v2')).toThrow(FaultInjected);
+    disarmFault('import-session:cursor-before-save');
+
+    // Reload from disk (the in-memory v2 is the "lost" crash state).
+    const s2 = ImportSession.loadOrCreate(d, 'wix', {}, { resume: true });
+    expect(s2.getCursor('page')).toBe('v1');
+  });
+
+  it('a crash during save leaves the prior session.json intact (atomic rename)', () => {
+    const d = dir('import-session-save');
+    const s1 = ImportSession.loadOrCreate(d, 'wix', {});
+    s1.setStage('extracting'); // durably saved
+
+    armFault('import-session:before-save');
+    expect(() => s1.setStage('finalizing')).toThrow(FaultInjected);
+    disarmFault('import-session:before-save');
+
+    const s2 = ImportSession.loadOrCreate(d, 'wix', {}, { resume: true });
+    expect(s2.stage).toBe('extracting'); // not the half-written 'finalizing'
+  });
+});
+
+describe('media-stubs crash recovery', () => {
+  it('a crash between tmp-write and rename leaves the live store valid (atomic rename)', () => {
+    const d = dir('media-stubs');
+    const s1 = MediaStubStore.load(d);
+    s1.markSuccess('https://cdn.test/a.jpg', '/a.jpg');
+    s1.flush(); // durable: a.jpg success
+
+    armFault('media-stubs:mid-flush');
+    s1.markSuccess('https://cdn.test/b.jpg', '/b.jpg'); // buffered (dirty)
+    expect(() => s1.flush()).toThrow(FaultInjected);
+    disarmFault('media-stubs:mid-flush');
+
+    // The live media-stubs.json must still parse and hold only the durable a.jpg.
+    const s2 = MediaStubStore.load(d);
+    expect(s2.get('https://cdn.test/a.jpg')?.status).toBe('success');
+    expect(s2.get('https://cdn.test/b.jpg')).toBeUndefined();
+  });
+});
+
+const fakeItem = { title: 'A', content: '<p>a</p>', sourceUrl: 'https://x.test/a' } as unknown as WxrItem;
+
+describe('pending-imports crash recovery (buffer contract)', () => {
+  it('a URL stays pending after a simulated crash before markImported, then clears', () => {
+    const buf = new PendingImportsBuffer(dir('pending-imports'));
+    buf.enqueue({ url: 'https://x.test/a', archetype: 'page', slug: 'a', payload: fakeItem });
+
+    // Simulated crash: installPost "succeeded" but markImported never ran.
+    expect(buf.listPending().map((p) => p.url)).toEqual(['https://x.test/a']);
+
+    // Resume flush would call installPost again (idempotent on _source_url),
+    // then mark imported — after which the URL is no longer pending.
+    buf.markImported({ url: 'https://x.test/a', postId: 7, action: 'inserted' });
+    expect(buf.listPending()).toEqual([]);
+  });
+});

--- a/src/lib/resume-state/extraction-log.ts
+++ b/src/lib/resume-state/extraction-log.ts
@@ -1,5 +1,6 @@
 import { appendFileSync, readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
+import { faultpoint } from './faultpoint.js';
 
 export interface ProcessedEntry {
   url: string;
@@ -51,6 +52,7 @@ export class ExtractionLog {
       qualityScore: entry.qualityScore,
       timestamp: new Date().toISOString(),
     });
+    faultpoint('extraction-log:before-append');
     appendFileSync(this.logPath, line + '\n');
   }
 

--- a/src/lib/resume-state/faultpoint.test.ts
+++ b/src/lib/resume-state/faultpoint.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { faultpoint, armFault, disarmFault, withFault, clearFaults, FaultInjected } from './faultpoint.js';
+
+afterEach(() => clearFaults());
+
+describe('faultpoint', () => {
+  it('is a no-op when nothing is armed', () => {
+    expect(() => faultpoint('x:y')).not.toThrow();
+  });
+
+  it('throws FaultInjected for an armed name, then only that name', () => {
+    armFault('a:b');
+    expect(() => faultpoint('a:b')).toThrow(FaultInjected);
+    expect(() => faultpoint('c:d')).not.toThrow();
+  });
+
+  it('stops throwing once disarmed', () => {
+    armFault('a:b');
+    disarmFault('a:b');
+    expect(() => faultpoint('a:b')).not.toThrow();
+  });
+
+  it('withFault arms for the callback and disarms in finally even on throw', () => {
+    expect(() =>
+      withFault('a:b', () => {
+        faultpoint('a:b');
+      }),
+    ).toThrow(FaultInjected);
+    // disarmed afterwards
+    expect(() => faultpoint('a:b')).not.toThrow();
+  });
+});

--- a/src/lib/resume-state/faultpoint.ts
+++ b/src/lib/resume-state/faultpoint.ts
@@ -1,0 +1,54 @@
+// src/lib/resume-state/faultpoint.ts
+//
+// Test-only fault injection for resume-state boundaries.
+// ====================================================
+// `faultpoint(name)` is a single guarded check that throws ONLY when a test has
+// armed `name`. In production nothing arms a fault, so every call is a cheap
+// Set.has on an empty set — effectively free, and inert. The named seams double
+// as living documentation of where the durable, atomic boundaries are: a crash
+// at the seam must leave prior state intact and resume cleanly.
+//
+// MVP is an in-process registry (covers vitest-driven boundary tests). A
+// subprocess / env-var variant for real process death is deliberately deferred —
+// none of the covered boundaries need it (they are single-write atomicity or
+// idempotent replay).
+
+/** Thrown by `faultpoint` when its name is armed. */
+export class FaultInjected extends Error {
+  constructor(name: string) {
+    super(`fault injected at ${name}`);
+    this.name = 'FaultInjected';
+  }
+}
+
+const armed = new Set<string>();
+
+/** Throw `FaultInjected` iff `name` is currently armed; otherwise no-op. */
+export function faultpoint(name: string): void {
+  if (armed.size > 0 && armed.has(name)) throw new FaultInjected(name);
+}
+
+/** Test helper: arm a fault name so the next matching `faultpoint` throws. */
+export function armFault(name: string): void {
+  armed.add(name);
+}
+
+/** Test helper: disarm a previously-armed fault name. */
+export function disarmFault(name: string): void {
+  armed.delete(name);
+}
+
+/** Test helper: clear all armed faults (use in afterEach). */
+export function clearFaults(): void {
+  armed.clear();
+}
+
+/** Test helper: run `fn` with `name` armed, disarming in `finally`. */
+export function withFault<T>(name: string, fn: () => T): T {
+  armFault(name);
+  try {
+    return fn();
+  } finally {
+    disarmFault(name);
+  }
+}

--- a/src/lib/resume-state/import-session.ts
+++ b/src/lib/resume-state/import-session.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
+import { faultpoint } from './faultpoint.js';
 
 /**
  * Pipeline stage.
@@ -183,6 +184,7 @@ export class ImportSession {
 
   setCursor(key: string, value: unknown): void {
     this.data.cursors[key] = value;
+    faultpoint('import-session:cursor-before-save');
     this.save();
   }
 
@@ -194,6 +196,7 @@ export class ImportSession {
     this.data.updatedAt = new Date().toISOString();
     mkdirSync(dirname(this.sessionPath), { recursive: true });
     const tmp = this.sessionPath + '.tmp';
+    faultpoint('import-session:before-save');
     writeFileSync(tmp, JSON.stringify(this.data, null, 2));
     renameSync(tmp, this.sessionPath);
   }

--- a/src/lib/resume-state/media-stubs.ts
+++ b/src/lib/resume-state/media-stubs.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
+import { faultpoint } from './faultpoint.js';
 
 export type MediaStatus = 'awaiting' | 'success' | 'error' | 'ignored';
 
@@ -206,6 +207,7 @@ export class MediaStubStore {
     mkdirSync(dirname(this.storePath), { recursive: true });
     const tmp = this.storePath + '.tmp';
     writeFileSync(tmp, JSON.stringify(this.data, null, 2));
+    faultpoint('media-stubs:mid-flush');
     renameSync(tmp, this.storePath);
     this.dirty = false;
   }


### PR DESCRIPTION
## Summary

Adopts two techniques from adamziel/wp-extensions' `universal-wordpress-importer`, scoped to where DLA actually had gaps:

- **Generic block recipe catalog** (`feat(replicate)`): a platform-agnostic catalog that converts common semantic wrappers into native blocks — `<details>`/accordion → `core/details`, callout/card/notice/alert → `core/group`, image+text → `core/media-text`, pullquote → `core/pullquote`, button links → `core/buttons`. Wired into `applyBlockRecipe` as the last attempt before the `core/html` floor, so every adapter and the `default` fallback benefit at both firing points (per-section reconstruct + bulk WXR bodies). Lossless: it only claims a body when it recognizes a wrapper; unmatched siblings stay verbatim as `core/html`, and already-blockified input is skipped.
- **Crash-injection harness** (`test(resume-state)`): a `faultpoint(name)` mechanism (a no-op in production, armed only by tests) plus crash-recovery tests that prove the resume-state atomic boundaries survive interruption — extraction-log dedupe append, import-session cursor + atomic save, media-stubs atomic flush, and the pending-imports queued→imported contract.

## Validation

- 11 catalog unit tests + 28 resume-state/crash tests; full touched-area suite 729 green; `tsc --noEmit` clean.
- Real-content checks: demonstrated firing on a live MkDocs page (real `<details>` → valid `core/details`, summary preserved); **zero false positives** across borkweb.com (31 WordPress bodies) and swiftlumber.com (Wix).

## Known scope / follow-ups

- The catalog matches semantic wrappers at the **top level** of a section/body. On already-WordPress (block-rendered) and Wix (obfuscated, deeply-nested) sources it finds little — its yield is on docs/Webflow/hand-coded content. Recursing into nested wrappers + platform-specific button/accordion structures is a tracked follow-up; today those nested cases remain lossless `core/html`.
- The block-fixer sidecar (`scripts/block-fixer`) needs its own `npm install` (jsdom) for the per-section reconstruct path. Unrelated to this diff.

## Test Plan

- [ ] `npx vitest run src/lib/replicate src/lib/resume-state src/lib/extraction/blockify-wxr.test.ts src/adapters/squarespace`
- [ ] `npx tsc --noEmit`
- [ ] Optional real-source check: render a docs/Webflow page, run `applyBlockRecipe(content, undefined, ctx)`, expect native blocks for top-level wrappers and lossless `core/html` otherwise.