### PR TITLE
fix(local-site): preserve nested styling and loose body elements

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "data-liberation",
   "description": "Extract content from closed web platforms (GoDaddy Websites & Marketing, Hostinger, HubSpot, Shopify, Squarespace, Webflow, Weebly, Wix) into WordPress-compatible WXR files. Inspect, extract, QA, and import to WordPress.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Automattic"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "data-liberation",
   "description": "Extract content from closed web platforms (GoDaddy Websites & Marketing, Hostinger, HubSpot, Shopify, Squarespace, Webflow, Weebly, Wix) into WordPress-compatible WXR files. Inspect, extract, QA, and import to WordPress.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Automattic"
   },

--- a/src/lib/replicate/local-theme/source-assets.test.ts
+++ b/src/lib/replicate/local-theme/source-assets.test.ts
@@ -18,10 +18,14 @@ function makeSite(): string {
 describe('WP_COMPAT_CSS', () => {
   it('strips the inner core/button link chrome for carried (lib-cta) buttons so the wrapper pill renders once', () => {
     expect(WP_COMPAT_CSS).toContain('.wp-block-button.lib-cta > .wp-block-button__link');
-    // The reset must zero the box that would paint a second pill.
+    // The reset must zero the box that would paint a second pill — INCLUDING the
+    // box-shadow. A carried `.btn{box-shadow:6px 6px 0 ink}` left on the inner
+    // link casts a hard offset shadow behind the label that reads as a second
+    // border around the text (the double-border bug).
     const rule = WP_COMPAT_CSS.slice(WP_COMPAT_CSS.indexOf('.wp-block-button.lib-cta'));
     expect(rule).toMatch(/background:\s*transparent/);
     expect(rule).toMatch(/padding:\s*0/);
+    expect(rule).toMatch(/box-shadow:\s*none/);
   });
 });
 

--- a/src/lib/replicate/local-theme/source-assets.ts
+++ b/src/lib/replicate/local-theme/source-assets.ts
@@ -51,16 +51,19 @@ nav.wp-block-navigation ul, nav.wp-block-navigation li { display: contents; }
 /* core/button renders TWO boxes: the source button class lands on the
    .wp-block-button WRAPPER (core/button stores className there; the fixer
    strips it off the inner link), so the carried .btn/.btn-* rules style the
-   wrapper pill — while WP still paints the inner .wp-block-button__link with
-   its own default button chrome (fill bg + padding + radius), a second pill
-   inside the source one. Strip the inner link's box so the carried wrapper
-   style renders once. The lib-cta marker (emit-blocks) scopes this to carried
+   wrapper pill — while the inner .wp-block-button__link still carries BOTH WP's
+   default button chrome (fill bg + padding + radius) AND the carried source
+   button class the emitter writes onto the link (a .btn box-shadow of 6px 6px 0
+   ink casts a hard offset shadow behind the label — the double-border bug). Strip the
+   inner link's whole box (incl. box-shadow) so the carried wrapper style renders
+   once. The lib-cta marker (emit-blocks) scopes this to carried
    buttons so genuine native core/button blocks keep their chrome; class-level
    specificity beats WP's :where()/global-styles button defaults, and source
    stylesheets never target wp-* classes. */
 .wp-block-button.lib-cta > .wp-block-button__link {
   background: transparent;
   border: 0;
+  box-shadow: none;
   padding: 0;
   border-radius: inherit;
   color: inherit;

--- a/src/lib/replicate/normalize/compose-page.test.ts
+++ b/src/lib/replicate/normalize/compose-page.test.ts
@@ -227,3 +227,36 @@ describe('composePage block-contract issues (warning-level)', () => {
     expect(composePage(empty).contractIssues).toEqual([]);
   });
 });
+
+describe('composePage styling-conservation (dropped source classes)', () => {
+  it('reports no dropped classes when source classes survive the conversion', () => {
+    const p: LocalPage = {
+      ...page,
+      html: '<body><main><section id="s"><div class="stat"><div class="stat-num">12k</div></div></section></main></body>',
+    };
+    expect(composePage(p).stylingDrops).toEqual([]);
+  });
+
+  it('flags a dropped source class with its section id (inline <code> unwrapped in rich text)', () => {
+    const p: LocalPage = {
+      ...page,
+      html: '<body><main><section id="s"><p>hi <code class="bar">x</code></p></section></main></body>',
+    };
+    expect(composePage(p).stylingDrops).toEqual([{ sectionId: 's', droppedClasses: ['bar'] }]);
+  });
+
+  it('does not flag classes dropped by an intentional form→Jetpack conversion', () => {
+    const p: LocalPage = {
+      ...page,
+      html: '<body><main><section id="contact"><form class="form-card"><div class="field"><input type="email" name="email" placeholder="x"></div></form></section></main></body>',
+    };
+    const { stylingDrops, formsConverted } = composePage(p, { jetpackForms: true });
+    expect(formsConverted).toBeGreaterThan(0); // the form actually converted
+    expect(stylingDrops).toEqual([]); // form-card/field are intentionally replaced by Jetpack markup
+  });
+
+  it('empty page returns an empty stylingDrops array', () => {
+    const empty: LocalPage = { ...page, html: '<body><main></main></body>' };
+    expect(composePage(empty).stylingDrops).toEqual([]);
+  });
+});

--- a/src/lib/replicate/normalize/compose-page.ts
+++ b/src/lib/replicate/normalize/compose-page.ts
@@ -5,6 +5,7 @@ import { blockMarkupRoundtrips } from '../../streaming/block-markup-validate.js'
 import { segmentPage } from './segment.js';
 import { rewriteInternalHrefs } from '../local-site/href-rewrite.js';
 import { emitSectionBlocks } from './emit-blocks.js';
+import { findDroppedClasses, type SectionStylingDrop } from './styling-conservation.js';
 import type { InstanceStyleSheet } from './instance-styles.js';
 import type { LocalPage, NormalizeReportEntry, RevealBehavior, Section, SectionBehavior } from '../local-site/types.js';
 
