### PR TITLE
fix(carry): style chrome on block-rendered WooCommerce pages

### DIFF
--- a/src/lib/replicate/theme-scaffold-carry.test.ts
+++ b/src/lib/replicate/theme-scaffold-carry.test.ts
@@ -423,6 +423,30 @@ describe('buildCarryThemeFiles — WooCommerce store templates', () => {
     expect(find(files, 'templates/single-product.html')).toBeUndefined();
     expect(find(files, 'templates/archive-product.html')).toBeUndefined();
   });
+
+  it('reapplies the donor page class + CSS on is_woocommerce() contexts so block-rendered store pages get the carried chrome styling', () => {
+    // Block-rendered single-product / archive-product templates have no carried island, so they
+    // never match an is_page()/is_front_page() branch. The donor page (whose island the store
+    // header was carved from) holds the header's full styling in its per-page CSS — reapply it.
+    const files = buildCarryThemeFiles({
+      ...base,
+      pages: [
+        page({ slug: 'home', isHome: true, pageCss: '' }),
+        page({ slug: 'about', isHome: false, pageCss: 'body.lib-carry-page-about{}' }),
+      ],
+      hasProducts: true,
+      storeHeaderIsland: STORE_HEADER,
+      storeChromeDonorSlug: 'about',
+    });
+    const fn = find(files, 'functions.php')!;
+    expect(fn).toMatch(/is_woocommerce\(\)[^\n]*\$classes\[\] = 'lib-carry-page-about'/);
+    expect(fn).toMatch(/is_woocommerce\(\)[^\n]*wp_enqueue_style\( 'lib-carry-page-about'[^\n]*page-about\.css/);
+  });
+
+  it('omits the is_woocommerce() reapply branch when no store-header donor was isolated (back-compat)', () => {
+    const fn = find(buildCarryThemeFiles({ ...base, hasProducts: true, storeHeaderIsland: STORE_HEADER }), 'functions.php')!;
+    expect(fn).not.toContain('is_woocommerce');
+  });
 });
 
 describe('buildCarryThemeFiles — mobile viewport scaling (non-responsive Wix only)', () => {

--- a/src/lib/replicate/theme-scaffold-carry.ts
+++ b/src/lib/replicate/theme-scaffold-carry.ts
@@ -124,6 +124,18 @@ export interface CarryThemeInput {
   /** True when the run produced WooCommerce products — gates the store templates. */
   hasProducts?: boolean;
   /**
+   * Slug of the donor page whose carried per-page CSS styles the dedicated store header
+   * (`header-store`). Block-rendered WooCommerce templates (single-product / archive-product)
+   * have NO carried island, so they never hit an `is_page()`/`is_front_page()` branch — and on
+   * Shopify-family sources the store header's rich styling rides in the donor page's CSS, not
+   * the global site.css (the header wasn't split into a chrome region). functions.php reapplies
+   * this page's body class + CSS on `is_woocommerce()` contexts so the store chrome matches the
+   * rest of the site. The CSS is `:where()`-zero-specificity, so it styles the carried chrome
+   * but loses to WooCommerce's own block CSS on the product body (no bleed). Set by
+   * reconstruct-pages-carry when it carves the store header; absent → no reapply branch.
+   */
+  storeChromeDonorSlug?: string;
+  /**
    * Captured design tokens registered in theme.json (`settings.color.palette` /
    * `settings.typography.fontFamilies`) so the product-marketing core blocks resolve
    * their color/font token references. Same slugs the reconstruction maps to — built by
@@ -413,7 +425,12 @@ function stripViewportMeta(html: string): string {
   return html.replace(/<meta\b[^>]*\bname=["']viewport["'][^>]*>\s*/gi, '');
 }
 
-function functionsPhp(pages: CarryPage[], bodyClasses: string[], mobileViewport: boolean): string {
+function functionsPhp(
+  pages: CarryPage[],
+  bodyClasses: string[],
+  mobileViewport: boolean,
+  storeChromeDonorSlug: string,
+): string {
   // body_class filter: always add lib-carry-site; replicate the source body classes
   // (so body-state-gated carried rules behave like the source); add per-page class.
   const sourceBodyCases = bodyClasses
@@ -432,6 +449,23 @@ function functionsPhp(pages: CarryPage[], bodyClasses: string[], mobileViewport:
         `    if ( ${pageCondition(p)} ) { wp_enqueue_style( 'lib-carry-page-${p.slug}', get_stylesheet_directory_uri() . '/assets/css/page-${p.slug}.css', array( 'lib-carry-site' ), '1.0.0' ); }`,
     )
     .join('\n');
+
+  // Block-rendered WooCommerce templates (single-product / archive-product) have NO carried
+  // per-page island, so they never match an is_page()/is_front_page() branch and would render
+  // the dedicated header-store part with only the shared site.css. On Shopify-family sources the
+  // header rides inline in each page island (its full styling lives in that page's CSS), so
+  // reapply the DONOR page's class + CSS on every is_woocommerce() context. (`:where()`-zero-
+  // specificity, so it styles the carried store chrome but loses to WooCommerce's block CSS on
+  // the product body — no bleed.) No-op when no store header was isolated (donor slug empty).
+  const storeChromeCond = "function_exists( 'is_woocommerce' ) && is_woocommerce()";
+  const storeBodyCase = storeChromeDonorSlug
+    ? `    if ( ${storeChromeCond} ) { $classes[] = 'lib-carry-page-${storeChromeDonorSlug}'; }`
+    : '';
+  const storeEnqueue = storeChromeDonorSlug
+    ? `    if ( ${storeChromeCond} ) { wp_enqueue_style( 'lib-carry-page-${storeChromeDonorSlug}', get_stylesheet_directory_uri() . '/assets/css/page-${storeChromeDonorSlug}.css', array( 'lib-carry-site' ), '1.0.0' ); }`
+    : '';
+  const bodyCasesAll = [bodyCases, storeBodyCase].filter(Boolean).join('\n');
+  const enqueueAll = [enqueue, storeEnqueue].filter(Boolean).join('\n');
 
   // Non-responsive (classic/adaptive) source mobile layout is a FIXED-width canvas (carried
   // as the .lib-carry-vp-mobile iframe). The source scales it to fill via a width=320 viewport
@@ -462,13 +496,13 @@ add_action( 'wp_head', function () {
   return `<?php
 add_filter( 'body_class', function( $classes ) {
     $classes[] = 'lib-carry-site';
-${sourceBodyCases ? sourceBodyCases + '\n' : ''}${bodyCases}
+${sourceBodyCases ? sourceBodyCases + '\n' : ''}${bodyCasesAll}
     return $classes;
 } );
 
 add_action( 'wp_enqueue_scripts', function() {
     wp_enqueue_style( 'lib-carry-site', get_stylesheet_directory_uri() . '/assets/css/site.css', array(), '1.0.0' );
-${enqueue}
+${enqueueAll}
 } );
 
 // Allow the dual-viewport mobile-DOM <iframe> (carried mobile layout) through KSES
@@ -644,7 +678,7 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
   const files: ThemeFile[] = [
     { path: 'style.css', content: styleCssHeader(input.themeName) },
     { path: 'theme.json', content: JSON.stringify(themeJson, null, 2) },
-    { path: 'functions.php', content: functionsPhp(pages, input.bodyClasses ?? [], hasMobileCanvas) },
+    { path: 'functions.php', content: functionsPhp(pages, input.bodyClasses ?? [], hasMobileCanvas, input.storeChromeDonorSlug ?? '') },
     // Site-wide CSS — reset first (so source rules win the cascade), then the
     // chrome-wrapper rescue, then EVERY variant's carried chrome CSS (concatenated
     // upstream into siteCss; comp-id-scoped so variants never collide).

--- a/src/mcp-server/handlers/reconstruct-pages-carry.ts
+++ b/src/mcp-server/handlers/reconstruct-pages-carry.ts
@@ -247,6 +247,10 @@ export function assembleCarryTheme(input: AssembleInput): AssembleOutput {
   // vanishes on a white store page), falling back to any page that yields one. Only
   // when the run has products; otherwise no store templates are emitted.
   let storeHeaderIsland = '';
+  // The page whose island the store header was carved from — its per-page CSS styles that
+  // header. Passed to the scaffold so functions.php reapplies that CSS on WooCommerce
+  // (block-rendered, island-less) templates. See CarryThemeInput.storeChromeDonorSlug.
+  let storeChromeDonorSlug = '';
   if (input.hasProducts) {
     const ordered = [...recos.filter((x) => !x.p.isHome), ...recos.filter((x) => x.p.isHome)];
     for (const cand of ordered) {
@@ -255,7 +259,10 @@ export function assembleCarryTheme(input: AssembleInput): AssembleOutput {
       // the region, then fall back to the body.
       storeHeaderIsland =
         extractStoreHeaderIsland(cand.r.headerIsland) || extractStoreHeaderIsland(cand.r.mainIsland);
-      if (storeHeaderIsland) break;
+      if (storeHeaderIsland) {
+        storeChromeDonorSlug = cand.p.slug;
+        break;
+      }
     }
   }
 
@@ -266,6 +273,7 @@ export function assembleCarryTheme(input: AssembleInput): AssembleOutput {
     bodyClasses,
     pages: scaffoldPages,
     storeHeaderIsland,
+    storeChromeDonorSlug,
     hasProducts: input.hasProducts,
     themeJsonPalette: input.themeJsonPalette,
     themeJsonFontFamilies: input.themeJsonFontFamilies,


### PR DESCRIPTION
## Summary
Block-rendered WooCommerce templates (`single-product` / `archive-product`) in the carry path rendered their header/nav with only the shared `site.css`, so the carried store chrome was unstyled — oversized logo, sprawling ~181px layout — while core/html pages stayed correctly styled. This reapplies the donor page's body class + per-page CSS on `is_woocommerce()` contexts so the store chrome matches the rest of the site.

## Root cause
On Shopify-family sources the header splitter can't isolate the header, so it rides inline in each page's `core/html` island, styled by that page's per-page CSS (`page-<slug>.css`, scoped `.lib-carry-page-<slug>`, enqueued only via `is_page()`/`is_front_page()`). Product/shop pages have no carried island: they use the dedicated `header-store` part but receive no `page-*.css` and no `.lib-carry-page-*` class, so only `site.css`'s partial `STORE_HEADER_RESCUE` (~6 Dawn rules) applied. The source's own CDN component CSS 404s. Footers don't hit this because they DO split into the global `site.css`.

## Fix
- `reconstruct-pages-carry` records the slug of the donor page the store header was carved from → new `CarryThemeInput.storeChromeDonorSlug`.
- `theme-scaffold-carry`'s `functions.php` emits `body_class` + `wp_enqueue_style` branches gated on `function_exists('is_woocommerce') && is_woocommerce()` that reapply that page's class + CSS.
- The carried CSS is `:where()` zero-specificity, so it styles the carried store chrome but **loses to WooCommerce's own block CSS on the product body — no bleed**.
- No-op when no store header was isolated, so non-store carries are byte-identical.

## Verification
Hand-applied to a live getsnooz carry replica and rendered `/product/breez-2/`:
- Header **181px → 100px**, logo properly sized (was oversized); nav/icons laid out to match the homepage chrome.
- Buy box intact — `h1` "Breez 2", price `$199.99`, add-to-cart all present (no bleed from the donor CSS).
- `npx vitest run src/lib/replicate/theme-scaffold-carry.test.ts` → 47 pass (2 new: donor reapply + back-compat).
- `npx tsc --noEmit` → clean.

## Follow-up (not in this PR)
The deeper fix the `STORE_HEADER_RESCUE` comment foreshadows — lifting headers into global template parts (like footers already are) + a computed-style chrome snapshot — is a separate, riskier change. The low-risk first step (populate the empty header parts from the carve so more templates use real parts) is being spiked on a follow-up branch.
