### PR TITLE
refactor(replicate): extract shared theme-file primitives to theme-php

### DIFF
--- a/src/lib/preview/blank-theme.ts
+++ b/src/lib/preview/blank-theme.ts
@@ -27,6 +27,7 @@
 //
 import { LIBRARY_CDN_ALLOWLIST } from '../screenshot/js-aggregator.js';
 import type { ReplicaFile } from './types.js';
+import { buildThemeHeader } from '../replicate/theme-php.js';
 
 export interface BlankThemeOpts {
   themeSlug: string;
@@ -58,12 +59,11 @@ export interface BlankThemeOpts {
 export function buildBlankTheme(opts: BlankThemeOpts): ReplicaFile[] {
   const { themeSlug, hasJs, headLinks, headerBlockMarkup, footerHtml, hasChromeCss, hasDesignCapture } = opts;
 
-  const styleCss = `/*
-Theme Name: DLA Replica (${themeSlug})
-Description: Blank companion theme for html-first design replication. Carried CSS lives in site.css.
-Version: 1.0.0
-*/
-`;
+  const styleCss = buildThemeHeader([
+    ['Theme Name', `DLA Replica (${themeSlug})`],
+    ['Description', 'Blank companion theme for html-first design replication. Carried CSS lives in site.css.'],
+    ['Version', '1.0.0'],
+  ]);
 
   const fontEnqueues = headLinks
     .map((href, i) => `  wp_enqueue_style('dla-font-${i}', ${phpString(href)}, array(), null);`)

--- a/src/lib/replicate/theme-php.ts
+++ b/src/lib/replicate/theme-php.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared WordPress theme-file primitives used by the replica theme builders
+ * (`theme-scaffold`, `blank-theme`, …).
+ *
+ * These keep the style.css/functions.php boilerplate single-sourced so the
+ * theme header, block registration, and slug derivation don't drift between
+ * builders.
+ */
+
+/** Kebab-case slug: lowercase, non-alphanumeric runs → '-', leading/trailing '-' trimmed. */
+export function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/**
+ * A `style.css` WordPress theme header comment from ordered key/value fields.
+ * Emits `/*\nKey: Value\n…\n*\/\n` — callers append any trailing CSS.
+ */
+export function buildThemeHeader(fields: Array<[string, string]>): string {
+  const body = fields.map(([key, value]) => `${key}: ${value}`).join('\n');
+  return `/*\n${body}\n*/\n`;
+}
+
+/**
+ * `add_action('init')` that registers every theme-embedded block found at
+ * `blocks/<slug>/build` (guarded on `block.json`). Directory-driven so callers
+ * don't have to enumerate block slugs — the same glob the scaffold uses.
+ */
+export function registerThemeBlocksPhp(): string {
+  return `add_action('init', function () {
+    foreach ((array) glob(get_theme_file_path('blocks/*/build')) as $build_dir) {
+        if ($build_dir && file_exists(trailingslashit($build_dir) . 'block.json')) {
+            register_block_type($build_dir);
+        }
+    }
+});`;
+}

--- a/src/lib/replicate/theme-scaffold.ts
+++ b/src/lib/replicate/theme-scaffold.ts
@@ -34,6 +34,7 @@ import {
   type LocalFontFace,
 } from './font-capture.js';
 import { assertNoInjection } from './validate-artifacts.js';
+import { buildThemeHeader, registerThemeBlocksPhp, slugify } from './theme-php.js';
 
 export interface ThemeScaffoldOpts {
   /** Required — the parsed design-foundation.json. */
@@ -338,21 +339,20 @@ function buildStyleCss(args: { themeName: string; themeSlug: string; themeDescri
   // Self-hosted source fonts (captured @font-face rules → local assets/fonts/).
   const fontFaceCss = buildFontFaceCss(args.capturedFonts ?? []);
   // Standard WordPress theme header; required keys: Theme Name, Version, Text Domain.
-  return `/*
-Theme Name: ${args.themeName}
-Theme URI: https://github.com/Automattic/data-liberation-agent
-Author: data-liberation
-Description: ${args.themeDescription}
-Version: 0.1.0
-Requires at least: 6.5
-Tested up to: 6.5
-Requires PHP: 8.0
-License: GPL-2.0-or-later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Text Domain: ${args.themeSlug}
-Tags: block-theme, full-site-editing
-*/
-
+  return buildThemeHeader([
+    ['Theme Name', args.themeName],
+    ['Theme URI', 'https://github.com/Automattic/data-liberation-agent'],
+    ['Author', 'data-liberation'],
+    ['Description', args.themeDescription],
+    ['Version', '0.1.0'],
+    ['Requires at least', '6.5'],
+    ['Tested up to', '6.5'],
+    ['Requires PHP', '8.0'],
+    ['License', 'GPL-2.0-or-later'],
+    ['License URI', 'https://www.gnu.org/licenses/gpl-2.0.html'],
+    ['Text Domain', args.themeSlug],
+    ['Tags', 'block-theme, full-site-editing'],
+  ]) + `
 /*
  * Responsive-content guard. Imported page/post content (carried from the
  * source platform — Shopify/Replo, Wix, Squarespace, etc.) frequently ships its
@@ -778,10 +778,6 @@ function buildFontFamilies(
   return out;
 }
 
-function slugify(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
-}
-
 /** Slug of the body family entry (first entry conventionally has slug "body"). */
 function bodyFamilySlug(fams: FontFamilyEntry[]): string {
   const body = fams.find((e) => e.slug === 'body');
@@ -965,13 +961,7 @@ add_action('wp_enqueue_scripts', function () {
  * build/ since the streaming flow has no wp-scripts step. Skipped
  * silently when the directory is empty.
  */
-add_action('init', function () {
-    foreach ((array) glob(get_theme_file_path('blocks/*/build')) as $build_dir) {
-        if ($build_dir && file_exists(trailingslashit($build_dir) . 'block.json')) {
-            register_block_type($build_dir);
-        }
-    }
-});
+${registerThemeBlocksPhp()}
 `;
 }
 


### PR DESCRIPTION
## Summary
Pull the WordPress theme-file boilerplate that `theme-scaffold.ts` and `blank-theme.ts` each hand-rolled — the `style.css` header, the block registrar, and slug derivation — into a shared `src/lib/replicate/theme-php.ts` module, and route both builders through it.

## Why
`theme-scaffold.ts` carried its own private `slugify`, an inline `style.css` header literal, and an inline `register_block_type` glob loop; `blank-theme.ts` hand-built its own header. Same boilerplate, multiple copies, free to drift.

## How
New `theme-php.ts` exports:

- `slugify` — canonical kebab-case slug (lowercase, non-alnum runs → `-`, trimmed)
- `buildThemeHeader(fields)` — `style.css` theme header from ordered key/value pairs
- `registerThemeBlocksPhp()` — directory-driven block registrar (`blocks/*/build`, guarded on `block.json`)

Wiring:

- **`theme-scaffold.ts`** drops its private `slugify` and inline header/registrar in favor of the helpers.
- **`blank-theme.ts`** builds its header via `buildThemeHeader`.

Output is **byte-identical** for both builders — verified by their unchanged test suites.

## Testing
- `npx vitest run src/lib/replicate/theme-scaffold.test.ts src/lib/preview/blank-theme.test.ts` → **63 passing** (53 scaffold + 10 blank-theme).

---

_Note: an earlier revision of this branch also swept in `purposeful-theme.ts`/`.test.ts`, which are WIP belonging to `feature/purposeful-html-blocks`. They've been removed from this PR — it is now a pure, self-contained shared-helper extraction._