@@ -15,6 +16,10 @@ export interface ComposePageResult {
   /** Registered-metadata contract issues (WARNING-level — the emitter is
    * contract-clean by construction; non-empty = an emitter bug to fix). */
   contractIssues: BlockContractIssue[];
+  /** Source CSS classes that did NOT survive a section's block conversion
+   * (WARNING-level styling-conservation diagnostic). Empty on a clean page;
+   * non-empty = a dropped styling hook the carried CSS targeted. */
+  stylingDrops: SectionStylingDrop[];
 }
 
 export interface ComposePageOpts {
@@ -71,11 +76,13 @@ export function composePage(page: LocalPage, opts: ComposePageOpts = {}): Compos
       return opts.reveal ? { ...s, behavior: opts.reveal } : s;
     });
   // Genuinely empty page: nothing to validate, skip the roundtrip gate.
-  if (bodySections.length === 0) return { postContent: '', report: [], formsConverted: 0, contractIssues: [] };
+  if (bodySections.length === 0)
+    return { postContent: '', report: [], formsConverted: 0, contractIssues: [], stylingDrops: [] };
 
   const skeleton: LayoutSkeleton = { sections: [] };
   const pageContent: Record<string, string> = {};
   const report: NormalizeReportEntry[] = [];
+  const stylingDrops: SectionStylingDrop[] = [];
   let formsConverted = 0;
 
   for (const section of bodySections) {
@@ -86,6 +93,13 @@ export function composePage(page: LocalPage, opts: ComposePageOpts = {}): Compos
       jetpackForms: opts.jetpackForms,
     });
     formsConverted += sectionFormsConverted;
+    // Styling-conservation: surface any source class the conversion dropped
+    // (the carried CSS that targeted it no longer matches). Warning-level.
+    // Sections converted to a Jetpack Form are SKIPPED — their source form
+    // structure (form-card/field/field-row/…) is intentionally replaced by the
+    // Jetpack block markup, so those drops are by-design, not lost styling.
+    const droppedClasses = sectionFormsConverted > 0 ? [] : findDroppedClasses(section.html, markup);
+    if (droppedClasses.length > 0) stylingDrops.push({ sectionId: section.id, droppedClasses });
     skeleton.sections.push({ type: 'content', slots: [section.id] });
     pageContent[section.id] = markup;
     // blockType reflects the WRAPPER EMITTED: carry-tagged sections wrap as
@@ -117,5 +131,5 @@ export function composePage(page: LocalPage, opts: ComposePageOpts = {}): Compos
   }
   // Warning-level sibling of the roundtrip gate: emitted attrs vs registered
   // core metadata (never throws; dla/* + core/html allowlisted in the check).
-  return { postContent, report, formsConverted, contractIssues: validateBlockContract(postContent) };
+  return { postContent, report, formsConverted, contractIssues: validateBlockContract(postContent), stylingDrops };
 }

--- a/src/lib/replicate/normalize/emit-blocks.test.ts
+++ b/src/lib/replicate/normalize/emit-blocks.test.ts
@@ -116,8 +116,12 @@ describe('emitSectionBlocks', () => {
     expect(markup).toContain('<!-- wp:heading');
   });
 
