### PR TITLE
feat(replicate): convert provider iframes to native core/embed

### DIFF
--- a/src/adapters/squarespace/blocks.test.ts
+++ b/src/adapters/squarespace/blocks.test.ts
@@ -106,6 +106,17 @@ describe('squarespace blocks recipe (htmlToBlocks)', () => {
     expect(out).toContain('wp-block-embed-youtube');
   });
 
+  it('emits a rich (not video) embed for a Twitter/X embed-block', () => {
+    const html = `
+      <div class="sqs-block embed-block">
+        <iframe src="https://twitter.com/a/status/1"></iframe>
+      </div>`;
+    const out = toBlocks(html);
+    expect(out).toContain('"providerNameSlug":"twitter"');
+    expect(out).toContain('"type":"rich"');
+    expect(out).not.toContain('wp-embed-aspect');
+  });
+
   it('drops spacer-block entirely', () => {
     const html = `
       <div class="sqs-block image-block">

--- a/src/adapters/squarespace/blocks.ts
+++ b/src/adapters/squarespace/blocks.ts
@@ -36,6 +36,7 @@ import type { CheerioAPI, Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 import type { AdapterBlocks, BlockRecipeContext } from '../page-actions.js';
 import { sanitize } from '../../lib/replicate/html-fallback.js';
+import { buildEmbedBlock } from '../../lib/replicate/embed-block.js';
 
 const SQS_BLOCK_MARKER = /\bsqs-block\b/;
 
@@ -120,29 +121,9 @@ function emitEmbed(_$: CheerioAPI, node: Cheerio<Element>): string | null {
   const iframe = node.find('iframe').first();
   const url = iframe.attr('src') || node.find('a[href]').first().attr('href') || '';
   if (!/^https?:\/\//.test(url)) return null;
-  const provider = guessEmbedProvider(url);
-  // The url sits inside the block-comment JSON, so it must be JSON-escaped, NOT
-  // HTML-escaped — escapeAttr would turn `?a=1&b=2` into `&amp;`, which json_decode
-  // reads literally and breaks oEmbed resolution. JSON.stringify emits the quotes.
-  const attrs = provider
-    ? `{"url":${JSON.stringify(url)},"type":"video","providerNameSlug":"${provider}","responsive":true}`
-    : `{"url":${JSON.stringify(url)},"responsive":true}`;
-  return (
-    `<!-- wp:embed ${attrs} -->\n` +
-    `<figure class="wp-block-embed${provider ? ` is-provider-${provider} wp-block-embed-${provider}` : ''} wp-embed-aspect-16-9 wp-has-aspect-ratio">` +
-    `<div class="wp-block-embed__wrapper">\n${url}\n</div></figure>\n` +
-    `<!-- /wp:embed -->`
-  );
-}
-
-function guessEmbedProvider(url: string): string | null {
-  if (/youtube\.com|youtu\.be/i.test(url)) return 'youtube';
-  if (/vimeo\.com/i.test(url)) return 'vimeo';
-  if (/twitter\.com|x\.com/i.test(url)) return 'twitter';
-  if (/instagram\.com/i.test(url)) return 'instagram';
-  if (/soundcloud\.com/i.test(url)) return 'soundcloud';
-  if (/spotify\.com/i.test(url)) return 'spotify';
-  return null;
+  // Provider detection + embed markup are shared with the generic block catalog
+  // (src/lib/replicate/embed-block.ts) so coverage stays in one place.
+  return buildEmbedBlock(url);
 }
 
 function emitQuote(_$: CheerioAPI, node: Cheerio<Element>): string | null {

--- a/src/lib/replicate/embed-block.test.ts
+++ b/src/lib/replicate/embed-block.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { guessEmbedProvider, buildEmbedBlock } from './embed-block.js';
+
+describe('guessEmbedProvider', () => {
+  it('maps known video providers to their slug', () => {
+    expect(guessEmbedProvider('https://www.youtube.com/watch?v=abc')).toBe('youtube');
+    expect(guessEmbedProvider('https://youtu.be/abc')).toBe('youtube');
+    expect(guessEmbedProvider('https://player.vimeo.com/video/123')).toBe('vimeo');
+    expect(guessEmbedProvider('https://www.dailymotion.com/video/x1')).toBe('dailymotion');
+  });
+
+  it('maps known rich providers to their slug', () => {
+    expect(guessEmbedProvider('https://twitter.com/a/status/1')).toBe('twitter');
+    expect(guessEmbedProvider('https://www.instagram.com/p/abc/')).toBe('instagram');
+    expect(guessEmbedProvider('https://www.facebook.com/x/posts/1')).toBe('facebook');
+    expect(guessEmbedProvider('https://www.tiktok.com/@a/video/1')).toBe('tiktok');
+    expect(guessEmbedProvider('https://soundcloud.com/a/b')).toBe('soundcloud');
+    expect(guessEmbedProvider('https://open.spotify.com/track/1')).toBe('spotify');
+  });
+
+  it('treats x.com as twitter', () => {
+    expect(guessEmbedProvider('https://x.com/a/status/1')).toBe('twitter');
+  });
+
+  it('returns null for an unknown provider', () => {
+    expect(guessEmbedProvider('https://maps.example.com/embed?pb=1')).toBeNull();
+  });
+});
+
+describe('buildEmbedBlock', () => {
+  it('emits a video embed with 16:9 aspect classes for youtube', () => {
+    const out = buildEmbedBlock('https://www.youtube.com/embed/abc');
+    expect(out).toContain('<!-- wp:embed');
+    expect(out).toContain('"type":"video"');
+    expect(out).toContain('"providerNameSlug":"youtube"');
+    expect(out).toContain('"responsive":true');
+    expect(out).toContain('is-provider-youtube');
+    expect(out).toContain('wp-block-embed-youtube');
+    expect(out).toContain('wp-embed-aspect-16-9');
+    expect(out).toContain('wp-has-aspect-ratio');
+    expect(out).toContain('https://www.youtube.com/embed/abc');
+    expect(out).toContain('<!-- /wp:embed -->');
+  });
+
+  it('emits a rich embed without aspect-ratio classes for twitter', () => {
+    const out = buildEmbedBlock('https://twitter.com/a/status/1');
+    expect(out).toContain('"type":"rich"');
+    expect(out).toContain('"providerNameSlug":"twitter"');
+    expect(out).not.toContain('wp-embed-aspect');
+    expect(out).not.toContain('wp-has-aspect-ratio');
+  });
+
+  it('emits a lossless generic embed for an unknown provider', () => {
+    const url = 'https://widgets.example.com/embed/xyz';
+    const out = buildEmbedBlock(url);
+    expect(out).toContain('<!-- wp:embed');
+    expect(out).toContain(`"url":"${url}"`);
+    expect(out).toContain('"responsive":true');
+    expect(out).not.toContain('"type"');
+    expect(out).not.toContain('providerNameSlug');
+    expect(out).not.toContain('wp-embed-aspect');
+    expect(out).toContain(url);
+  });
+});

--- a/src/lib/replicate/embed-block.ts
+++ b/src/lib/replicate/embed-block.ts
@@ -1,0 +1,75 @@
+// src/lib/replicate/embed-block.ts
+//
+// Shared, platform-agnostic embed helpers. Given a URL, identify the oEmbed
+// provider and emit native `core/embed` block markup. Used by BOTH the
+// Squarespace adapter recipe (`adapters/squarespace/blocks.ts`) and the generic
+// block catalog (`generic-block-catalog.ts`, iframe -> embed), so provider
+// coverage and block markup live in exactly one place.
+
+type EmbedType = 'video' | 'rich';
+
+interface ProviderDef {
+  slug: string;
+  type: EmbedType;
+  match: RegExp;
+}
+
+// Recognised oEmbed providers. `video` providers get the 16:9 aspect-ratio
+// classes WordPress applies to fixed-ratio video embeds; `rich` providers
+// (social posts, audio) size themselves and get no aspect classes.
+const PROVIDERS: ProviderDef[] = [
+  { slug: 'youtube', type: 'video', match: /youtube\.com|youtu\.be/i },
+  { slug: 'vimeo', type: 'video', match: /vimeo\.com/i },
+  { slug: 'dailymotion', type: 'video', match: /dailymotion\.com|dai\.ly/i },
+  { slug: 'twitter', type: 'rich', match: /twitter\.com|x\.com/i },
+  { slug: 'instagram', type: 'rich', match: /instagram\.com/i },
+  { slug: 'facebook', type: 'rich', match: /facebook\.com|fb\.watch/i },
+  { slug: 'tiktok', type: 'rich', match: /tiktok\.com/i },
+  { slug: 'soundcloud', type: 'rich', match: /soundcloud\.com/i },
+  { slug: 'spotify', type: 'rich', match: /spotify\.com/i },
+];
+
+function providerDef(url: string): ProviderDef | null {
+  for (const p of PROVIDERS) {
+    if (p.match.test(url)) return p;
+  }
+  return null;
+}
+
+/** Identify the oEmbed provider slug for a URL, or null when unrecognised. */
+export function guessEmbedProvider(url: string): string | null {
+  return providerDef(url)?.slug ?? null;
+}
+
+/**
+ * Build native `core/embed` block markup for a URL. When the provider is known,
+ * the block carries its `type`/`providerNameSlug` and (for video) 16:9 aspect
+ * classes. An unknown URL still produces a valid, responsive embed block with no
+ * provider hint — a lossless upgrade over leaving a raw iframe in a core/html
+ * island.
+ *
+ * The URL sits inside the block-comment JSON, so it is JSON-escaped (NOT
+ * HTML-escaped): `escapeAttr` would turn `?a=1&b=2` into `&amp;`, which
+ * `json_decode` reads literally and breaks oEmbed resolution. `JSON.stringify`
+ * emits the surrounding quotes.
+ */
+export function buildEmbedBlock(url: string): string {
+  const def = providerDef(url);
+  const isVideo = def?.type === 'video';
+
+  const attrParts = [`"url":${JSON.stringify(url)}`];
+  if (def) attrParts.push(`"type":"${def.type}"`);
+  if (def) attrParts.push(`"providerNameSlug":"${def.slug}"`);
+  attrParts.push('"responsive":true');
+  const attrs = `{${attrParts.join(',')}}`;
+
+  const providerClasses = def ? ` is-provider-${def.slug} wp-block-embed-${def.slug}` : '';
+  const aspectClasses = isVideo ? ' wp-embed-aspect-16-9 wp-has-aspect-ratio' : '';
+
+  return (
+    `<!-- wp:embed ${attrs} -->\n` +
+    `<figure class="wp-block-embed${providerClasses}${aspectClasses}">` +
+    `<div class="wp-block-embed__wrapper">\n${url}\n</div></figure>\n` +
+    `<!-- /wp:embed -->`
+  );
+}

--- a/src/lib/replicate/generic-block-catalog.test.ts
+++ b/src/lib/replicate/generic-block-catalog.test.ts
@@ -97,3 +97,38 @@ describe('generic-block-catalog: lossless mixed content', () => {
     expect(run(once)).toBeNull();
   });
 });
+
+describe('generic-block-catalog: embeds (iframe -> core/embed)', () => {
+  it('converts a top-level provider iframe to core/embed', () => {
+    const out = run('<iframe src="https://www.youtube.com/embed/abc"></iframe>');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<!-- wp:embed');
+    expect(out!).toContain('"providerNameSlug":"youtube"');
+    expect(out!).toContain('wp-block-embed-youtube');
+    expect(validateBlockMarkup(out!)).toEqual([]);
+  });
+
+  it('converts a figure wrapping a provider iframe to core/embed', () => {
+    const out = run('<figure><iframe src="https://player.vimeo.com/video/1"></iframe></figure>');
+    expect(out).not.toBeNull();
+    expect(out!).toContain('<!-- wp:embed');
+    expect(out!).toContain('"providerNameSlug":"vimeo"');
+    expect(validateBlockMarkup(out!)).toEqual([]);
+  });
+
+  it('does not claim an unknown-provider iframe (leaves it for the caller)', () => {
+    expect(run('<iframe src="https://maps.example.com/embed?pb=1"></iframe>')).toBeNull();
+  });
+
+  it('does not swallow a paragraph that contains an iframe alongside real text', () => {
+    expect(run('<p>Watch <iframe src="https://www.youtube.com/embed/abc"></iframe> here</p>')).toBeNull();
+  });
+
+  it('is idempotent: skips input that already contains a wp:embed', () => {
+    const embedded =
+      '<!-- wp:embed {"url":"https://www.youtube.com/embed/abc","providerNameSlug":"youtube","responsive":true} -->\n' +
+      '<figure class="wp-block-embed"><div class="wp-block-embed__wrapper">https://www.youtube.com/embed/abc</div></figure>\n' +
+      '<!-- /wp:embed -->';
+    expect(run(embedded)).toBeNull();
+  });
+});

--- a/src/lib/replicate/generic-block-catalog.ts
+++ b/src/lib/replicate/generic-block-catalog.ts
@@ -19,6 +19,7 @@ import type { CheerioAPI, Cheerio } from 'cheerio';
 import type { Element } from 'domhandler';
 import type { AdapterBlocks, BlockRecipeContext } from '../../adapters/page-actions.js';
 import { sanitize } from './html-fallback.js';
+import { guessEmbedProvider, buildEmbedBlock } from './embed-block.js';
 
 interface Converted {
   matched: boolean;
@@ -47,6 +48,10 @@ function genericHtmlToBlocks(html: string, ctx: BlockRecipeContext): string | nu
 }
 
 function convertElement($: CheerioAPI, el: Element, ctx: BlockRecipeContext): Converted {
+  // Embeds run first: a provider iframe is often wrapped in a figure/div that a
+  // later recipe (callout/media-text) could otherwise mis-claim.
+  const embed = tryEmbed($, el);
+  if (embed) return { matched: true, markup: embed };
   const details = tryDetails($, el, ctx);
   if (details) return { matched: true, markup: details };
   const callout = tryCallout($, el, ctx);
@@ -58,6 +63,38 @@ function convertElement($: CheerioAPI, el: Element, ctx: BlockRecipeContext): Co
   const mediaText = tryMediaText($, el, ctx);
   if (mediaText) return { matched: true, markup: mediaText };
   return { matched: false, markup: coreHtmlIsland($.html(el)) };
+}
+
+// --- provider iframe -> core/embed -------------------------------------------
+
+const EMBED_WRAPPER_TAGS = new Set(['figure', 'div', 'p', 'span']);
+
+function tryEmbed($: CheerioAPI, el: Element): string | null {
+  const $el = $(el);
+  let src: string | undefined;
+
+  if (el.tagName === 'iframe') {
+    src = $el.attr('src');
+  } else if (EMBED_WRAPPER_TAGS.has(el.tagName)) {
+    const iframes = $el.find('iframe');
+    if (iframes.length !== 1) return null;
+    // Only claim a thin wrapper around the iframe. If the wrapper carries its
+    // own text (e.g. a paragraph that merely contains an iframe), leave it for
+    // the caller so nothing is swallowed.
+    const clone = $el.clone();
+    clone.find('iframe').remove();
+    if (clone.text().trim()) return null;
+    src = iframes.first().attr('src');
+  } else {
+    return null;
+  }
+
+  if (!src || !/^https?:\/\//i.test(src)) return null;
+  // Known providers only: an unrecognised iframe is left untouched so the
+  // working embed survives (as a core/html island) rather than becoming a
+  // broken oEmbed that resolves to nothing.
+  if (!guessEmbedProvider(src)) return null;
+  return buildEmbedBlock(src);
 }
 
 // --- details / accordion -> core/details -------------------------------------


### PR DESCRIPTION
## Summary
Adds a generic iframe → `core/embed` recipe to the block-recipe catalog (#74) so any adapter — Wix, Webflow, the `default` fallback, and bulk WXR blog bodies via `liberate_blockify_wxr` — upgrades a known-provider iframe into a native, editable, responsive `core/embed` instead of a frozen `core/html` island. Provider detection + embed markup are extracted into a shared module the Squarespace adapter now reuses.

## Background
Came out of a survey of `alleyinteractive/wp-block-converter` and `tellyworth/universal-importer` for anything worth porting. Conclusion: ~90% redundant with DLA's existing `rawHandler` usage (the library's own docstring says it "mirrors rawHandler"); MS-Word cleanup is irrelevant to our sources and image sideloading we already do. Embeds were the one genuinely additive idea.

Verified facts that motivate this:
- `rawHandler` does not convert `<iframe>` to `core/embed` — iframes become `wp:html` residue and fall through.
- The reconstruct-path sanitizer (`html-fallback.sanitize`) does not strip iframes, so a provider iframe currently lands as a frozen, non-editable `wp:html` island (or is dropped by structured-render's media-first rule).
- The embed logic already existed but was locked inside the Squarespace adapter.

## Changes
- New `src/lib/replicate/embed-block.ts` — shared `guessEmbedProvider` + `buildEmbedBlock` (9 providers; video → 16:9 aspect classes, rich → none).
- `generic-block-catalog.ts` — `tryEmbed` runs first in `convertElement`, gated to known providers only (unknown iframes left untouched → lossless).
- `squarespace/blocks.ts` — refactored onto the shared helper (net −12 lines). Fixes a latent bug: it hardcoded `type:"video"` + 16:9 for every provider, so twitter/instagram are now correctly `type:"rich"`.

## Testing
- `tsc --noEmit` clean
- Full suite: 2072 passed / 1 skipped / 0 failed
- TDD throughout (new module, catalog recipe, and the twitter `rich` fix each driven by a failing test first)

## Known limitation
The recipe fires only where `applyBlockRecipe` runs: bulk WXR bodies (clearest beneficiary, e.g. a blog post with a YouTube embed) and coverage-lost sections. A section where structured-render silently drops an iframe without tripping the text/image coverage gate may not reach it — a separate pipeline-gating concern, intentionally not addressed here.
