### PR TITLE
fix(carry): render store header chrome on island-less templates

### DIFF
--- a/src/lib/replicate/theme-scaffold-carry.test.ts
+++ b/src/lib/replicate/theme-scaffold-carry.test.ts
@@ -357,6 +357,39 @@ describe('buildCarryThemeFiles — native blog templates (hybrid carry)', () => 
     expect(pick(files, 'templates/home.html')).toBe('');
     expect(pick(files, 'templates/single.html')).toBe('');
   });
+
+  it('SPIKE: native blog templates render the carved store header (+ donor CSS) when one exists', () => {
+    // Without a store header the native templates keep the (possibly empty) home header part.
+    const noStore = build([page({ slug: 'home', isHome: true, scaffold, pageCss: '' })]);
+    expect(pick(noStore, 'templates/single.html')).toContain('"slug":"header"');
+    expect(pick(noStore, 'templates/single.html')).not.toContain('header-store');
+
+    // With a carved store header, the island-less native templates render IT instead, so blog
+    // pages get real chrome; functions.php reapplies the donor CSS on native contexts too.
+    const withStore = buildCarryThemeFiles({
+      themeName: 'Acme Carry',
+      chromeVariants: oneVariant(
+        '<!-- wp:html --><header id="H">nav</header><!-- /wp:html -->',
+        '<!-- wp:html --><footer id="F">foot</footer><!-- /wp:html -->',
+      ),
+      siteCss: '',
+      pages: [page({ slug: 'home', isHome: true, pageCss: '' })],
+      hasProducts: true,
+      storeHeaderIsland:
+        '<!-- wp:html -->\n<div class="lib-carry-vp-desktop"><header class="section-header">NAV</header></div>\n<!-- /wp:html -->',
+      storeChromeDonorSlug: 'home',
+    });
+    const pickWith = (p: string) => withStore.find((f) => f.path === p)?.content ?? '';
+    expect(pickWith('templates/single.html')).toContain('"slug":"header-store"');
+    expect(pickWith('templates/home.html')).toContain('"slug":"header-store"');
+    expect(pickWith('templates/archive.html')).toContain('"slug":"header-store"');
+    // canonical footer still used on the native templates
+    expect(pickWith('templates/single.html')).toContain('"slug":"footer"');
+    // the index.html fallback (404 / search) also renders the store header
+    expect(pickWith('templates/index.html')).toContain('"slug":"header-store"');
+    // donor CSS reapply now covers every island-less view (not is_page / not is_front_page)
+    expect(pickWith('functions.php')).toMatch(/! is_page\(\) && ! is_front_page\(\)/);
+  });
 });
 
 describe('buildCarryThemeFiles — WooCommerce store templates', () => {
@@ -424,10 +457,11 @@ describe('buildCarryThemeFiles — WooCommerce store templates', () => {
     expect(find(files, 'templates/archive-product.html')).toBeUndefined();
   });
 
-  it('reapplies the donor page class + CSS on is_woocommerce() contexts so block-rendered store pages get the carried chrome styling', () => {
-    // Block-rendered single-product / archive-product templates have no carried island, so they
-    // never match an is_page()/is_front_page() branch. The donor page (whose island the store
-    // header was carved from) holds the header's full styling in its per-page CSS — reapply it.
+  it('reapplies the donor page class + CSS on island-less views so block-rendered store/blog pages get the carried chrome styling', () => {
+    // Block-rendered store templates (and, when no post is carried, the native blog/index views)
+    // have no carried island, so they never match an is_page()/is_front_page() branch. The donor
+    // page (whose island the store header was carved from) holds the header's full styling in its
+    // per-page CSS — reapply it on every island-less view (! is_page() && ! is_front_page()).
     const files = buildCarryThemeFiles({
       ...base,
       pages: [
@@ -439,8 +473,27 @@ describe('buildCarryThemeFiles — WooCommerce store templates', () => {
       storeChromeDonorSlug: 'about',
     });
     const fn = find(files, 'functions.php')!;
-    expect(fn).toMatch(/is_woocommerce\(\)[^\n]*\$classes\[\] = 'lib-carry-page-about'/);
-    expect(fn).toMatch(/is_woocommerce\(\)[^\n]*wp_enqueue_style\( 'lib-carry-page-about'[^\n]*page-about\.css/);
+    expect(fn).toMatch(/! is_front_page\(\) \) \{ \$classes\[\] = 'lib-carry-page-about'/);
+    expect(fn).toMatch(/! is_front_page\(\) \) \{ wp_enqueue_style\( 'lib-carry-page-about'[^\n]*page-about\.css/);
+  });
+
+  it('narrows the reapply to is_woocommerce() (not the island-less predicate) when a post is carried', () => {
+    // A carried post means native blog templates are NOT emitted, so only the WooCommerce store
+    // templates render the store header. The broad ! is_page() predicate would then wrongly load
+    // the donor CSS on the carried post (which has its own island + per-page CSS).
+    const files = buildCarryThemeFiles({
+      ...base,
+      pages: [
+        page({ slug: 'home', isHome: true, pageCss: '' }),
+        page({ slug: 'my-post', postType: 'post', pageCss: '' }),
+      ],
+      hasProducts: true,
+      storeHeaderIsland: STORE_HEADER,
+      storeChromeDonorSlug: 'home',
+    });
+    const fn = find(files, 'functions.php')!;
+    expect(fn).toContain("function_exists( 'is_woocommerce' ) && is_woocommerce() ) { $classes[] = 'lib-carry-page-home'");
+    expect(fn).not.toContain('! is_page()');
   });
 
   it('omits the is_woocommerce() reapply branch when no store-header donor was isolated (back-compat)', () => {

--- a/src/lib/replicate/theme-scaffold-carry.test.ts
+++ b/src/lib/replicate/theme-scaffold-carry.test.ts
@@ -423,6 +423,30 @@ describe('buildCarryThemeFiles — WooCommerce store templates', () => {
     expect(find(files, 'templates/single-product.html')).toBeUndefined();
     expect(find(files, 'templates/archive-product.html')).toBeUndefined();
   });
+
+  it('reapplies the donor page class + CSS on is_woocommerce() contexts so block-rendered store pages get the carried chrome styling', () => {
+    // Block-rendered single-product / archive-product templates have no carried island, so they
+    // never match an is_page()/is_front_page() branch. The donor page (whose island the store
+    // header was carved from) holds the header's full styling in its per-page CSS — reapply it.
+    const files = buildCarryThemeFiles({
+      ...base,
+      pages: [
+        page({ slug: 'home', isHome: true, pageCss: '' }),
+        page({ slug: 'about', isHome: false, pageCss: 'body.lib-carry-page-about{}' }),
+      ],
+      hasProducts: true,
+      storeHeaderIsland: STORE_HEADER,
+      storeChromeDonorSlug: 'about',
+    });
+    const fn = find(files, 'functions.php')!;
+    expect(fn).toMatch(/is_woocommerce\(\)[^\n]*\$classes\[\] = 'lib-carry-page-about'/);
+    expect(fn).toMatch(/is_woocommerce\(\)[^\n]*wp_enqueue_style\( 'lib-carry-page-about'[^\n]*page-about\.css/);
+  });
+
+  it('omits the is_woocommerce() reapply branch when no store-header donor was isolated (back-compat)', () => {
+    const fn = find(buildCarryThemeFiles({ ...base, hasProducts: true, storeHeaderIsland: STORE_HEADER }), 'functions.php')!;
+    expect(fn).not.toContain('is_woocommerce');
+  });
 });
 
 describe('buildCarryThemeFiles — mobile viewport scaling (non-responsive Wix only)', () => {

--- a/src/lib/replicate/theme-scaffold-carry.ts
+++ b/src/lib/replicate/theme-scaffold-carry.ts
@@ -124,6 +124,18 @@ export interface CarryThemeInput {
   /** True when the run produced WooCommerce products — gates the store templates. */
   hasProducts?: boolean;
   /**
+   * Slug of the donor page whose carried per-page CSS styles the dedicated store header
+   * (`header-store`). Block-rendered WooCommerce templates (single-product / archive-product)
+   * have NO carried island, so they never hit an `is_page()`/`is_front_page()` branch — and on
+   * Shopify-family sources the store header's rich styling rides in the donor page's CSS, not
+   * the global site.css (the header wasn't split into a chrome region). functions.php reapplies
+   * this page's body class + CSS on `is_woocommerce()` contexts so the store chrome matches the
+   * rest of the site. The CSS is `:where()`-zero-specificity, so it styles the carried chrome
+   * but loses to WooCommerce's own block CSS on the product body (no bleed). Set by
+   * reconstruct-pages-carry when it carves the store header; absent → no reapply branch.
+   */
+  storeChromeDonorSlug?: string;
+  /**
    * Captured design tokens registered in theme.json (`settings.color.palette` /
    * `settings.typography.fontFamilies`) so the product-marketing core blocks resolve
    * their color/font token references. Same slugs the reconstruction maps to — built by
@@ -413,7 +425,12 @@ function stripViewportMeta(html: string): string {
   return html.replace(/<meta\b[^>]*\bname=["']viewport["'][^>]*>\s*/gi, '');
 }
 
-function functionsPhp(pages: CarryPage[], bodyClasses: string[], mobileViewport: boolean): string {
+function functionsPhp(
+  pages: CarryPage[],
+  bodyClasses: string[],
+  mobileViewport: boolean,
+  storeChromeDonorSlug: string,
+): string {
   // body_class filter: always add lib-carry-site; replicate the source body classes
   // (so body-state-gated carried rules behave like the source); add per-page class.
   const sourceBodyCases = bodyClasses
@@ -432,6 +449,23 @@ function functionsPhp(pages: CarryPage[], bodyClasses: string[], mobileViewport:
         `    if ( ${pageCondition(p)} ) { wp_enqueue_style( 'lib-carry-page-${p.slug}', get_stylesheet_directory_uri() . '/assets/css/page-${p.slug}.css', array( 'lib-carry-site' ), '1.0.0' ); }`,
     )
     .join('\n');
+
+  // Block-rendered WooCommerce templates (single-product / archive-product) have NO carried
+  // per-page island, so they never match an is_page()/is_front_page() branch and would render
+  // the dedicated header-store part with only the shared site.css. On Shopify-family sources the
+  // header rides inline in each page island (its full styling lives in that page's CSS), so
+  // reapply the DONOR page's class + CSS on every is_woocommerce() context. (`:where()`-zero-
+  // specificity, so it styles the carried store chrome but loses to WooCommerce's block CSS on
+  // the product body — no bleed.) No-op when no store header was isolated (donor slug empty).
+  const storeChromeCond = "function_exists( 'is_woocommerce' ) && is_woocommerce()";
+  const storeBodyCase = storeChromeDonorSlug
+    ? `    if ( ${storeChromeCond} ) { $classes[] = 'lib-carry-page-${storeChromeDonorSlug}'; }`
+    : '';
+  const storeEnqueue = storeChromeDonorSlug
+    ? `    if ( ${storeChromeCond} ) { wp_enqueue_style( 'lib-carry-page-${storeChromeDonorSlug}', get_stylesheet_directory_uri() . '/assets/css/page-${storeChromeDonorSlug}.css', array( 'lib-carry-site' ), '1.0.0' ); }`
+    : '';
+  const bodyCasesAll = [bodyCases, storeBodyCase].filter(Boolean).join('\n');
+  const enqueueAll = [enqueue, storeEnqueue].filter(Boolean).join('\n');
 
   // Non-responsive (classic/adaptive) source mobile layout is a FIXED-width canvas (carried
   // as the .lib-carry-vp-mobile iframe). The source scales it to fill via a width=320 viewport
@@ -462,13 +496,13 @@ add_action( 'wp_head', function () {
   return `<?php
 add_filter( 'body_class', function( $classes ) {
     $classes[] = 'lib-carry-site';
-${sourceBodyCases ? sourceBodyCases + '\n' : ''}${bodyCases}
+${sourceBodyCases ? sourceBodyCases + '\n' : ''}${bodyCasesAll}
     return $classes;
 } );
 
 add_action( 'wp_enqueue_scripts', function() {
     wp_enqueue_style( 'lib-carry-site', get_stylesheet_directory_uri() . '/assets/css/site.css', array(), '1.0.0' );
-${enqueue}
+${enqueueAll}
 } );
 
 // Allow the dual-viewport mobile-DOM <iframe> (carried mobile layout) through KSES
@@ -644,7 +678,7 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
   const files: ThemeFile[] = [
     { path: 'style.css', content: styleCssHeader(input.themeName) },
     { path: 'theme.json', content: JSON.stringify(themeJson, null, 2) },
-    { path: 'functions.php', content: functionsPhp(pages, input.bodyClasses ?? [], hasMobileCanvas) },
+    { path: 'functions.php', content: functionsPhp(pages, input.bodyClasses ?? [], hasMobileCanvas, input.storeChromeDonorSlug ?? '') },
     // Site-wide CSS — reset first (so source rules win the cascade), then the
     // chrome-wrapper rescue, then EVERY variant's carried chrome CSS (concatenated
     // upstream into siteCss; comp-id-scoped so variants never collide).

--- a/src/lib/replicate/theme-scaffold-carry.ts
+++ b/src/lib/replicate/theme-scaffold-carry.ts
@@ -430,6 +430,7 @@ function functionsPhp(
   bodyClasses: string[],
   mobileViewport: boolean,
   storeChromeDonorSlug: string,
+  nativeStoreChrome: boolean,
 ): string {
   // body_class filter: always add lib-carry-site; replicate the source body classes
   // (so body-state-gated carried rules behave like the source); add per-page class.
@@ -457,7 +458,14 @@ function functionsPhp(
   // reapply the DONOR page's class + CSS on every is_woocommerce() context. (`:where()`-zero-
   // specificity, so it styles the carried store chrome but loses to WooCommerce's block CSS on
   // the product body — no bleed.) No-op when no store header was isolated (donor slug empty).
-  const storeChromeCond = "function_exists( 'is_woocommerce' ) && is_woocommerce()";
+  // Reapply the donor chrome CSS on templates that render the dedicated header-store part with no
+  // carried island. When native blog templates use it too (nativeStoreChrome), that is EVERY
+  // non-content, non-home view — product/shop, blog post/index/archive, search, 404 (index.html
+  // fallback) — i.e. anything that is not an is_page() content island or the is_front_page() home.
+  // Otherwise (posts are carried) only the WooCommerce store templates use it.
+  const storeChromeCond = nativeStoreChrome
+    ? "! is_page() && ! is_front_page()"
+    : "function_exists( 'is_woocommerce' ) && is_woocommerce()";
   const storeBodyCase = storeChromeDonorSlug
     ? `    if ( ${storeChromeCond} ) { $classes[] = 'lib-carry-page-${storeChromeDonorSlug}'; }`
     : '';
@@ -667,18 +675,31 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
     themeJson.templateParts = tp;
   }
 
-  // index.html (required fallback) reuses the home page's scaffold + chrome so it
-  // renders correctly; falls back to the legacy shell when no scaffold exists.
+  // Island-less templates (native blog single/home/archive + the index.html fallback) have NO
+  // carried island; on Shopify-family carries the home-variant header part is empty, so they
+  // render with no nav/logo. When a populated store header was carved, render IT on them (SPIKE
+  // — branch spike/carry-real-header-parts). `nativeStoreChrome` ties the two halves together:
+  // functions.php only reapplies the donor chrome CSS on those contexts when they use the header.
   const homePage = pages.find((p) => p.isHome);
   const homeSlugs = slugsFor(homePage?.chromeKey ?? input.chromeVariants[0]?.key ?? '');
-  const indexTemplate = homePage?.scaffold
-    ? scaffoldedTemplate(homePage.scaffold, homeSlugs, homePage.mobile)
-    : pageTemplate(homeSlugs);
+  const nativeBlog = input.nativeBlog ?? !pages.some((p) => p.postType === 'post');
+  const useStoreHeader = (input.hasProducts ?? false) && !!input.storeHeaderIsland;
+  const nativeStoreChrome = nativeBlog && useStoreHeader;
+  const storeHeaderSlugs: ChromeSlugs = { header: STORE_HEADER_SLUG, footer: homeSlugs.footer };
+
+  // index.html (required fallback — also serves 404 / search when those templates are absent).
+  // With a carved store header, render real chrome + a recent-posts loop; else reuse the home
+  // page's scaffold/shell (legacy behavior).
+  const indexTemplate = useStoreHeader
+    ? nativeBlogTemplate(nativeQueryLoop(NATIVE_HOME_TITLE), storeHeaderSlugs)
+    : homePage?.scaffold
+      ? scaffoldedTemplate(homePage.scaffold, homeSlugs, homePage.mobile)
+      : pageTemplate(homeSlugs);
 
   const files: ThemeFile[] = [
     { path: 'style.css', content: styleCssHeader(input.themeName) },
     { path: 'theme.json', content: JSON.stringify(themeJson, null, 2) },
-    { path: 'functions.php', content: functionsPhp(pages, input.bodyClasses ?? [], hasMobileCanvas, input.storeChromeDonorSlug ?? '') },
+    { path: 'functions.php', content: functionsPhp(pages, input.bodyClasses ?? [], hasMobileCanvas, input.storeChromeDonorSlug ?? '', nativeStoreChrome) },
     // Site-wide CSS — reset first (so source rules win the cascade), then the
     // chrome-wrapper rescue, then EVERY variant's carried chrome CSS (concatenated
     // upstream into siteCss; comp-id-scoped so variants never collide).
@@ -731,12 +752,14 @@ export function buildCarryThemeFiles(input: CarryThemeInput): ThemeFile[] {
   // posts (single.html), the posts page (home.html) and date/term archives (archive.html)
   // render properly. index.html is left as the homepage fallback. The carried-post case
   // (posts in the carry set) keeps its own single.html via the loop above.
-  const nativeBlog = input.nativeBlog ?? !pages.some((p) => p.postType === 'post');
   if (nativeBlog) {
-    const sc = homePage?.scaffold;
-    files.push({ path: 'templates/single.html', content: nativeBlogTemplate(NATIVE_SINGLE_MIDDLE, homeSlugs, sc) });
-    files.push({ path: 'templates/home.html', content: nativeBlogTemplate(nativeQueryLoop(NATIVE_HOME_TITLE), homeSlugs, sc) });
-    files.push({ path: 'templates/archive.html', content: nativeBlogTemplate(nativeQueryLoop(NATIVE_ARCHIVE_TITLE), homeSlugs, sc) });
+    // Island-less: with a carved store header, render it (clean header → main → footer, no home
+    // scaffold) so blog pages get real chrome; else keep the home scaffold's (maybe empty) header.
+    const nativeSlugs: ChromeSlugs = useStoreHeader ? storeHeaderSlugs : homeSlugs;
+    const sc = useStoreHeader ? undefined : homePage?.scaffold;
+    files.push({ path: 'templates/single.html', content: nativeBlogTemplate(NATIVE_SINGLE_MIDDLE, nativeSlugs, sc) });
+    files.push({ path: 'templates/home.html', content: nativeBlogTemplate(nativeQueryLoop(NATIVE_HOME_TITLE), nativeSlugs, sc) });
+    files.push({ path: 'templates/archive.html', content: nativeBlogTemplate(nativeQueryLoop(NATIVE_ARCHIVE_TITLE), nativeSlugs, sc) });
   }
 
   // WooCommerce store templates. Product + shop/category-archive pages have NO carried

--- a/src/mcp-server/handlers/reconstruct-pages-carry.ts
+++ b/src/mcp-server/handlers/reconstruct-pages-carry.ts
@@ -247,6 +247,10 @@ export function assembleCarryTheme(input: AssembleInput): AssembleOutput {
   // vanishes on a white store page), falling back to any page that yields one. Only
   // when the run has products; otherwise no store templates are emitted.
   let storeHeaderIsland = '';
+  // The page whose island the store header was carved from — its per-page CSS styles that
+  // header. Passed to the scaffold so functions.php reapplies that CSS on WooCommerce
+  // (block-rendered, island-less) templates. See CarryThemeInput.storeChromeDonorSlug.
+  let storeChromeDonorSlug = '';
   if (input.hasProducts) {
     const ordered = [...recos.filter((x) => !x.p.isHome), ...recos.filter((x) => x.p.isHome)];
     for (const cand of ordered) {
@@ -255,7 +259,10 @@ export function assembleCarryTheme(input: AssembleInput): AssembleOutput {
       // the region, then fall back to the body.
       storeHeaderIsland =
         extractStoreHeaderIsland(cand.r.headerIsland) || extractStoreHeaderIsland(cand.r.mainIsland);
-      if (storeHeaderIsland) break;
+      if (storeHeaderIsland) {
+        storeChromeDonorSlug = cand.p.slug;
+        break;
+      }
     }
   }
 
@@ -266,6 +273,7 @@ export function assembleCarryTheme(input: AssembleInput): AssembleOutput {
     bodyClasses,
     pages: scaffoldPages,
     storeHeaderIsland,
+    storeChromeDonorSlug,
     hasProducts: input.hasProducts,
     themeJsonPalette: input.themeJsonPalette,
     themeJsonFontFamilies: input.themeJsonFontFamilies,


### PR DESCRIPTION
## Summary
Extends #76. Native blog templates (`single` / `home` / `archive`) and the `index.html` fallback rendered with **no header at all** on Shopify-family carries — their home-variant header part is empty (the header rides inline in content-page islands, which these templates don't have). They now render the dedicated `header-store` part + the donor page's CSS, so blog posts, the blog index, archives, search, and 404 get the same site chrome as the rest of the replica.

> **Stacked on #76** (base = `fix/product-chrome`). Builds on that PR's `storeChromeDonorSlug`. Merge/retarget after #76 lands.

## Root cause
The carry header splitter can't isolate Shopify-family headers, so the per-variant header parts are empty and the header lives inline in each content-page island. Island-less templates (native blog + the index fallback) reference those empty parts → no nav/logo. #76 fixed the WooCommerce store templates the same way; this extends it to the remaining island-less templates. On getsnooz that's **38 native blog posts** that previously rendered with no header.

## Changes
- `buildCarryThemeFiles` points the native blog templates **and** the `index.html` fallback (which also serves 404/search) at the `header-store` part + canonical footer when a store header was carved (`useStoreHeader`), using the clean non-scaffold `header → main → footer` form.
- `functions.php` reapplies the donor chrome CSS with one precise predicate — `! is_page() && ! is_front_page()` — which covers **every** island-less view (product/shop, blog post/index/archive, search, 404) without enumerating them. Content pages (`is_page`) and the home page (`is_front_page`) keep their own per-page CSS.
- When posts are **carried** instead (so no native blog templates exist), the predicate narrows back to `is_woocommerce()` so the donor CSS never loads on a carried post (which has its own island + CSS).
- The donor CSS is `:where()` zero-specificity → it styles the carried chrome but loses to core/WooCommerce CSS on the body (**no bleed**).

## Verification
- Live getsnooz post page (`/2026/05/18/best-bedroom-temperature-for-sleep/`): header **NONE → styled SNOOZ chrome** (logo 136×45), announcement bar + nav + cart/account icons, post content intact below — no bleed.
- `npx vitest run src/lib/replicate/theme-scaffold-carry.test.ts` → **49 pass** (native store-header, index fallback, carried-post narrowing).
- `npx tsc --noEmit` → clean.

## Notes / scope
- Single posts were verified live; `home`/`archive`/`index` share the identical `header-store` + donor-CSS wiring (only the body content differs), and are covered by unit tests.
- Still **not** the deeper refactor (lift headers into global parts + computed-style snapshot, stripping the inline header from content-page islands) — that remains a separate, riskier follow-up.
- Gated on a store header existing (`hasProducts`); a blog-only Shopify-family site would need the carve ungated (not done here).
