### PR TITLE
feat(local-site): carry HTML <img>/SVG assets + harden carried JS/CSS

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "data-liberation",
   "description": "Extract content from closed web platforms (GoDaddy Websites & Marketing, Hostinger, HubSpot, Shopify, Squarespace, Webflow, Weebly, Wix) into WordPress-compatible WXR files. Inspect, extract, QA, and import to WordPress.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Automattic"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "data-liberation",
   "description": "Extract content from closed web platforms (GoDaddy Websites & Marketing, Hostinger, HubSpot, Shopify, Squarespace, Webflow, Weebly, Wix) into WordPress-compatible WXR files. Inspect, extract, QA, and import to WordPress.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Automattic"
   },

--- a/src/lib/replicate/local-theme/source-assets.test.ts
+++ b/src/lib/replicate/local-theme/source-assets.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { collectSourceAssets, WP_COMPAT_CSS } from './source-assets.js';
+import { collectSourceAssets, rewriteHtmlImageSrcs, WP_COMPAT_CSS } from './source-assets.js';
 
 const FIXTURE_TMP = join(process.cwd(), '.tmp-test');
 
@@ -251,5 +251,92 @@ describe('collectSourceAssets: unlinked fallback gating (stale-revision pollutio
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('collectSourceAssets: non-JS <script> blocks (bundle-poisoning guard)', () => {
+  it('does NOT carry application/ld+json into the JS bundle, keeping it parseable', () => {
+    const dir = mkdtempSync(join(FIXTURE_TMP, 'sa-ldjson-'));
+    try {
+      writeFileSync(join(dir, 'app.js'), "document.querySelectorAll('.reveal');");
+      const html =
+        '<html><head>' +
+        '<script type="application/ld+json">{ "@context": "https://schema.org", "@type": "HairSalon" }</script>' +
+        '</head><body><p>x</p>' +
+        '<script src="app.js"></script>' +
+        '<script>initReveal();</script>' +
+        '</body></html>';
+      writeFileSync(join(dir, 'index.html'), html);
+      const out = collectSourceAssets(dir, [{ relPath: 'index.html', html }]);
+      // JSON-LD must NOT leak into the bundle (concatenated it is a syntax error
+      // that kills every carried behavior — the live regression we are guarding).
+      expect(out.js).not.toContain('@context');
+      expect(out.js).not.toContain('schema.org');
+      // Real JS (linked + classic inline) still carried.
+      expect(out.js).toContain("document.querySelectorAll('.reveal')");
+      expect(out.js).toContain('initReveal();');
+      // The whole bundle parses as JS.
+      expect(() => new Function(out.js)).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips importmap/application/json but carries module + classic inline JS', () => {
+    const dir = mkdtempSync(join(FIXTURE_TMP, 'sa-types-'));
+    try {
+      const html =
+        '<html><body>' +
+        '<script type="importmap">{ "imports": {} }</script>' +
+        '<script type="application/json">{ "k": 1 }</script>' +
+        '<script type="module">globalThis.mod = 1;</script>' +
+        '<script type="text/javascript">classic();</script>' +
+        '</body></html>';
+      writeFileSync(join(dir, 'index.html'), html);
+      const out = collectSourceAssets(dir, [{ relPath: 'index.html', html }]);
+      expect(out.js).toContain('globalThis.mod = 1;');
+      expect(out.js).toContain('classic();');
+      expect(out.js).not.toContain('"imports"');
+      expect(out.js).not.toContain('"k": 1');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('collectSourceAssets: HTML <img> asset carry', () => {
+  it('harvests local <img src> files into imgAssets + per-page rewrites; skips remote/data/missing/data-src', () => {
+    const dir = mkdtempSync(join(FIXTURE_TMP, 'sa-htmlimg-'));
+    try {
+      mkdirSync(join(dir, 'assets'), { recursive: true });
+      writeFileSync(join(dir, 'assets', 'logo.svg'), '<svg/>');
+      const html =
+        '<html><body>' +
+        '<img src="assets/logo.svg" alt="logo">' +
+        '<img data-src="assets/logo.svg" src="assets/logo.svg">' + // dedup; data-src ignored
+        '<img src="https://cdn.example.com/x.png">' + // remote → skip
+        '<img src="data:image/svg+xml,%3Csvg%3E">' + // data → skip
+        '<img src="assets/missing.svg">' + // missing → skip
+        '</body></html>';
+      writeFileSync(join(dir, 'index.html'), html);
+      const out = collectSourceAssets(dir, [{ relPath: 'index.html', html }]);
+      expect(out.imgAssets).toEqual([
+        { srcAbs: join(dir, 'assets', 'logo.svg'), themeRel: 'assets/img/logo.svg' },
+      ]);
+      expect(out.imgRewritesByPage['index.html']).toEqual([
+        { ref: 'assets/logo.svg', themeRel: 'assets/img/logo.svg' },
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rewriteHtmlImageSrcs repoints carried refs at the theme URL (both quote styles)', () => {
+    const refs = [{ ref: 'assets/logo.svg', themeRel: 'assets/img/logo.svg' }];
+    const html = '<img src="assets/logo.svg"><img src=\'assets/logo.svg\'>';
+    expect(rewriteHtmlImageSrcs(html, refs, 'my-theme')).toBe(
+      '<img src="/wp-content/themes/my-theme/assets/img/logo.svg">' +
+        '<img src=\'/wp-content/themes/my-theme/assets/img/logo.svg\'>',
+    );
   });
 });

--- a/src/lib/replicate/local-theme/source-assets.ts
+++ b/src/lib/replicate/local-theme/source-assets.ts
@@ -90,6 +90,14 @@ export interface MediaAsset {
   themeRel: string;
 }
 
+/** One HTML <img src> reference carried from a source page into the theme. */
+export interface ImgAssetRef {
+  /** Exact src string as authored in the page HTML (e.g. "assets/logo.svg"). */
+  ref: string;
+  /** Theme-relative destination the file was copied to (e.g. assets/img/logo.svg). */
+  themeRel: string;
+}
+
 export interface SourceAssets {
   /** Compat layer + all source CSS (linked files in DOCUMENT order, then unlinked top-level fallback, then inline <style> blocks). */
   css: string;
@@ -104,6 +112,14 @@ export interface SourceAssets {
   /** Image files referenced via CSS url() that the handler must copy into the
    * theme (the css urls are already rewritten to point at them). */
   mediaAssets: MediaAsset[];
+  /** Image files referenced via HTML <img src> that the handler must copy into
+   * the theme. Unlike CSS images these are NOT pre-rewritten (post_content has
+   * no carried-stylesheet anchor) — the handler repoints each <img> using the
+   * per-page rewrite list below. */
+  imgAssets: MediaAsset[];
+  /** Per source page (keyed by relPath): the exact <img src> ref strings found
+   * and the theme-relative path each was carried to, for the handler's rewrite. */
+  imgRewritesByPage: Record<string, ImgAssetRef[]>;
 }
 
 /** Theme subdir (relative to assets/css/source.css) holding carried CSS images. */
@@ -162,6 +178,104 @@ export function localizeCssImages(
     }),
   );
   return { parts: outParts, mediaAssets };
+}
+
+/** Inline <script> bodies are carried into the concatenated bundle ONLY when
+ * they are executable JS — type absent/empty, a JS MIME, or `module`. Data
+ * blocks (`application/ld+json` SEO, `application/json`, `importmap`,
+ * `speculationrules`, `text/*` microtemplates) are NOT JS: concatenating one
+ * injects a parse-time SyntaxError that aborts the ENTIRE bundle (the per-chunk
+ * try/catch catches RUNTIME throws only, never parse errors), silently killing
+ * every carried behavior — reveal, nav, accordions. So they are skipped. */
+const EXECUTABLE_INLINE_JS_TYPES = new Set([
+  'text/javascript',
+  'application/javascript',
+  'application/x-javascript',
+  'text/ecmascript',
+  'application/ecmascript',
+  'module',
+]);
+function isExecutableInlineScript(openTagAttrs: string): boolean {
+  const m = openTagAttrs.match(/\btype\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i);
+  if (!m) return true; // no type attribute → classic JS
+  const type = (m[1] ?? m[2] ?? m[3] ?? '').trim().toLowerCase();
+  if (type === '') return true; // type="" is classic JS per the HTML spec
+  return EXECUTABLE_INLINE_JS_TYPES.has(type);
+}
+
+/** Theme subdir (relative to the theme root) holding carried HTML <img> assets. */
+const IMG_SUBDIR = 'assets/img';
+
+/** Harvest LOCAL <img src> image references from each page's HTML, returning the
+ * copy-list (unique source files → a flat assets/img/<name>, collision-suffixed)
+ * and a per-page rewrite list (exact ref string → themeRel). The handler copies
+ * the files into the theme and repoints each <img src> at the theme URL — HTML
+ * <img>s, unlike CSS url()s, have no carried stylesheet to anchor a relative
+ * path against, so they need an absolute theme URL. Remote (http/protocol-
+ * relative), data:, fragment, and missing refs are left verbatim (never
+ * fabricated). */
+export function collectHtmlImages(
+  pageHtmls: Array<{ html: string; relPath: string }>,
+  dir: string,
+): { imgAssets: MediaAsset[]; rewritesByPage: Record<string, ImgAssetRef[]> } {
+  const bySrc = new Map<string, string>(); // srcAbs → assigned basename
+  const usedNames = new Set<string>();
+  const imgAssets: MediaAsset[] = [];
+  const rewritesByPage: Record<string, ImgAssetRef[]> = {};
+
+  const assign = (srcAbs: string, rawName: string): string => {
+    const existing = bySrc.get(srcAbs);
+    if (existing) return existing;
+    let name = rawName;
+    if (usedNames.has(name)) {
+      const dot = name.lastIndexOf('.');
+      const stem = dot > 0 ? name.slice(0, dot) : name;
+      const ext = dot > 0 ? name.slice(dot) : '';
+      let n = 2;
+      while (usedNames.has(`${stem}-${n}${ext}`)) n++;
+      name = `${stem}-${n}${ext}`;
+    }
+    usedNames.add(name);
+    bySrc.set(srcAbs, name);
+    imgAssets.push({ srcAbs, themeRel: `${IMG_SUBDIR}/${name}` });
+    return name;
+  };
+
+  for (const { html, relPath } of pageHtmls) {
+    const baseDir = posix.dirname(relPath);
+    const seenRefs = new Set<string>();
+    const list: ImgAssetRef[] = [];
+    // `\ssrc` (whitespace-anchored) so `data-src` / `xlink:href` never match.
+    for (const m of html.matchAll(/<img\b[^>]*?\ssrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s>]+))/gi)) {
+      const ref = (m[1] ?? m[2] ?? m[3] ?? '').trim();
+      if (!ref || seenRefs.has(ref)) continue;
+      if (/^(?:https?:)?\/\//i.test(ref) || ref.startsWith('data:') || ref.startsWith('#')) continue;
+      const cleaned = ref.split(/[?#]/)[0];
+      const within = cleaned.startsWith('/')
+        ? posix.normalize(cleaned.slice(1))
+        : posix.normalize(posix.join(baseDir, cleaned));
+      if (within.startsWith('..')) continue; // never escape the source root
+      const srcAbs = join(dir, within);
+      if (!existsSync(srcAbs)) continue; // missing → leave as authored
+      seenRefs.add(ref);
+      const name = assign(srcAbs, posix.basename(within));
+      list.push({ ref, themeRel: `${IMG_SUBDIR}/${name}` });
+    }
+    if (list.length > 0) rewritesByPage[relPath] = list;
+  }
+  return { imgAssets, rewritesByPage };
+}
+
+/** Repoint carried <img src> refs at the theme-carried copies. Pure string
+ * replacement bounded by the surrounding quote so a path token can't match
+ * inside another attribute; safe because the refs are literal source paths. */
+export function rewriteHtmlImageSrcs(html: string, refs: ImgAssetRef[], themeSlug: string): string {
+  let out = html;
+  for (const { ref, themeRel } of refs) {
+    const themeUrl = `/wp-content/themes/${themeSlug}/${themeRel}`;
+    out = out.split(`"${ref}"`).join(`"${themeUrl}"`).split(`'${ref}'`).join(`'${themeUrl}'`);
+  }
+  return out;
 }
 
 export function collectSourceAssets(
@@ -273,8 +387,11 @@ export function collectSourceAssets(
   // follow the libraries they call).
   const seenInlineJs = new Set<string>();
   for (const { html } of pageHtmls) {
-    for (const m of html.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi)) {
-      const body = m[1].trim();
+    for (const m of html.matchAll(/<script(?![^>]*\bsrc=)([^>]*)>([\s\S]*?)<\/script>/gi)) {
+      // Skip non-JS <script> data blocks (JSON-LD, importmaps, templates): a
+      // parse error in one aborts the whole concatenated bundle.
+      if (!isExecutableInlineScript(m[1])) continue;
+      const body = m[2].trim();
       if (body && !seenInlineJs.has(body)) {
         seenInlineJs.add(body);
         jsParts.push(`(function () { try {\n${body}\n} catch (e) { /* page-scoped inline chunk */ } })();`);
@@ -288,5 +405,16 @@ export function collectSourceAssets(
   // startsWith(WP_COMPAT_CSS) is preserved; Google imports only exist in cssParts.
   const { parts: localizedParts, mediaAssets } = localizeCssImages(cssParts, dir);
   const css = (WP_COMPAT_CSS + localizedParts.join('\n\n')).replace(GOOGLE_IMPORT_RE, '');
-  return { css, js: jsParts.join('\n\n'), cssFiles, jsFiles, skippedUnlinked, mediaAssets };
+  // Carry HTML <img> assets too (content images the CSS pass never sees).
+  const { imgAssets, rewritesByPage: imgRewritesByPage } = collectHtmlImages(pageHtmls, dir);
+  return {
+    css,
+    js: jsParts.join('\n\n'),
+    cssFiles,
+    jsFiles,
+    skippedUnlinked,
+    mediaAssets,
+    imgAssets,
+    imgRewritesByPage,
+  };
 }

--- a/src/lib/replicate/local-theme/theme-files.test.ts
+++ b/src/lib/replicate/local-theme/theme-files.test.ts
@@ -377,9 +377,21 @@ describe('instance-styles carry (per-instance lib-i rules)', () => {
     const fns = files.find((f) => f.relativePath === 'functions.php')?.content ?? '';
     expect(fns).toContain('add_editor_style');
     expect(fns).toContain("add_theme_support( 'editor-styles' )");
-    expect(fns).toContain("'assets/css/source.css', 'assets/css/instance-styles.css', 'assets/css/parity-patch.css'");
+    expect(fns).toContain(
+      "'assets/css/source.css', 'assets/css/instance-styles.css', 'assets/css/parity-patch.css', 'assets/css/editor-reveal-reset.css'",
+    );
     // Guarded so an absent asset is skipped, not fatal.
     expect(fns).toContain('if ( file_exists( get_theme_file_path( $rel ) ) )');
+    // The editor reveal-reset ships as a theme file and forces carried
+    // scroll-reveal blocks visible in the editor canvas...
+    const reset = files.find((f) => f.relativePath === 'assets/css/editor-reveal-reset.css');
+    expect(reset?.content).toContain('opacity: 1 !important');
+    expect(reset?.content).toContain('.reveal');
+    // ...but it is EDITOR-ONLY: never wp_enqueue_style'd on the front end (so the
+    // live reveal animation is untouched). The frontend enqueue block precedes
+    // the after_setup_theme (editor) block in functions.php.
+    const frontendEnqueues = fns.slice(0, fns.indexOf("add_action( 'after_setup_theme'"));
+    expect(frontendEnqueues).not.toContain('editor-reveal-reset');
   });
 
   it('no instanceStylesCss → no asset file, but add_editor_style still loads source.css', () => {

--- a/src/lib/replicate/local-theme/theme-files.ts
+++ b/src/lib/replicate/local-theme/theme-files.ts
@@ -204,6 +204,9 @@ add_action( 'wp_body_open', function () {
     'assets/css/instance-styles.css',
     ...(includeJetpackFormParity ? [JETPACK_FORM_PARITY_CSS.editorStylePath] : []),
     'assets/css/parity-patch.css',
+    // LAST so it wins: force carried scroll-reveal initial-hidden states visible
+    // in the editor canvas (which can't run the reveal JS). Editor-only.
+    'assets/css/editor-reveal-reset.css',
   ];
   const cascadeComment = includeJetpackFormParity
     ? `// wins) → jetpack-form-parity.css (form-specific carried CSS bridge) →
@@ -259,6 +262,28 @@ add_action( 'after_setup_theme', function () {
 } );
 ${htmlJsBlock}${bodyDataBlock}`;
 }
+
+/** Editor-only CSS: the block-editor canvas renders blocks statically and never
+ * runs the source's scroll-reveal JS, so any carried animate-in initial-hidden
+ * state (opacity:0 + a JS-toggled class) would leave blocks invisible and
+ * uneditable. Force the common reveal/fade/animate patterns visible. Added via
+ * add_editor_style ONLY (never enqueued on the front end), so the live reveal
+ * animation is untouched. `!important` beats the carried (non-important) rules. */
+export const EDITOR_REVEAL_RESET_CSS = `/* editor-reveal-reset.css — add_editor_style ONLY; never a front-end style. */
+.reveal,
+[class*="reveal"],
+[class*="fade-in"],
+[class*="fadein"],
+[class*="animate"],
+[class*="aos-"],
+[data-aos] {
+  opacity: 1 !important;
+  transform: none !important;
+  visibility: visible !important;
+  animation: none !important;
+  transition: none !important;
+}
+`;
 
 export function assembleLocalTheme(opts: AssembleLocalThemeOpts): ReplicaFile[] {
   // NOTE: buildThemeScaffold's footerBgToken/footerTextToken opts are NOT
@@ -351,6 +376,10 @@ export function assembleLocalTheme(opts: AssembleLocalThemeOpts): ReplicaFile[] 
     // 2. Emit asset files — each file only when its content is non-empty.
     if (hasCSS) {
       withTemplates.push({ relativePath: 'assets/css/source.css', content: css });
+      // Editor-only reveal reset (add_editor_style list above; NOT enqueued on
+      // the front end), so blocks hidden by carried scroll-reveal CSS stay
+      // visible + editable in the block editor while the live animation runs.
+      withTemplates.push({ relativePath: 'assets/css/editor-reveal-reset.css', content: EDITOR_REVEAL_RESET_CSS });
     }
     if (hasJS) {
       withTemplates.push({ relativePath: 'assets/js/source.js', content: js });

--- a/src/mcp-server/handlers/convert-local-site.ts
+++ b/src/mcp-server/handlers/convert-local-site.ts
@@ -45,6 +45,7 @@ import { compareScreenshotDirs } from '../../lib/screenshot/compare.js';
 import { openEditorSession, scoreEditorSurface, type EditorSurfacePage } from '../../lib/preview/editor-preview.js';
 import { ensureStudioSite, expandTilde, studioWpRoot } from '../../lib/preview/studio-site.js';
 import { studioWp as studioWpExec } from '../../lib/preview/studio.js';
+import { ensurePlugin } from '../../lib/preview/ensure-plugin.js';
 import { connectBrowser } from '../../lib/browser-kit/index.js';
 import type { DataModel } from '../../lib/replicate/local-data/types.js';
 import { installLocalData } from '../../lib/replicate/local-data/data-install.js';
@@ -57,7 +58,7 @@ import { InstanceStyleSheet, mergeInstanceStyleCss } from '../../lib/replicate/n
 import { composedSidecarPath, instanceStylesPath } from '../../lib/streaming/block-markup-validate.js';
 import { buildLocalFoundation, extractCssColors, type PaletteAgg, type TypographyAgg, type BreakpointsAgg } from '../../lib/replicate/local-theme/foundation.js';
 import { extractGoogleFontCssUrls, selfHostGoogleFonts } from '../../lib/replicate/local-theme/google-fonts.js';
-import { collectSourceAssets, WP_COMPAT_CSS } from '../../lib/replicate/local-theme/source-assets.js';
+import { collectSourceAssets, rewriteHtmlImageSrcs, WP_COMPAT_CSS, type ImgAssetRef } from '../../lib/replicate/local-theme/source-assets.js';
 import { buildJetpackFormParityCss } from '../../lib/replicate/local-site/jetpack-form-css.js';
 import { JETPACK_FORM_PARITY_CSS } from '../../lib/replicate/local-theme/jetpack-form-parity-contract.js';
 import { detectBehaviors } from '../../lib/replicate/normalize/detect-behaviors.js';
@@ -562,12 +563,32 @@ export const convertLocalSiteHandler: Handler = async (args, ctx) => {
   // empty object (that would change theme assembly).
   let carrySourceAssets: { css: string; js: string } | undefined;
   let behaviors: DetectedBehaviors | undefined;
+  // Carried HTML <img> assets (content images) — repointed at the theme copies
+  // in the install loop; any SVG among them arms the safe-svg install below.
+  let imgRewritesByPage: Record<string, ImgAssetRef[]> = {};
+  let carriedImgCount = 0;
+  let svgCarried = false;
   if (carryCss || carryJs || nativeBehaviors) {
     const assets = collectSourceAssets(dir, site.pages.map((p) => ({ relPath: p.relPath, html: p.html })));
     if (assets.skippedUnlinked.length > 0) {
       warnings.push(
         `unlinked top-level assets skipped (linked assets exist; stale-revision protection): ${assets.skippedUnlinked.join(', ')}`,
       );
+    }
+    // Carry HTML <img> assets (content images: svg/png/jpg…) into the theme so
+    // the rewritten <img src> theme URLs resolve. Independent of carryCss — these
+    // are content, not design. Best-effort: a copy failure degrades to a warning.
+    imgRewritesByPage = assets.imgRewritesByPage;
+    for (const m of assets.imgAssets) {
+      try {
+        const dest = join(outputDir, 'theme', m.themeRel);
+        mkdirSync(dirname(dest), { recursive: true });
+        copyFileSync(m.srcAbs, dest);
+        carriedImgCount++;
+        if (/\.svg$/i.test(m.themeRel)) svgCarried = true;
+      } catch (err) {
+        warnings.push(`carry img ${m.themeRel}: ${(err as Error).message}`);
+      }
     }
     if (carryCss || carryJs) {
       // Splice the localized Google-font css (verbatim subsets, local URLs)
@@ -925,6 +946,23 @@ export const convertLocalSiteHandler: Handler = async (args, ctx) => {
       warnings.push(`plugin activate failed for ${slug}: ${(err as Error).message}`);
     }
   }
+  // SVGs ride into the theme as static assets (they render without a plugin),
+  // but install safe-svg whenever SVGs are present so the user can UPLOAD/replace
+  // them via the media library + block editor — the any-liberate-path "SVGs
+  // detected → safe-svg" rule (parity with the remote media-install path).
+  // Best-effort; a failure never aborts the conversion.
+  let safeSvgEnsured = false;
+  if (svgCarried) {
+    const ensured = await ensurePlugin(studioSitePath, 'safe-svg', studioWp);
+    if (ensured.ok) safeSvgEnsured = true;
+    else warnings.push(`safe-svg install failed: ${ensured.error}`);
+  }
+  if (carriedImgCount > 0) {
+    warnings.push(
+      `carried ${carriedImgCount} HTML <img> asset(s) into the theme` +
+        (svgCarried ? ` (safe-svg ${safeSvgEnsured ? 'ensured' : 'NOT installed'})` : ''),
+    );
+  }
   // Resolve the replica base URL now that the site is known reachable
   // (activation just ran against it). Failure degrades to the conventional
   // wp-env default with a warning — never aborts.
@@ -1077,6 +1115,13 @@ export const convertLocalSiteHandler: Handler = async (args, ctx) => {
           contentOverride = inj.markup;
           warnings.push(`data: ${item.slug} → query loop(s) for ${inj.injected.join(', ')}`);
         }
+      }
+      // Repoint carried <img src> at the theme-carried asset copies (else the
+      // source-relative paths 404 against the WP page permalink).
+      const imgPage = site.pages.find((p) => p.slug === item.slug);
+      const imgRefs = imgPage ? imgRewritesByPage[imgPage.relPath] : undefined;
+      if (imgRefs && imgRefs.length > 0) {
+        contentOverride = rewriteHtmlImageSrcs(contentOverride ?? item.content, imgRefs, themeSlug);
       }
       const res = await installPost({ item, outputDir, studioSitePath, contentOverride });
       if (!res || res.action === 'error') {


### PR DESCRIPTION
## Summary

Three fidelity fixes for the **owned-local convert path** (`liberate_convert_local_site` / `liberate-local`), all surfaced by dogfooding a hand-authored static site through `/liberate`:

1. **Carry HTML `<img>`/SVG assets** — `collectSourceAssets` only harvested CSS-referenced images and self-hosted fonts, so every `<img src="assets/*.svg">` stayed site-root-relative and **404'd** in the replica, and `safe-svg` was never installed on this path. New `collectHtmlImages` + `rewriteHtmlImageSrcs` carry local `<img>` assets into `theme/assets/img/`, repoint each page's content (via the existing install-loop `contentOverride` seam), and run `ensurePlugin('safe-svg')` once when any SVG is carried — so SVGs render as theme statics and become media-library uploadable.

2. **Keep the carried JS bundle parseable** — the inline-script harvester slurped *every* `<script>` without a `src` into `source.js`, including `<script type="application/ld+json">`. A JSON-LD body concatenated as JavaScript is a parse-time `SyntaxError` that aborts the **entire** bundle, silently killing every carried behavior (scroll-reveal, nav, accordions) and leaving reveal content stuck at `opacity:0`. A new `isExecutableInlineScript` gate carries inline scripts only for executable JS types (absent/empty type, JS MIME, or `module`).

3. **Keep reveal blocks visible in the block editor** — the carried `.reveal{opacity:0}` loads into the editor canvas via `add_editor_style`, but the editor can't run the scroll-reveal JS, so those blocks were invisible and uneditable. `assembleLocalTheme` now emits an **editor-only** `assets/css/editor-reveal-reset.css` (`opacity:1 !important` for reveal/fade/animate patterns) appended last to the `add_editor_style` list and never enqueued on the front end, so the live animation is untouched.

## Verification (on the dogfood site)

- All 13 SVG `<img>` URLs return **200** (were 404); `safe-svg` active.
- Carried `source.js` passes `node --check` (was a `SyntaxError`); reveal fires on scroll (21/21 sections), mobile parity 0.640 → 0.710.
- Block editor: **21/21 reveal blocks at opacity 1, 0 hidden**.
- Text-contrast probe across all 5 pages: 0 low-contrast text.

## Test plan

- [ ] `npx vitest run src/lib/replicate/local-theme/source-assets.test.ts src/lib/replicate/local-theme/theme-files.test.ts src/mcp-server/handlers/convert-local-site.test.ts`
- [ ] `/liberate <dir>` on a local site containing SVG `<img>`s + JSON-LD; confirm SVGs render (200), `source.js` parses, and reveal blocks are visible/editable in the block editor.

## Notes / follow-up

- Known gap left untouched: the `lib-i` instance-style mechanism flattens an inline `style=""` to a single class, which **loses inline's precedence** over equal-specificity source class rules (it ties and the cascade order decides). A faithful fix would emit `lib-i` declarations `!important` to mirror inline beating classes — deferred as broader/riskier.