-  it('flags confidence < 1 when an unrecognized child is downgraded to a paragraph', () => {
-    const section = { id: 's', role: 'body' as const, html: '<section><figure>weird</figure></section>' };
+  it('flags confidence < 1 when a child loses content (loose text beside elements is dropped)', () => {
+    // A wrapper mixing element children with stray loose text drops that text
+    // (only a childless wrapper emits its loose text) — a genuine loss the
+    // confidence signal surfaces. (A styling-bearing leaf is now preserved
+    // losslessly and no longer lowers confidence — see the nested-leaf suite.)
+    const section = { id: 's', role: 'body' as const, html: '<section><div><h3>Kept</h3> dropped stray text</div></section>' };
     const { confidence } = emitSectionBlocks(section);
     expect(confidence).toBeLessThan(1);
   });
@@ -145,7 +149,7 @@ describe('emitSectionBlocks', () => {
     expect(blockMarkupRoundtrips(markup).ok).toBe(true);
   });
 
-  it('rescues img descendants of an unknown wrapper instead of dropping them', () => {
+  it('converts a figure (img + figcaption) without loss: image block + preserved caption', () => {
     const section = {
       id: 's',
       role: 'body' as const,
@@ -154,8 +158,10 @@ describe('emitSectionBlocks', () => {
     const { markup, confidence } = emitSectionBlocks(section);
     expect(markup).toContain('<!-- wp:image');
     expect(markup).toContain('pic.png');
-    expect(markup).toContain('Cap text');
-    expect(confidence).toBeLessThan(1);
+    // figcaption is element-targeted CSS (.gallery figcaption{}) — kept verbatim,
+    // not flattened to a class-less <p>, so the figure converts losslessly.
+    expect(markup).toContain('<figcaption>Cap text</figcaption>');
+    expect(confidence).toBe(1);
     expect(blockMarkupRoundtrips(markup).ok).toBe(true);
   });
 
@@ -173,10 +179,13 @@ describe('emitSectionBlocks', () => {
   });
 
   it('unwraps non-allowlisted inline wrappers, preserving nested links', () => {
+    // A non-allowlisted inline tag (here <u>) is transparently unwrapped so its
+    // nested link survives. (A classless <span> is now KEPT, not unwrapped — it
+    // anchors contextual `.parent span` CSS; see the nested-leaf suite.)
     const section = {
       id: 's',
       role: 'body' as const,
-      html: '<section><p>Visit <span><a href="/shop.html">the shop</a></span> today</p></section>',
+      html: '<section><p>Visit <u><a href="/shop.html">the shop</a></u> today</p></section>',
     };
     const { markup, confidence } = emitSectionBlocks(section);
     expect(markup).toContain('Visit <a href="/shop.html">the shop</a> today');
@@ -683,16 +692,18 @@ describe('id-preserving unknown wrappers (JS-rendered sites)', () => {
     expect(confidence).toBe(1); // structural preservation, nothing lost
   });
 
-  it('an unknown div WITHOUT id keeps the existing downgrade path (regression)', () => {
+  it('an unknown classed div WITHOUT id becomes a paragraph that keeps its class (not a group anchor)', () => {
     const section = {
       id: 's',
       role: 'body' as const,
       html: '<section id="s"><div class="mystery">Loose text</div></section>',
     };
     const { markup, confidence } = emitSectionBlocks(section);
-    expect(markup).toContain('Loose text');
+    // Class-bearing leaf → core/paragraph carrying the class (carried CSS keeps
+    // matching), NOT a group with an id anchor (no id present).
+    expect(markup).toContain('<p class="mystery">Loose text</p>');
     expect(markup).not.toContain('"anchor":"mystery"');
-    expect(confidence).toBeLessThan(1);
+    expect(confidence).toBe(1);
   });
 });
 
@@ -742,15 +753,18 @@ describe('structural wrapper preservation (owned-source bodies)', () => {
     expect(sheet.toCss()).toContain('display:grid;gap:24px');
   });
 
-  it('a true text leaf still downgrades to a paragraph', () => {
+  it('a true text leaf becomes a paragraph that keeps its class (not a structural group)', () => {
     const section = {
       id: 's',
       role: 'body' as const,
       html: '<section id="s"><div class="badge">Leaf text only</div></section>',
     };
     const { markup, confidence } = emitSectionBlocks(section);
-    expect(markup).toContain('Leaf text only');
-    expect(confidence).toBeLessThan(1);
+    // A childless leaf is NOT promoted to a group; it becomes a paragraph that
+    // carries its source class (previously dropped to a bare <p>).
+    expect(markup).toContain('<p class="badge">Leaf text only</p>');
+    expect(markup).not.toContain('wp-block-group badge');
+    expect(confidence).toBe(1);
   });
 });
 
@@ -881,11 +895,13 @@ describe('emitSectionBlocks verbatimInteractive (chrome carry)', () => {
     '<ul class="submenu"><li><a href="/a.html">Docs</a></li></ul>' +
     '</li></ul></section>';
 
-  it('default (off): drops the button, chevron svg, and has-children class', () => {
+  it('default (off): drops the button + chevron svg, but keeps the list-item class', () => {
     const { markup } = emitSectionBlocks({ id: 'hdr', role: 'body' as const, html: navHtml });
     expect(markup).not.toContain('<button');
     expect(markup).not.toContain('<svg');
-    expect(markup).not.toContain('menu-item--has-children');
+    // The list-item CLASS now survives (a carried-CSS styling hook) even though
+    // the interactive button/svg still need verbatimInteractive to be preserved.
+    expect(markup).toContain('menu-item--has-children');
   });
 
   it('on: preserves the button, chevron svg, has-children class, and submenu', () => {
@@ -922,16 +938,20 @@ describe('emitSectionBlocks verbatimInteractive (chrome carry)', () => {
 
   it('on: preserves an EMPTY classed element (CSS-background logo hook)', () => {
     // A logo is often an empty <a class="brand-logo"> filled by CSS
-    // background:url(logo.svg). The normal path downgrades an empty element to
-    // <p></p>, dropping the class and killing the logo. verbatimInteractive
-    // keeps the classed anchor.
+    // background:url(logo.svg). Both paths keep the classed anchor: the body path
+    // preserves an empty classed styling hook verbatim, and verbatimInteractive
+    // keeps it as part of the byte-true interactive subtree.
     const html =
       '<section id="hdr">' +
       '<a class="brand-logo" href="/" aria-label="Home"></a>' +
       '<ul class="site-menu"><li><a href="/home.html">Home</a></li></ul>' +
       '</section>';
     const off = emitSectionBlocks({ id: 'hdr', role: 'body' as const, html });
-    expect(off.markup).not.toContain('brand-logo'); // control: dropped without the opt
+    // The body path now ALSO preserves an empty classed styling hook verbatim
+    // (the overlay/logo case — see the nested-leaf suite), so the class survives
+    // even without the opt. verbatimInteractive additionally keeps interactive
+    // subtrees (the nav) byte-true.
+    expect(off.markup).toContain('brand-logo');
 
     const { markup } = emitSectionBlocks(
       { id: 'hdr', role: 'body' as const, html },
@@ -986,5 +1006,111 @@ describe('emitSectionBlocks verbatimInteractive (chrome carry)', () => {
     );
     expect(markup).toContain('<!-- wp:list');
     expect(markup).not.toContain('<!-- wp:html -->');
+  });
+});
+
+describe('emitSectionBlocks — nested leaf styling preservation', () => {
+  it('keeps a nested leaf div class on a core/paragraph (class-targeted CSS)', () => {
+    // <div class="stat-num">12k</div> inside a .stat group is class-targeted
+    // (.stat .stat-num{}). It must keep its class, not flatten to a bare <p>.
+    const section = {
+      id: 'stats',
+      role: 'body' as const,
+      html: '<section><div class="stat"><div class="stat-num">12k</div><div class="stat-label">Members</div></div></section>',
+    };
+    const { markup } = emitSectionBlocks(section);
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toContain('<p class="stat-num">12k</p>');
+    expect(markup).toContain('<p class="stat-label">Members</p>');
+  });
+
+  it('keeps a nested leaf span class on a core/paragraph (e.g. a quote attribution)', () => {
+    const section = {
+      id: 'quote',
+      role: 'body' as const,
+      html: '<section><blockquote class="quote"><p>A fine review.</p><span class="quote-by">— A Patron</span></blockquote></section>',
+    };
+    const { markup } = emitSectionBlocks(section);
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toContain('<p class="quote-by">— A Patron</p>');
+  });
+
+  it('carries a nested leaf inline style as a lib-i class (not a stripped style= attr)', () => {
+    const sheet = new InstanceStyleSheet();
+    const section = {
+      id: 's',
+      role: 'body' as const,
+      html: '<section><div class="badge"><div class="tag" style="color:var(--hot)">New</div></div></section>',
+    };
+    const { markup } = emitSectionBlocks(section, { instanceStyles: sheet });
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toMatch(/<p class="tag lib-i[0-9a-f]{10}">New<\/p>/);
+    expect(markup).not.toContain('style="color');
+    expect(sheet.toCss()).toContain('color:var(--hot)');
+  });
+
+  it('preserves a nested semantic leaf tag verbatim (element-targeted CSS survives)', () => {
+    // .gallery figcaption{} targets the ELEMENT (no class) — flattening to <p>
+    // would break it. Keep the figcaption tag via a verbatim html island.
+    const section = {
+      id: 'gallery',
+      role: 'body' as const,
+      html: '<section><figure><img src="a.jpg" alt="A"><figcaption>Caption text</figcaption></figure></section>',
+    };
+    const { markup } = emitSectionBlocks(section);
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toContain('<figcaption>Caption text</figcaption>');
+  });
+
+  it('preserves an empty classed styling-hook element (decorative CSS-painted overlay)', () => {
+    // <div class="overlay"></div> is painted entirely by CSS — a bare empty <p>
+    // drops the class and kills the visual. Keep it verbatim.
+    const section = {
+      id: 's',
+      role: 'body' as const,
+      html: '<section><div class="overlay"></div></section>',
+    };
+    const { markup } = emitSectionBlocks(section);
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toContain('<div class="overlay"></div>');
+  });
+
+  it('keeps a classless <span> inside rich text so contextual ".parent span" CSS survives', () => {
+    const section = {
+      id: 's',
+      role: 'body' as const,
+      html: '<section><p class="pull">We <span>start</span> arguments.</p></section>',
+    };
+    const { markup } = emitSectionBlocks(section);
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toContain('We <span>start</span> arguments.');
+  });
+
+  it('preserves a list-item class on core/list-item (e.g. a reveal hook)', () => {
+    // <li class="reveal"> drove a scroll animation; listItemBlock dropped the
+    // class, flattening to a bare <li> (the carried .reveal rule stops matching).
+    const section = {
+      id: 's',
+      role: 'body' as const,
+      html: '<section><ol class="manifesto"><li class="reveal">One</li><li class="reveal">Two</li></ol></section>',
+    };
+    const { markup } = emitSectionBlocks(section);
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toContain('<li class="reveal">One</li>');
+    expect(markup).toContain('<li class="reveal">Two</li>');
+  });
+
+  it('carries an <img> inline style as a lib-i class + rule (fixer-safe)', () => {
+    const sheet = new InstanceStyleSheet();
+    const section = {
+      id: 's',
+      role: 'body' as const,
+      html: '<section><img src="a.svg" alt="A" style="background:var(--ink)"></section>',
+    };
+    const { markup } = emitSectionBlocks(section, { instanceStyles: sheet });
+    expect(blockMarkupRoundtrips(markup).ok).toBe(true);
+    expect(markup).toMatch(/wp-block-image lib-i[0-9a-f]{10}/);
+    expect(markup).not.toContain('style="background');
+    expect(sheet.toCss()).toContain('background:var(--ink)');
   });
 });

--- a/src/lib/replicate/normalize/emit-blocks.ts
+++ b/src/lib/replicate/normalize/emit-blocks.ts
@@ -78,13 +78,13 @@ function inlineHtml($: CheerioAPI, el: Element): string {
       }
       const cls = ($(node).attr('class') ?? '').trim();
       const styleA = ($(node).attr('style') ?? '').trim();
-      // A <span> with NEITHER class nor style carries no styling info — keep
-      // unwrapping it so nested content (links) survives without a noise
-      // wrapper. A span with a class (.num/.it) or inline style (color hooks)
-      // is a source styling anchor and is preserved verbatim.
-      if (tag === 'span' && !cls && !styleA) {
-        out += inlineHtml($, node);
-      } else if (INLINE_ALLOWED.has(tag)) {
+      // Keep every allowed inline tag verbatim — INCLUDING a classless, styleless
+      // <span>. A bare span looks inert but contextual source selectors target it
+      // (`.pull span{color:…}`, `.marquee span{…}`); unwrapping it drops that
+      // styling. Spans carrying a class (.num/.it) or inline style are styling
+      // anchors and are likewise preserved. Keeping the wrapper never loses nested
+      // content — a link inside the span still survives.
+      if (INLINE_ALLOWED.has(tag)) {
         const inner = inlineHtml($, node);
         const clsAttr = cls ? ` class="${escapeHtml(cls)}"` : '';
         if (tag === 'a') {
@@ -104,10 +104,16 @@ function inlineHtml($: CheerioAPI, el: Element): string {
   return out;
 }
 
-function imageBlock($: CheerioAPI, imgEl: Element): string {
+function imageBlock($: CheerioAPI, imgEl: Element, sheet: InstanceStyleSheet): string {
   const src = escapeHtml($(imgEl).attr('src') ?? '');
   const alt = escapeHtml($(imgEl).attr('alt') ?? '');
-  const cls = classNameOf($(imgEl));
+  // Fold the img's source class AND its inline style (a background backdrop,
+  // aspect-ratio, object-fit…) into the className: classNameWithInstance hashes
+  // the inline style into a lib-i class + carried rule. A raw style= attr would
+  // be stripped by the fixer (core/image keeps only [class]); the class survives.
+  // The rule lands on the wp-block-image figure, which wraps the img tightly, so
+  // a carried `background` paints exactly behind the image.
+  const cls = classNameWithInstance($(imgEl), sheet);
   const attrs = blockAttrs([], cls);
   const figCls = ['wp-block-image', cls].filter(Boolean).join(' ');
   return `<!-- wp:image${attrs} -->\n<figure class="${escapeHtml(figCls)}"><img src="${src}" alt="${alt}"/></figure>\n<!-- /wp:image -->`;
@@ -119,9 +125,15 @@ function paragraphBlock(inner: string): string {
 
 function listItemBlock($: CheerioAPI, li: Element, sheet: InstanceStyleSheet): string {
   const $li = $(li);
+  // Preserve the <li> class (+ per-instance inline style) — owned sources hang
+  // styling/animation hooks on list items (a .reveal scroll animation); core/
+  // list-item carries a className, so the carried CSS keeps matching.
+  const cls = classNameWithInstance($li, sheet);
+  const attrs = blockAttrs([], cls);
+  const clsPart = cls ? ` class="${escapeHtml(cls)}"` : '';
   const nestedLists = $li.children('ul, ol').toArray() as Element[];
   if (nestedLists.length === 0) {
-    return `<!-- wp:list-item -->\n<li>${inlineHtml($, li).trim()}</li>\n<!-- /wp:list-item -->`;
+    return `<!-- wp:list-item${attrs} -->\n<li${clsPart}>${inlineHtml($, li).trim()}</li>\n<!-- /wp:list-item -->`;
   }
 
   const leadingClone = $li.clone();
@@ -131,7 +143,7 @@ function listItemBlock($: CheerioAPI, li: Element, sheet: InstanceStyleSheet): s
   const leading = leadingEl && isTag(leadingEl) ? inlineHtml($, leadingEl).trim() : '';
   const nested = nestedLists.map((nestedList) => listBlock($, nestedList, sheet)).join('\n');
   const body = [leading, nested].filter(Boolean).join('\n');
-  return `<!-- wp:list-item -->\n<li>${body}</li>\n<!-- /wp:list-item -->`;
+  return `<!-- wp:list-item${attrs} -->\n<li${clsPart}>${body}</li>\n<!-- /wp:list-item -->`;
 }
 
 function listBlock($: CheerioAPI, listEl: Element, sheet: InstanceStyleSheet): string {
@@ -283,7 +295,7 @@ function emitChild($: CheerioAPI, el: Element, sheet: InstanceStyleSheet, opts: 
   }
 
   if (tag === 'img') {
-    return { markup: imageBlock($, el), clean: true };
+    return { markup: imageBlock($, el, sheet), clean: true };
   }
 
   if (tag === 'a' && isButtonAnchor($, el)) {
@@ -448,7 +460,7 @@ function emitChild($: CheerioAPI, el: Element, sheet: InstanceStyleSheet, opts: 
   const imgs = $el.find('img');
   if (imgs.length > 0) {
     const imgMarkup = imgs
-      .map((_, imgEl) => imageBlock($, imgEl))
+      .map((_, imgEl) => imageBlock($, imgEl, sheet))
       .get()
       .join('\n');
     const text = escapeHtml($el.text().trim());
@@ -456,8 +468,39 @@ function emitChild($: CheerioAPI, el: Element, sheet: InstanceStyleSheet, opts: 
     return { markup: imgMarkup + textPara, clean: false };
   }
 
-  // Fallback: downgrade unknown element to a paragraph of its text.
-  return { markup: paragraphBlock(escapeHtml($el.text().trim())), clean: false };
+  // Leaf element (no element children, no id) reached the fallback. Preserve its
+  // styling instead of flattening to a bare <p>, which silently drops the class
+  // the carried CSS targets (`.stat .stat-num`, `.quote .quote-by`), the element
+  // tag a selector targets (`.gallery figcaption`), and any inline style.
+  const text = $el.text().trim();
+  if (tag === 'div' || tag === 'span') {
+    if (text) {
+      // Generic text container with content → a core/paragraph carrying the
+      // source class + a per-instance style class. Class-targeted CSS matches the
+      // className; the <p> tag is immaterial (the source styles by class, not
+      // element). Nested inline markup (a <strong>/<a>) survives via inlineHtml.
+      // Stays natively editable.
+      const cls = classNameWithInstance($el, sheet);
+      const attrs = blockAttrs([], cls);
+      const clsPart = cls ? ` class="${escapeHtml(cls)}"` : '';
+      return {
+        markup: `<!-- wp:paragraph${attrs} -->\n<p${clsPart}>${inlineHtml($, el).trim()}</p>\n<!-- /wp:paragraph -->`,
+        clean: true,
+      };
+    }
+    // An EMPTY classed div/span is a CSS-painted styling hook (a decorative
+    // overlay, a divider, a spacer): preserve it verbatim so the class — and the
+    // carried rule that paints it — survives. Empty + classless → nothing to keep.
+    const verbatimHook = ($el.attr('class') ?? '').trim() ? ($.html(el) ?? '').trim() : '';
+    if (verbatimHook) return { markup: htmlBlock(verbatimHook), clean: true };
+    return { markup: paragraphBlock(escapeHtml(text)), clean: false };
+  }
+  // A semantic leaf (figcaption, cite, time, address, small…): the source may
+  // select it by ELEMENT, so a <p> would break the selector. Preserve it verbatim
+  // (tag + class + inline style + inline content) as an html island.
+  const verbatim = ($.html(el) ?? '').trim();
+  if (verbatim) return { markup: htmlBlock(verbatim), clean: true };
+  return { markup: paragraphBlock(escapeHtml(text)), clean: false };
 }
 
 export interface EmitSectionOpts {

--- a/src/lib/replicate/normalize/instance-styles.ts
+++ b/src/lib/replicate/normalize/instance-styles.ts
@@ -73,6 +73,12 @@ export class InstanceStyleSheet {
    * Emit the stylesheet: one rule per unique declaration set, sorted by class
    * for byte-stable output (so re-runs produce an identical instance-styles.css
    * and don't churn the theme / bust caches needlessly).
+   *
+   * No `!important`: the carried sheet is enqueued AFTER the source stylesheet
+   * (theme-files cascade order), so a `lib-i` rule already outranks a competing
+   * source single-class rule (e.g. an inline `background:…` override of
+   * `.sticker{background:…}`) on load order. `!important` is reserved for cases
+   * where that genuinely doesn't suffice (a higher-specificity source selector).
    */
   toCss(): string {
     return [...this.rules.entries()]

--- a/src/lib/replicate/normalize/segment.test.ts
+++ b/src/lib/replicate/normalize/segment.test.ts
@@ -187,14 +187,17 @@ describe('segmentPage', () => {
     expect(rails[0].html).toContain('role="complementary"');
   });
 
-  it('does not over-capture a short decorative aside as chrome', () => {
+  it('does not over-capture a short decorative aside as chrome (it becomes loose body content)', () => {
     const html = `<body>
       <aside class="badge">New</aside>
       <main><section id="content"><h1>Content</h1></section></main>
     </body>`;
     const sections = segmentPage(html);
+    // The aside is NOT chrome (not a nav/rail)...
     expect(sections.find((s) => s.role === 'nav')).toBeUndefined();
-    expect(sections.filter((s) => s.role === 'body').map((s) => s.id)).toEqual(['content']);
+    // ...but as a loose body-level sibling of <main> it is carried as body
+    // content (never-lose-content), not dropped.
+    expect(sections.filter((s) => s.role === 'body').map((s) => s.id)).toEqual(['badge', 'content']);
   });
 
   it('avoids dedup suffix collision with a pre-existing literal id', () => {
@@ -251,5 +254,37 @@ describe('segmentPage', () => {
     const sections = segmentPage(html).filter((s) => s.role === 'body');
     expect(sections[0].classes).toEqual(['hero', 'splash']);
     expect(sections[1].classes).toEqual(['cards']);
+  });
+
+  it('captures loose body siblings outside <main> (decorative/sticky bars) as body sections', () => {
+    // A .grain overlay before <header> and a sticky .marquee between header and
+    // <main> are body-level siblings of <main> — carry them, do not drop them.
+    const html = `<body>
+      <div class="grain" aria-hidden="true"></div>
+      <header id="masthead"><nav><a href="x.html">X</a></nav></header>
+      <div class="marquee"><span>Ticker</span></div>
+      <main>
+        <section id="hero"><h1>Hi</h1></section>
+      </main>
+      <footer><p>(c)</p></footer>
+    </body>`;
+    const sections = segmentPage(html);
+    expect(sections.find((s) => s.role === 'header')).toBeTruthy();
+    expect(sections.find((s) => s.role === 'footer')).toBeTruthy();
+    const body = sections.filter((s) => s.role === 'body');
+    // DOM order: grain + marquee (both before <main>) then main's hero.
+    expect(body.map((s) => s.id)).toEqual(['grain', 'marquee', 'hero']);
+    expect(body.find((s) => s.id === 'marquee')?.html).toContain('Ticker');
+  });
+
+  it('captures a loose body sibling AND still expands a wrapped <main> in place', () => {
+    // The loose-sibling capture must descend to <main>'s children when main is
+    // nested in a layout wrapper — emit the hero, not the whole .page wrapper.
+    const html = `<body>
+      <div class="marquee"><span>Ticker</span></div>
+      <div class="page"><main><section id="hero"><h1>Hi</h1></section></main></div>
+    </body>`;
+    const body = segmentPage(html).filter((s) => s.role === 'body');
+    expect(body.map((s) => s.id)).toEqual(['marquee', 'hero']);
   });
 });

--- a/src/lib/replicate/normalize/segment.ts
+++ b/src/lib/replicate/normalize/segment.ts
@@ -3,7 +3,7 @@ import { createHash } from 'node:crypto';
 import * as cheerio from 'cheerio';
 import type { Cheerio, CheerioAPI } from 'cheerio';
 import { isTag, isText } from 'domhandler';
-import type { Element } from 'domhandler';
+import type { AnyNode, Element } from 'domhandler';
 import { escapeHtml } from './emit-blocks.js';
 import type { Section, SectionRole } from '../local-site/types.js';
 
@@ -188,16 +188,35 @@ export function segmentPage(html: string): Section[] {
     layoutChromeOrdinal += 1;
   }
 
-  const main = $('main').first();
-  const container = main.length ? main : $('body');
-  // One uniform rule: EVERY top-level node of the container becomes a body
-  // section — wrapper elements (section/article/div) AND loose content
-  // (figure/h1/p/img/table/…) AND nonempty text nodes. The old
-  // children('section, article, div') filter silently dropped mixed loose
-  // children with no diagnostic ("body = top-level children of main",
-  // never-lose-content).
+  // Body content = EVERY top-level node — wrapper elements (section/article/div)
+  // AND loose content (figure/h1/p/img/…) AND nonempty text nodes. When a <main>
+  // exists its CHILDREN are the body (the <main> wrapper is unwrapped); loose
+  // body-level SIBLINGS of <main> are carried TOO (a .grain overlay before
+  // <header>, a sticky .marquee between header and main) — neither chrome nor
+  // inside <main>, they were previously dropped. The <main> expands in place even
+  // when nested in a layout wrapper, so the wrapper still yields main's children,
+  // not the wrapper itself. No <main> → every top-level body node is a section.
+  const mainEl = $('main').first().get(0) ?? null;
+  // True when a body-level node IS <main> or is an ANCESTOR of it (the layout
+  // wrapper holding <main>): that slot expands to main's own children.
+  const isMainSlot = (node: Element): boolean => {
+    if (!mainEl) return false;
+    if (node === mainEl) return true;
+    for (let p = mainEl.parent; p && isTag(p); p = p.parent) if (p === node) return true;
+    return false;
+  };
+  // Flatten body's top-level nodes in DOM order, expanding the <main> slot to its
+  // own children in place. Loose siblings keep their position relative to main.
+  const bodyNodes: AnyNode[] = [];
+  for (const node of $('body').contents().get()) {
+    if (isTag(node) && isMainSlot(node)) {
+      for (const child of $(mainEl as Element).contents().get()) bodyNodes.push(child);
+    } else {
+      bodyNodes.push(node);
+    }
+  }
   let ordinal = 0;
-  for (const node of container.contents().get()) {
+  for (const node of bodyNodes) {
     if (isTag(node)) {
       if (SKIP_TAGS.has(node.tagName?.toLowerCase() ?? '')) continue;
       if (chromeEls.has(node)) continue; // already captured as chrome

--- a/src/lib/replicate/normalize/styling-conservation.test.ts
+++ b/src/lib/replicate/normalize/styling-conservation.test.ts
@@ -1,0 +1,47 @@
+// src/lib/replicate/normalize/styling-conservation.test.ts
+import { describe, it, expect } from 'vitest';
+import { extractClassTokens, findDroppedClasses } from './styling-conservation.js';
+
+describe('extractClassTokens', () => {
+  it('collects class tokens from every element, split on whitespace', () => {
+    const set = extractClassTokens('<div class="a b"><span class="c">x</span></div>');
+    expect([...set].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('ignores classes on non-rendering tags (script/style/template/noscript)', () => {
+    const set = extractClassTokens('<div class="keep"></div><script class="track"></script><style class="s"></style>');
+    expect(set.has('keep')).toBe(true);
+    expect(set.has('track')).toBe(false);
+    expect(set.has('s')).toBe(false);
+  });
+
+  it('also reads classes carried only on a block "className" attribute (block markup)', () => {
+    // The emitter sometimes rides a class on the block comment attr; the rendered
+    // element may not byte-match. Both forms must count as "present".
+    const set = extractClassTokens('<!-- wp:group {"className":"only-attr"} -->\n<div class="wp-block-group">x</div>\n<!-- /wp:group -->');
+    expect(set.has('only-attr')).toBe(true);
+  });
+});
+
+describe('findDroppedClasses', () => {
+  it('flags a source class absent from the emitted markup (the dropped styling hook)', () => {
+    const source = '<div class="stat"><div class="stat-num">12k</div></div>';
+    const emitted = '<!-- wp:group {"className":"stat"} -->\n<div class="wp-block-group stat"><p>12k</p></div>\n<!-- /wp:group -->';
+    expect(findDroppedClasses(source, emitted)).toEqual(['stat-num']);
+  });
+
+  it('passes (no drops) when every source class survives in the emitted markup', () => {
+    const source = '<div class="stat"><div class="stat-num">12k</div></div>';
+    const emitted =
+      '<!-- wp:group {"className":"stat"} -->\n<div class="wp-block-group stat">' +
+      '<!-- wp:paragraph {"className":"stat-num"} -->\n<p class="stat-num">12k</p>\n<!-- /wp:paragraph -->' +
+      '</div>\n<!-- /wp:group -->';
+    expect(findDroppedClasses(source, emitted)).toEqual([]);
+  });
+
+  it('returns dropped classes sorted and de-duplicated', () => {
+    const source = '<div class="z"><span class="a">1</span><span class="a">2</span><b class="m">3</b></div>';
+    const emitted = '<div class="wp-block-group z">123</div>';
+    expect(findDroppedClasses(source, emitted)).toEqual(['a', 'm']);
+  });
+});

--- a/src/lib/replicate/normalize/styling-conservation.ts
+++ b/src/lib/replicate/normalize/styling-conservation.ts
@@ -1,0 +1,59 @@
+// src/lib/replicate/normalize/styling-conservation.ts
+//
+// Styling-conservation diagnostic: a deterministic, render-free check that a
+// section's source CSS classes survive into its emitted block markup. The block
+// conversion can silently DROP a class the carried stylesheet targets — a leaf
+// `.stat-num` flattened to a bare <p>, a styling hook unwrapped — and the loss
+// is invisible until someone eyeballs the rendered site. This is the safety net:
+// any source class missing from the output is surfaced as a WARNING so the whole
+// drop-category is caught on the first run, on every site, not rediscovered one
+// dogfood at a time.
+//
+// Scope is deliberately CLASS-level (the dominant, lowest-noise styling hook in
+// owned sources). Element-tag and inline-style conservation are noisier
+// (container tags legitimately convert to core/group <div>) and left to a deeper
+// follow-up; the specific tag/inline-style fixes have their own unit tests.
+import * as cheerio from 'cheerio';
+import type { Element } from 'domhandler';
+
+/** A section whose emitted block markup dropped one or more source classes. */
+export interface SectionStylingDrop {
+  sectionId: string;
+  droppedClasses: string[];
+}
+
+/** Non-rendering tags whose classes are never styling hooks. */
+const SKIP_TAGS = new Set(['script', 'style', 'template', 'noscript']);
+/** Block-markup `"className":"…"` attrs live inside HTML comments cheerio skips. */
+const CLASS_NAME_ATTR_RE = /"className"\s*:\s*"([^"]*)"/g;
+
+/**
+ * All CSS class tokens in `html` — from element `class=` attributes AND from
+ * block-markup `"className":"…"` attrs — so a class carried only on a block
+ * comment still counts as present. Classes on non-rendering tags are ignored.
+ */
+export function extractClassTokens(html: string): Set<string> {
+  const out = new Set<string>();
+  const $ = cheerio.load(html);
+  $('[class]').each((_, node) => {
+    const el = node as Element;
+    if (SKIP_TAGS.has(el.tagName?.toLowerCase() ?? '')) return;
+    for (const tok of ($(el).attr('class') ?? '').split(/\s+/)) if (tok) out.add(tok);
+  });
+  for (const m of html.matchAll(CLASS_NAME_ATTR_RE)) {
+    for (const tok of m[1].split(/\s+/)) if (tok) out.add(tok);
+  }
+  return out;
+}
+
+/**
+ * Source classes absent from the emitted block markup — dropped styling hooks
+ * the carried CSS targeted (`.stat .stat-num`, `.quote .quote-by`). Returns a
+ * sorted, de-duplicated list; `[]` when every source class survives.
+ */
+export function findDroppedClasses(sourceHtml: string, emittedMarkup: string): string[] {
+  const present = extractClassTokens(emittedMarkup);
+  const dropped = new Set<string>();
+  for (const cls of extractClassTokens(sourceHtml)) if (!present.has(cls)) dropped.add(cls);
+  return [...dropped].sort();
+}

--- a/src/mcp-server/handlers/convert-local-site.ts
+++ b/src/mcp-server/handlers/convert-local-site.ts
@@ -439,6 +439,7 @@ export const convertLocalSiteHandler: Handler = async (args, ctx) => {
     failedPagesList: Array<{ slug: string; error: string }>;
     formsConverted?: number;
     islandsConverted?: number;
+    stylingDrops?: number;
     behaviors?: { reveal: boolean; tabs: number; slider: number; modal: number; gaps: number };
   };
   const formsConverted = ingestSummary.formsConverted ?? 0;
@@ -447,6 +448,9 @@ export const convertLocalSiteHandler: Handler = async (args, ctx) => {
     lowConfidence: ingestSummary.lowConfidence,
     failedPageCount: ingestSummary.failedPageCount,
     failedPagesList: ingestSummary.failedPagesList,
+    // Styling-conservation: sections whose conversion dropped a source class
+    // (detail in normalize-report.json). 0 = every source class survived.
+    stylingDrops: ingestSummary.stylingDrops ?? 0,
   };
   // Per-kind section counts from the ingest summary — derived there from the
   // compose REPORTS (single source of truth; this handler never re-runs the

--- a/src/mcp-server/handlers/ingest-local-site.ts
+++ b/src/mcp-server/handlers/ingest-local-site.ts
@@ -32,7 +32,8 @@ import type {
   SectionBehavior,
 } from '../../lib/replicate/local-site/types.js';
 
-const NORMALIZE_REPORT_SCHEMA = 1;
+// v2: the report envelope gained `stylingDrops` (styling-conservation diagnostic).
+const NORMALIZE_REPORT_SCHEMA = 2;
 
 export const ingestLocalSiteHandler: Handler = async (args, ctx) => {
   const dir = args.dir as string | undefined;
@@ -85,6 +86,9 @@ export const ingestLocalSiteHandler: Handler = async (args, ctx) => {
   let islandsConverted = 0;
   // Warning-level block-contract issues (emitter-bug dial — see block-contract.ts).
   const contractIssues: Array<{ slug: string; code: string; blockName: string; detail: string }> = [];
+  // Warning-level styling-conservation drops: source classes a section's block
+  // conversion dropped (the carried CSS that targeted them no longer matches).
+  const stylingDrops: Array<{ slug: string; sectionId: string; droppedClasses: string[] }> = [];
 
   // One sheet across all pages: per-element inline styles are carried as
   // lib-i<hash> classes (fixer-safe) + deduped stylesheet rules emitted to
@@ -138,6 +142,7 @@ export const ingestLocalSiteHandler: Handler = async (args, ctx) => {
         writeFileSync(composedSidecarPath(outputDir, page.slug), finalContent);
         for (const r of report) entries.push({ ...r, slug: page.slug });
         for (const issue of composed.contractIssues) contractIssues.push({ slug: page.slug, ...issue });
+        for (const drop of composed.stylingDrops) stylingDrops.push({ slug: page.slug, ...drop });
       } catch (err) {
         failedPages.push({ slug: page.slug, error: (err as Error).message });
       }
@@ -192,7 +197,7 @@ export const ingestLocalSiteHandler: Handler = async (args, ctx) => {
   try {
     writeFileSync(
       tmpPath,
-      JSON.stringify({ schema: NORMALIZE_REPORT_SCHEMA, site: dir, entries, failedPages, emptyPages, contractIssues }, null, 2),
+      JSON.stringify({ schema: NORMALIZE_REPORT_SCHEMA, site: dir, entries, failedPages, emptyPages, contractIssues, stylingDrops }, null, 2),
     );
     renameSync(tmpPath, reportPath);
   } catch (err) {
@@ -209,6 +214,9 @@ export const ingestLocalSiteHandler: Handler = async (args, ctx) => {
     emptyPages,
     reportPath,
     contractIssues: contractIssues.length,
+    // Styling-conservation: sections whose conversion dropped a source class
+    // (detail in normalize-report.json). 0 = every source class survived.
+    stylingDrops: stylingDrops.length,
     formsConverted,
     ...(editableIslands ? { islandsConverted } : {}),
     // Per-instance inline styles carried as lib-i classes + rules (editor-valid).


### PR DESCRIPTION
## What

Prevents the local site → block-theme conversion (`liberate_convert_local_site`) from silently dropping source styling, and adds a generic safety net so the whole drop-category is caught automatically on future imports.

Found via a snip-city dogfood; every fix is generic (shared `src/lib/replicate/` code), not site-specific.

## Fidelity fixes

- **Nested element styling** (`emit-blocks.ts`): leaf `div`/`span` text elements keep their class + per-instance inline style on a `core/paragraph`; semantic leaves (`figcaption`, `cite`, …) preserved verbatim so element-targeted CSS survives; empty classed styling hooks kept; classless `<span>`s kept in rich text (`.pull span` etc.); `<img>` inline styles folded into a `lib-i` class; `<li>` classes preserved.
- **Loose body elements** (`segment.ts`): body-level siblings of `<main>` (a sticky `.marquee`, a `.grain` overlay) are now carried in DOM order; `<main>` still expands in place when nested in a layout wrapper.
- **Button double border** (`source-assets.ts`): the carried-button inner-link reset now zeroes `box-shadow`, removing the leaked `.btn` offset shadow that rendered as a second border around the label.

## Durability — styling-conservation diagnostic (new)

`styling-conservation.ts`: a deterministic, render-free check that every source CSS class survives into the emitted blocks. Wired `composePage → ingest → normalize-report.json`, surfaced as `ingest.stylingDrops`. Any future site that drops a class is flagged on the first run — no eyeballing required. Form→Jetpack sections are excluded (intentional transformation). Class-level by design; tag/inline-style conservation is a noted follow-up.

On its first run it caught a real residual drop (`<li class="reveal">` — list-item classes) which is now fixed, and is otherwise quiet on snip-city.

## Verification

- 1483 tests green across `src/lib/replicate` + the local-site handlers; `tsc --noEmit` clean.
- Live Studio render matches source: stat numbers (big/bold/pink), quote attributions, gallery figcaption bars, pull-quote accents, stickers (inline-bg overrides win on load order — no `!important`), hero image backdrop, marquee ticker, grain overlay, single-border buttons.
- Cascade note: carried inline styles win via load order (`instance-styles.css` enqueued after `source.css`), not `!important`.
