### PR TITLE
docs(how-it-works): add interactive course on the pipeline

### DIFF
--- a/docs/how-it-works/README.md
+++ b/docs/how-it-works/README.md
@@ -1,0 +1,57 @@
+# How It Works — an interactive course
+
+A self-contained course on the intricacies and flows of `data-liberation-agent`, built as a
+set of beautiful, printable HTML lessons. It teaches the system as a **conceptual scaffold**
+first, then drills into the real machinery — every lesson cites real source files by
+repo-relative path.
+
+**The links below render the styled pages** via [htmlpreview.github.io](https://htmlpreview.github.io)
+(GitHub itself shows `.html` as source). They resolve once these docs are on `main`. For full
+interactivity (the quizzes) or offline reading, clone the repo and open
+[`index.html`](./index.html) in a browser. If GitHub Pages is enabled for the repo, the course
+also renders at its Pages URL.
+
+> Note: in-page navigation (next/prev lesson, the stylesheet) is rewritten by htmlpreview
+> automatically, so once you open any lesson below you can move through the whole course.
+
+## Curriculum
+
+### Part I · The Scaffold
+1. [The Two-Phase Spine](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0001-the-two-phase-spine.html) — extract → reconstruct
+2. [Three Entry Points, One Core](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0002-three-entry-points.html) — CLI watch · subcommands · MCP
+3. [The Fork in the Road](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0003-fork-in-the-road.html) — blocks vs carry vs theme
+
+### Part II · Extraction
+4. [The Adapter Pattern](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0004-the-adapter-pattern.html) — detect/discover/extract, the two seams
+5. [Capture & the SectionSpec](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0005-capture-and-sectionspec.html) — where design becomes data
+6. [The Resume-State Contract](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0006-resume-state-contract.html) — the five capture-once stores
+
+### Part III · Reconstruction
+7. [The Tick Loop & Judgment Seam](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0007-the-tick-loop.html) — the agent-in-the-loop
+8. [Blocks Reconstruction](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0008-blocks-reconstruction.html) — native blocks + legible diagnostics
+9. [The Carry Path](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0009-the-carry-path.html) — verbatim source, scoped & self-hosted
+10. [The Shared Blocks Engine](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0010-blocks-engine-adoption.html) — the DLA↔engine seam
+
+### Part IV · Output & Quality
+11. [Output Artifacts](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0011-output-artifacts.html) — WXR · Woo CSV · self-hosted media
+12. [Quality Gates & Diagnostics](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0012-quality-gates.html) — gates vs diagnostics
+
+### Part V · Advanced Capabilities
+13. [The Local / Owned-Source Path](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0013-local-owned-source-path.html)
+14. [Forms → Jetpack](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0014-forms-to-jetpack.html)
+15. [Design Foundations](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0015-design-foundations.html)
+16. [Variation Hoisting & the Block-Fixer](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0016-variation-hoisting.html)
+17. [The Shopify GraphQL Path](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/lessons/0017-shopify-graphql.html)
+
+## Reference shelf
+- [Glossary](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/reference/glossary.html) — the canonical language
+- [Pipeline Map](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/reference/pipeline-map.html) — the whole flow on one page (badged D/J/M)
+- [Determinism Map](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/reference/determinism-map.html) — which steps are deterministic vs judgment
+- [File Map](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/reference/file-map.html) — where each concern lives in `src/`
+
+Or jump to the rendered [course home](https://htmlpreview.github.io/?https://github.com/Automattic/data-liberation-agent/blob/main/docs/how-it-works/index.html).
+
+---
+
+Companion to the prose docs in [`../how-it-works.md`](../how-it-works.md) and
+[`../flow.md`](../flow.md).

--- a/docs/how-it-works/assets/course.css
+++ b/docs/how-it-works/assets/course.css
@@ -1,0 +1,194 @@
+/* Data Liberation course — shared stylesheet.
+   Tufte-inspired: generous measure, serif body, restrained palette, prints clean. */
+
+:root {
+  --ink: #1a1a1a;
+  --paper: #fffff8;
+  --muted: #6b6b66;
+  --rule: #d9d9cf;
+  --accent: #7a1f1f;       /* deep red, sparingly */
+  --accent-soft: #f3e7e7;
+  --link: #2a5a8a;
+  --code-bg: #f4f3ea;
+  --good: #2e6e3f;
+  --warn: #9a6a00;
+  --bad: #9a2222;
+  --measure: 38rem;
+  --font-body: et-book, Palatino, "Palatino Linotype", "Book Antiqua", Georgia, serif;
+  --font-mono: "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html { font-size: 17px; }
+
+body {
+  font-family: var(--font-body);
+  color: var(--ink);
+  background: var(--paper);
+  line-height: 1.5;
+  margin: 0;
+  padding: 4rem 2rem 6rem;
+}
+
+.wrap { max-width: var(--measure); margin: 0 auto; }
+.wide { max-width: 52rem; margin: 0 auto; }
+
+/* --- Course masthead / breadcrumb --- */
+.masthead {
+  max-width: 52rem; margin: 0 auto 2.5rem;
+  border-bottom: 1px solid var(--rule); padding-bottom: 0.75rem;
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.04em;
+  text-transform: uppercase; color: var(--muted);
+}
+.masthead a { color: var(--muted); text-decoration: none; }
+.masthead a:hover { color: var(--accent); }
+
+/* --- Typography --- */
+h1 {
+  font-weight: 400; font-size: 2.1rem; line-height: 1.1;
+  margin: 0 0 0.3rem; letter-spacing: -0.01em;
+}
+.lesson-num {
+  font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--accent); margin-bottom: 0.6rem;
+}
+.subtitle { font-style: italic; color: var(--muted); font-size: 1.15rem; margin: 0 0 2rem; }
+h2 {
+  font-weight: 400; font-size: 1.45rem; margin: 2.6rem 0 0.6rem;
+  padding-bottom: 0.2rem;
+}
+h3 { font-weight: 600; font-size: 1.05rem; margin: 1.8rem 0 0.4rem; }
+p { margin: 0 0 1rem; }
+a { color: var(--link); text-decoration: none; border-bottom: 1px solid #cdd8e3; }
+a:hover { border-bottom-color: var(--link); }
+
+small, .small { font-size: 0.82rem; color: var(--muted); }
+
+/* --- Sidenotes / margin notes --- */
+.note {
+  font-size: 0.85rem; color: var(--muted); line-height: 1.4;
+  border-left: 2px solid var(--rule); padding-left: 0.9rem; margin: 1.2rem 0;
+}
+
+/* --- Callouts --- */
+.callout {
+  border: 1px solid var(--rule); border-left: 3px solid var(--accent);
+  background: #fcfcf5; padding: 0.9rem 1.1rem; margin: 1.4rem 0; border-radius: 2px;
+}
+.callout .label {
+  font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--accent); display: block; margin-bottom: 0.35rem;
+}
+.callout.key { border-left-color: var(--accent); }
+.callout.gotcha { border-left-color: var(--warn); background: #fdfaf0; }
+.callout.gotcha .label { color: var(--warn); }
+.callout.decision { border-left-color: var(--link); background: #f5f8fb; }
+.callout.decision .label { color: var(--link); }
+
+/* --- Code --- */
+code {
+  font-family: var(--font-mono); font-size: 0.82em;
+  background: var(--code-bg); padding: 0.1em 0.35em; border-radius: 3px;
+}
+pre {
+  font-family: var(--font-mono); font-size: 0.78rem; line-height: 1.5;
+  background: var(--code-bg); border: 1px solid var(--rule); border-radius: 4px;
+  padding: 0.9rem 1.1rem; overflow-x: auto; margin: 1.2rem 0;
+}
+pre code { background: none; padding: 0; font-size: inherit; }
+.path { font-family: var(--font-mono); font-size: 0.8em; color: var(--accent); }
+
+/* --- Pipeline / flow diagram --- */
+.flow { margin: 1.6rem 0; }
+.flow-stage {
+  display: flex; align-items: flex-start; gap: 0.9rem; padding: 0.55rem 0;
+  border-bottom: 1px dotted var(--rule);
+}
+.flow-stage:last-child { border-bottom: none; }
+.flow-badge {
+  flex: 0 0 auto; font-family: var(--font-mono); font-size: 0.7rem;
+  background: var(--accent-soft); color: var(--accent); border-radius: 3px;
+  padding: 0.15rem 0.5rem; margin-top: 0.15rem; min-width: 2.2rem; text-align: center;
+}
+.flow-body { flex: 1; }
+.flow-body strong { font-weight: 600; }
+.flow-body .artifact {
+  font-family: var(--font-mono); font-size: 0.74rem; color: var(--muted);
+}
+
+/* --- Tables --- */
+table { border-collapse: collapse; width: 100%; margin: 1.4rem 0; font-size: 0.9rem; }
+th, td { text-align: left; padding: 0.45rem 0.7rem; border-bottom: 1px solid var(--rule); vertical-align: top; }
+th { font-family: var(--font-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); font-weight: 600; }
+td code { font-size: 0.78em; }
+
+/* --- Quiz widget hook (styles; behavior in quiz.js) --- */
+.quiz { border: 1px solid var(--rule); border-radius: 4px; padding: 1.1rem 1.2rem; margin: 1.6rem 0; background: #fcfcf5; }
+.quiz .q { font-weight: 600; margin-bottom: 0.7rem; }
+.quiz .opts { list-style: none; padding: 0; margin: 0; }
+.quiz .opts li { margin: 0.4rem 0; }
+.quiz button.opt {
+  font-family: var(--font-body); font-size: 0.92rem; text-align: left; width: 100%;
+  background: var(--paper); border: 1px solid var(--rule); border-radius: 3px;
+  padding: 0.5rem 0.75rem; cursor: pointer; transition: background 0.15s, border-color 0.15s;
+}
+.quiz button.opt:hover { border-color: var(--accent); }
+.quiz button.opt.correct { background: #e9f3ec; border-color: var(--good); }
+.quiz button.opt.wrong { background: #f6e9e9; border-color: var(--bad); }
+.quiz .feedback { margin-top: 0.7rem; font-size: 0.88rem; min-height: 1.2rem; }
+.quiz .feedback.correct { color: var(--good); }
+.quiz .feedback.wrong { color: var(--bad); }
+
+/* --- Recall prompt (free retrieval, no auto-grade) --- */
+.recall { border: 1px dashed var(--rule); border-radius: 4px; padding: 1rem 1.2rem; margin: 1.5rem 0; }
+.recall .label { font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted); display: block; margin-bottom: 0.45rem; }
+.recall details { margin-top: 0.6rem; }
+.recall summary { cursor: pointer; color: var(--link); font-size: 0.88rem; }
+.recall details[open] summary { margin-bottom: 0.5rem; }
+
+/* --- Nav footer --- */
+.lesson-nav {
+  max-width: 52rem; margin: 3.5rem auto 0; padding-top: 1rem;
+  border-top: 1px solid var(--rule); display: flex; justify-content: space-between;
+  font-family: var(--font-mono); font-size: 0.78rem;
+}
+.lesson-nav a { border: none; }
+.ask {
+  max-width: 52rem; margin: 2.5rem auto 0; font-style: italic; color: var(--muted);
+  font-size: 0.9rem; text-align: center;
+}
+.source-cite {
+  max-width: 52rem; margin: 2rem auto 0; font-size: 0.85rem;
+  background: var(--accent-soft); border-radius: 4px; padding: 0.8rem 1rem;
+}
+.source-cite .label { font-family: var(--font-mono); font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); }
+
+/* --- Determinism badges (shared: pipeline map + determinism map) --- */
+.dbadge {
+  font-family: var(--font-mono); font-size: 0.6rem; letter-spacing: 0.06em;
+  text-transform: uppercase; padding: 0.05rem 0.4rem; border-radius: 3px;
+  border: 1px solid; vertical-align: middle; white-space: nowrap; font-weight: 600;
+}
+.dbadge.det { color: #2e6e3f; border-color: #bcd9c5; background: #eef5f0; }
+.dbadge.jud { color: #6a3aa0; border-color: #d8c9ec; background: #f3eef9; }
+.dbadge.mix { color: #8a5a00; border-color: #e6d3a3; background: #fbf5e6; }
+.det-legend {
+  display: flex; gap: 1.2rem; flex-wrap: wrap; align-items: center;
+  font-size: 0.82rem; color: var(--muted); margin: 1.2rem 0;
+  border: 1px solid var(--rule); border-radius: 4px; padding: 0.7rem 1rem; background: #fcfcf5;
+}
+.det-legend span { display: inline-flex; gap: 0.45rem; align-items: center; }
+td .dbadge, .flow-body .dbadge { margin-right: 0.35rem; }
+
+ul, ol { padding-left: 1.3rem; }
+li { margin: 0.3rem 0; }
+hr { border: none; border-top: 1px solid var(--rule); margin: 2.5rem 0; }
+
+@media print {
+  body { padding: 0; font-size: 11pt; background: #fff; }
+  .masthead, .lesson-nav, .ask { display: none; }
+  .callout, .quiz, pre { break-inside: avoid; }
+  a { color: var(--ink); border: none; }
+}

--- a/docs/how-it-works/assets/quiz.js
+++ b/docs/how-it-works/assets/quiz.js
@@ -1,0 +1,44 @@
+/* Shared quiz widget for the Data Liberation course.
+   Markup contract (built once, reused by every lesson):
+
+   <div class="quiz" data-answer="1">
+     <div class="q">Question text…</div>
+     <ul class="opts">
+       <li><button class="opt">First option</button></li>
+       <li><button class="opt">Second option</button></li>
+       ...
+     </ul>
+     <div class="feedback" data-correct="Why this is right." data-wrong="Nudge."></div>
+   </div>
+
+   data-answer is the 0-based index of the correct option. Options are deliberately
+   matched in length (no formatting tells). Feedback strings live on .feedback. */
+
+(function () {
+  function initQuiz(quiz) {
+    const answer = parseInt(quiz.getAttribute('data-answer'), 10);
+    const buttons = Array.from(quiz.querySelectorAll('button.opt'));
+    const feedback = quiz.querySelector('.feedback');
+    let done = false;
+
+    buttons.forEach((btn, i) => {
+      btn.addEventListener('click', () => {
+        if (done) return;
+        done = true;
+        const correct = i === answer;
+        btn.classList.add(correct ? 'correct' : 'wrong');
+        if (!correct) buttons[answer].classList.add('correct');
+        if (feedback) {
+          feedback.textContent = correct
+            ? (feedback.getAttribute('data-correct') || 'Correct.')
+            : (feedback.getAttribute('data-wrong') || 'Not quite — see the highlighted answer.');
+          feedback.classList.add(correct ? 'correct' : 'wrong');
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    document.querySelectorAll('.quiz').forEach(initQuiz);
+  });
+})();

--- a/docs/how-it-works/index.html
+++ b/docs/how-it-works/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Data Liberation · A Course</title>
+<link rel="stylesheet" href="assets/course.css">
+<style>
+  .curr { margin: 1.4rem 0; }
+  .part-label { font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin: 2rem 0 0.6rem; }
+  .lrow { display: flex; gap: 1rem; align-items: baseline; padding: 0.5rem 0; border-bottom: 1px dotted var(--rule); }
+  .lrow .ln { font-family: var(--font-mono); font-size: 0.75rem; color: var(--muted); flex: 0 0 1.6rem; }
+  .lrow .lt { flex: 1; }
+  .lrow .lt a { font-size: 1.02rem; }
+  .lrow .ld { display: block; font-size: 0.85rem; color: var(--muted); font-style: italic; }
+</style>
+</head>
+<body>
+<div class="masthead">
+  <span>Data Liberation · A Course</span>
+  <span>for architecture leadership</span>
+</div>
+
+<div class="wide">
+<h1>Data Liberation</h1>
+<p class="subtitle">The intricacies and flows of <code>data-liberation-agent</code>, taught as a scaffold you can hold in your head — then drilled into the real machinery, file by file.</p>
+
+<p><strong>Mission:</strong> build a complete, confident mental model of the end-to-end flows
+and the key architectural seams, so you can make and defend architecture decisions — blocks
+vs carry vs theme, the shared blocks engine, and where a change's blast radius really lands.</p>
+
+<div class="callout key">
+  <span class="label">How to take this course</span>
+  Seventeen short lessons, each one tangible win. Do Parts I–IV in order — Part I is the
+  scaffold every later lesson hangs off; Part V's advanced capabilities can be taken in any
+  order once you have the scaffold. Each lesson ends with a retrieval-practice prompt; <em>do them from
+  memory</em> (that's what builds lasting recall, not re-reading). I'm your teacher — ask
+  follow-ups any time.
+</div>
+
+<div class="part-label">Part I · The Scaffold (conceptual)</div>
+<div class="curr">
+  <div class="lrow"><span class="ln">01</span><span class="lt"><a href="lessons/0001-the-two-phase-spine.html">The Two-Phase Spine</a><span class="ld">Extract → reconstruct. The skeleton everything hangs off.</span></span></div>
+  <div class="lrow"><span class="ln">02</span><span class="lt"><a href="lessons/0002-three-entry-points.html">Three Entry Points, One Core</a><span class="ld">CLI watch · subcommands · MCP — all thin over one core.</span></span></div>
+  <div class="lrow"><span class="ln">03</span><span class="lt"><a href="lessons/0003-fork-in-the-road.html">The Fork in the Road</a><span class="ld">Blocks vs carry vs theme — the decision you'll reach for most.</span></span></div>
+</div>
+
+<div class="part-label">Part II · Extraction (drill)</div>
+<div class="curr">
+  <div class="lrow"><span class="ln">04</span><span class="lt"><a href="lessons/0004-the-adapter-pattern.html">The Adapter Pattern</a><span class="ld">detect/discover/extract, resolveAdapter fallback, two seams.</span></span></div>
+  <div class="lrow"><span class="ln">05</span><span class="lt"><a href="lessons/0005-capture-and-sectionspec.html">Capture &amp; the SectionSpec</a><span class="ld">Where design becomes data; the landmark census.</span></span></div>
+  <div class="lrow"><span class="ln">06</span><span class="lt"><a href="lessons/0006-resume-state-contract.html">The Resume-State Contract</a><span class="ld">Five stores; what each owns; idempotent crash recovery.</span></span></div>
+</div>
+
+<div class="part-label">Part III · Reconstruction (drill)</div>
+<div class="curr">
+  <div class="lrow"><span class="ln">07</span><span class="lt"><a href="lessons/0007-the-tick-loop.html">The Tick Loop &amp; Judgment Seam</a><span class="ld">The agent-in-the-loop — the architecture's defining move.</span></span></div>
+  <div class="lrow"><span class="ln">08</span><span class="lt"><a href="lessons/0008-blocks-reconstruction.html">Blocks Reconstruction</a><span class="ld">Native blocks, the fallback ladder, legible diagnostics.</span></span></div>
+  <div class="lrow"><span class="ln">09</span><span class="lt"><a href="lessons/0009-the-carry-path.html">The Carry Path</a><span class="ld">Verbatim source, scoped &amp; self-hosted; chrome fidelity.</span></span></div>
+  <div class="lrow"><span class="ln">10</span><span class="lt"><a href="lessons/0010-blocks-engine-adoption.html">The Shared Blocks Engine</a><span class="ld">The DLA↔engine seam, and the frozen-output guardrail.</span></span></div>
+</div>
+
+<div class="part-label">Part IV · Output &amp; Quality</div>
+<div class="curr">
+  <div class="lrow"><span class="ln">11</span><span class="lt"><a href="lessons/0011-output-artifacts.html">Output Artifacts</a><span class="ld">WXR · Woo CSV · self-hosted media; pure-artifact + manifest.</span></span></div>
+  <div class="lrow"><span class="ln">12</span><span class="lt"><a href="lessons/0012-quality-gates.html">Quality Gates &amp; Diagnostics</a><span class="ld">Gates vs diagnostics; the system's self-awareness.</span></span></div>
+</div>
+
+<div class="part-label">Part V · Advanced Capabilities</div>
+<div class="curr">
+  <div class="lrow"><span class="ln">13</span><span class="lt"><a href="lessons/0013-local-owned-source-path.html">The Local / Owned-Source Path</a><span class="ld">Owned directory → block theme; preserve-DOM, model JS data.</span></span></div>
+  <div class="lrow"><span class="ln">14</span><span class="lt"><a href="lessons/0014-forms-to-jetpack.html">Forms → Jetpack</a><span class="ld">Editable contact forms; the submit-button &amp; module-activate traps.</span></span></div>
+  <div class="lrow"><span class="ln">15</span><span class="lt"><a href="lessons/0015-design-foundations.html">Design Foundations</a><span class="ld">Raw aggregates → semantic roles; observations vs decisions.</span></span></div>
+  <div class="lrow"><span class="ln">16</span><span class="lt"><a href="lessons/0016-variation-hoisting.html">Variation Hoisting &amp; the Block-Fixer</a><span class="ld">Survive the save cycle; DRY styles into reusable variations.</span></span></div>
+  <div class="lrow"><span class="ln">17</span><span class="lt"><a href="lessons/0017-shopify-graphql.html">The Shopify GraphQL Path</a><span class="ld">A privileged, resumable, idempotent adapter — every pattern at once.</span></span></div>
+</div>
+
+<div class="part-label">Reference Shelf</div>
+<div class="curr">
+  <div class="lrow"><span class="ln">▸</span><span class="lt"><a href="reference/glossary.html">Glossary</a><span class="ld">The canonical language every lesson uses.</span></span></div>
+  <div class="lrow"><span class="ln">▸</span><span class="lt"><a href="reference/pipeline-map.html">Pipeline Map</a><span class="ld">The whole flow on one printable page, badged D/J/M.</span></span></div>
+  <div class="lrow"><span class="ln">▸</span><span class="lt"><a href="reference/determinism-map.html">Determinism Map</a><span class="ld">Which steps are deterministic vs judgment, and why.</span></span></div>
+  <div class="lrow"><span class="ln">▸</span><span class="lt"><a href="reference/file-map.html">File Map</a><span class="ld">Where each concern lives in <code>src/</code>.</span></span></div>
+</div>
+
+<hr>
+<p class="small">Lives at <code>docs/how-it-works/</code> in the <code>data-liberation-agent</code>
+repo. Lessons cite real files by repo-relative path — open them alongside. Open this in a
+browser (locally or via GitHub Pages) for the full experience; GitHub's file view shows these
+as source rather than rendering them.</p>
+
+<p class="ask">Start with <a href="lessons/0001-the-two-phase-spine.html">Lesson 1</a> — it's the
+scaffold every later lesson hangs off.</p>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0001-the-two-phase-spine.html
+++ b/docs/how-it-works/lessons/0001-the-two-phase-spine.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>1 · The Two-Phase Spine</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part I — Scaffold</span>
+  <span>Lesson 1 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 01 · The scaffold</div>
+<h1>The Two-Phase Spine</h1>
+<p class="subtitle">Everything in this codebase hangs off one sentence: <em>extract a URL into artifacts, then reconstruct those artifacts into a WordPress site.</em> Get this skeleton in muscle memory and every other lesson is just detail on a bone you already know.</p>
+
+<p>When you make an architecture call in this repo, the first question is always <em>which
+phase, which stage</em>. So before anything else, hold the whole shape in your head:</p>
+
+<div class="flow">
+  <div class="flow-stage">
+    <span class="flow-badge">IN</span>
+    <div class="flow-body"><strong>A URL</strong> (or an owned local directory)<br>
+    <span class="artifact">e.g. https://someshop.example</span></div>
+  </div>
+  <div class="flow-stage">
+    <span class="flow-badge">P1</span>
+    <div class="flow-body"><strong>Extraction phase</strong> — turn the live site into on-disk artifacts.<br>
+    <span class="artifact">→ output.wxr · products.jsonl · screenshots/ · palette/typography/breakpoints.json</span></div>
+  </div>
+  <div class="flow-stage">
+    <span class="flow-badge">P2</span>
+    <div class="flow-body"><strong>Reconstruction phase</strong> — turn those artifacts into a real, styled WordPress site.<br>
+    <span class="artifact">→ a block theme + imported content, running in Studio</span></div>
+  </div>
+  <div class="flow-stage">
+    <span class="flow-badge">OUT</span>
+    <div class="flow-body"><strong>A self-hosted WordPress site</strong> that looks and reads like the original.</div>
+  </div>
+</div>
+
+<h2>Why two phases, not one</h2>
+<p>The split is the most important design decision in the system, and it is deliberate.
+Extraction is <em>expensive and fragile</em> — it hits a live site, fights bot defenses,
+downloads media, and can crash halfway. Reconstruction is <em>cheap and deterministic</em> —
+it reads local files and rebuilds. Separating them means you can re-run reconstruction a
+hundred times against one expensive extraction. Every architecture conversation about
+"can we change how pages are built" lives entirely in phase two and never re-touches the
+live site.</p>
+
+<div class="callout key">
+  <span class="label">The load-bearing idea</span>
+  Extraction is a <strong>capture-once, resumable</strong> investment. Reconstruction is a
+  <strong>repeatable, deterministic</strong> transform over that capture. The artifacts on
+  disk are the contract between them — that is why the resume-state files (Lesson 6) matter
+  so much.
+</div>
+
+<h2>Extraction has named stages</h2>
+<p>Phase one is not a blob — it is a fixed sequence of stages, persisted so a crashed run
+resumes where it left off. This exact union lives in the source:</p>
+
+<pre><code>initial → discovering → extracting → downloading-media
+        → screenshotting → finalizing → complete
+                                        (error from any stage)</code></pre>
+<p class="path">src/lib/resume-state/import-session.ts:22</p>
+
+<p>You will drill into each of these. For now, just notice: <strong>discover</strong> finds
+the URLs, <strong>extract</strong> turns each URL into content + products, <strong>download-media</strong>
+fetches the assets, <strong>screenshot</strong> captures the design. Reconstruction is a
+<em>separate</em> phase driven by its own tools — it is not in this union.</p>
+
+<div class="callout gotcha">
+  <span class="label">Common mental-model error</span>
+  Don't picture reconstruction as a stage after <code>complete</code>. The
+  <code>ImportStage</code> union ends at <code>complete</code> — that is the end of
+  <em>extraction</em>. Reconstruction is a different set of tools (<code>liberate_reconstruct_*</code>)
+  reading the artifacts. The default streaming run blurs them together in time, but
+  architecturally they are two systems.
+</div>
+
+<div class="quiz" data-answer="1">
+  <div class="q">Why is the extraction / reconstruction split the central design decision?</div>
+  <ul class="opts">
+    <li><button class="opt">It lets the system support more source platforms cleanly</button></li>
+    <li><button class="opt">It lets one costly capture feed many cheap deterministic rebuilds</button></li>
+    <li><button class="opt">It keeps the WordPress import code fully separate now</button></li>
+    <li><button class="opt">It makes the command line interface simpler to read now</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Exactly — extraction is expensive/fragile and captured once; reconstruction is cheap/deterministic and re-runnable against that capture."
+    data-wrong="Re-read 'Why two phases': the point is expensive capture-once vs cheap repeatable rebuild. Platform support is the adapter seam, a different idea.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Without scrolling up: name the seven extraction stages in order, and say which artifact
+  the <em>extract</em> stage and the <em>screenshot</em> stage each produce.
+  <details><summary>Check yourself</summary>
+  initial → discovering → extracting → downloading-media → screenshotting → finalizing →
+  complete. Extract produces <code>output.wxr</code> + <code>products.jsonl</code>;
+  screenshot produces <code>screenshots/</code> + <code>palette/typography/breakpoints.json</code>.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read the stage diagram and union at the top of
+  <span class="path">src/lib/resume-state/import-session.ts</span> (lines 5–30). It is the
+  most authoritative one-screen statement of the extraction spine in the whole repo.
+</div>
+
+<p class="ask">Anything unclear? I'm your teacher — ask me to expand any stage, draw the
+flow differently, or connect it to a decision you're weighing.</p>
+
+<div class="lesson-nav">
+  <a href="../index.html">← Course home</a>
+  <a href="0002-three-entry-points.html">Lesson 2: Three entry points, one core →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0002-three-entry-points.html
+++ b/docs/how-it-works/lessons/0002-three-entry-points.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>2 · Three Entry Points, One Core</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part I — Scaffold</span>
+  <span>Lesson 2 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 02 · The scaffold</div>
+<h1>Three Entry Points, One Core</h1>
+<p class="subtitle">Same machine, three front doors. Knowing which door a request came through tells you which thin shell you're in — and that all of them bottom out in the same shared core.</p>
+
+<p>There is exactly <strong>one binary</strong>, <code>data-liberation</code>, defined by
+<span class="path">src/cli.ts</span>. It is a dispatcher that branches on the first
+argument. Everything else is a shell over <code>src/lib/</code> and <code>src/adapters/</code>.</p>
+
+<div class="flow">
+  <div class="flow-stage">
+    <span class="flow-badge">1</span>
+    <div class="flow-body"><strong>Streaming CLI</strong> — <code>data-liberation &lt;url&gt;</code><br>
+    The default. Boots the live "watch loop" (<code>ui/watch.tsx</code> → <code>watch-runner.ts</code>).
+    <span class="artifact">cli.ts:271 · --no-watch falls back to the legacy batch path</span></div>
+  </div>
+  <div class="flow-stage">
+    <span class="flow-badge">2</span>
+    <div class="flow-body"><strong>CLI subcommands</strong> — <code>inspect / import / qa / verify / setup / preview / screenshot / compare …</code><br>
+    Each lazy-imports a <code>ui/&lt;cmd&gt;.js</code> runner.
+    <span class="artifact">cli.ts:105 · the manual, à-la-carte surface</span></div>
+  </div>
+  <div class="flow-stage">
+    <span class="flow-badge">3</span>
+    <div class="flow-body"><strong>MCP stdio server</strong> — <code>data-liberation mcp</code><br>
+    Exposes ~38 <code>liberate_*</code> tools to agents/skills.
+    <span class="artifact">cli.ts:16 → src/mcp-server.ts · the Claude Code plugin wraps this</span></div>
+  </div>
+</div>
+
+<h2>The shape that matters</h2>
+<p>Picture an hourglass. Three entry points at the top, one shared core at the waist, the
+platform adapters at the bottom:</p>
+
+<pre><code>  CLI watch     CLI subcommands     MCP tools          ← entry (thin shells)
+       \              |              /
+        \             |             /
+         ▼            ▼            ▼
+      src/lib/*   +   src/adapters/*                    ← the core
+        (wxr, resume-state, replicate, screenshot…)</code></pre>
+
+<p>The CLI UI runners (<code>src/ui/*</code>) and the MCP handlers
+(<code>src/mcp-server/handlers/*</code>) are <em>both</em> thin. Neither contains real logic.
+This is why you can drive the same behavior from a skill (MCP) or from a terminal
+(CLI) — they call the same functions.</p>
+
+<div class="callout decision">
+  <span class="label">Why this matters for architecture calls</span>
+  When you decide <em>where</em> a new capability lives, the answer is almost always
+  "in <code>src/lib/</code>, exposed through a thin handler." Putting logic in the handler
+  or the UI runner is the anti-pattern — it can only be reached from one door. By design,
+  <strong>agents are the primary runtime</strong>, so the MCP door is first-class, not an
+  afterthought.
+</div>
+
+<h2>The agent door is the strategic one</h2>
+<p>Entry point 3 is not just "the API." The project's direction is agent-driven: the
+<code>data-liberation:*</code> Skills <em>are</em> the product surface for a Claude Code
+user. They orchestrate the <code>liberate_*</code> tools. So when you reason about UX, the
+relevant "user" is often an agent following a skill, and the relevant "interface" is the
+tool schemas in <code>mcp-server.ts</code>.</p>
+
+<div class="callout gotcha">
+  <span class="label">Live-process gotcha</span>
+  The MCP server runs <code>tsx src/mcp-server.ts</code> as <strong>one long-lived
+  process</strong>. Editing <code>src/</code> does <em>not</em> hot-reload it — ESM modules
+  are cached per process. After editing handler/lib source you must restart the server (or
+  drive the handler from a fresh <code>tsx</code> process) for callers to see the change.
+  Unit tests always use on-disk source, so they reflect edits immediately.
+</div>
+
+<div class="quiz" data-answer="2">
+  <div class="q">A new extraction capability is being added. Where should the real logic live?</div>
+  <ul class="opts">
+    <li><button class="opt">Inside the relevant CLI runner under the ui directory</button></li>
+    <li><button class="opt">Inside the MCP handler so agents can reach the new code</button></li>
+    <li><button class="opt">In a shared lib module, exposed by a thin handler shell</button></li>
+    <li><button class="opt">In the cli dispatcher so every front door can branch to it</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — logic in src/lib, reachable through a thin handler, so all three doors share it."
+    data-wrong="Logic in a handler or UI runner is the anti-pattern: only one door can reach it. It belongs in src/lib behind a thin shell.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the three entry points and the single file that dispatches between them. Then say
+  which one the Claude Code plugin and the <code>data-liberation:*</code> skills use.
+  <details><summary>Check yourself</summary>
+  Streaming watch CLI, CLI subcommands, MCP stdio server — all dispatched by
+  <code>src/cli.ts</code>. The plugin and skills use door 3 (MCP).
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Skim the branch logic in <span class="path">src/cli.ts</span> (the <code>args[0]</code>
+  switch), then the tool registry + <code>handlers</code> dispatch map in
+  <span class="path">src/mcp-server.ts</span> (~line 741). Seeing the handler map drives
+  home how thin the shells are.
+</div>
+
+<p class="ask">Want me to trace one tool from schema → handler → lib function end to end?
+Just ask.</p>
+
+<div class="lesson-nav">
+  <a href="0001-the-two-phase-spine.html">← Lesson 1</a>
+  <a href="0003-fork-in-the-road.html">Lesson 3: The fork in the road →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0003-fork-in-the-road.html
+++ b/docs/how-it-works/lessons/0003-fork-in-the-road.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>3 · The Fork in the Road</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part I — Scaffold</span>
+  <span>Lesson 3 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 03 · The scaffold</div>
+<h1>The Fork in the Road</h1>
+<p class="subtitle">Reconstruction is not one path — it is three, and choosing between them is the single most consequential decision an operator (or you) makes. This is the lesson you'll reach for most in architecture conversations.</p>
+
+<p>Once extraction has produced artifacts, there are three different ways to turn them into a
+WordPress site. They trade <strong>native-ness</strong> against <strong>pixel fidelity</strong>.</p>
+
+<table>
+  <thead><tr><th>Path</th><th>Tool</th><th>What it does</th><th>Tradeoff</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><strong>Blocks</strong></td>
+      <td><code>liberate_reconstruct_pages</code></td>
+      <td>Rebuilds each page into <em>native Gutenberg block markup</em> from its captured section specs.</td>
+      <td>Most editable & WordPress-native; fidelity depends on how well sections map to blocks.</td>
+    </tr>
+    <tr>
+      <td><strong>Carry</strong></td>
+      <td><code>liberate_reconstruct_pages_carry</code></td>
+      <td>Carries sanitized source HTML + scoped CSS <em>verbatim</em> into <code>core/html</code> islands; self-hosts media.</td>
+      <td>Highest pixel fidelity; least native (it's the source HTML wearing a WordPress hat).</td>
+    </tr>
+    <tr>
+      <td><strong>Theme / local</strong></td>
+      <td><code>liberate_convert_local_site</code></td>
+      <td>Converts an <em>owned local static-site directory</em> (no network extraction) into a live block theme.</td>
+      <td>For source you already own; different front door entirely (no detect/discover).</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>The axis you're actually choosing on</h2>
+<p>Think of one slider: <strong>how much of the source's literal HTML/CSS survives into the
+output</strong>.</p>
+
+<pre><code>  native blocks  ◄───────────────────────────►  verbatim source
+   (Blocks path)                                  (Carry path)
+   editable, clean markup            pixel-perfect, opaque core/html
+   risk: layout drift                 risk: not really "WordPress content"</code></pre>
+
+<p>The carry path wins on fidelity because it doesn't <em>interpret</em> the source — it
+ships it. The blocks path wins on editability because it <em>does</em> interpret the source
+into first-class blocks a user can edit in Gutenberg. Neither is "better"; they answer
+different missions.</p>
+
+<div class="callout key">
+  <span class="label">The bridge: editable islands</span>
+  The two paths share a bridge. By default, <code>core/html</code> islands convert to
+  <code>dla/editable-html</code> blocks — visible, styled, and <em>editable</em> in the
+  block editor, with identical front-end output. So even on the carry path the islands aren't
+  purely "opaque HTML" — they're editable in-canvas. This editable island is a real
+  architectural achievement, not a detail.
+</div>
+
+<h2>Why this is a hard, early gate</h2>
+<p>This path choice is a <strong>decision gate that fires early</strong> — right after
+discovery, while the operator is present — and is never auto-selected. The
+<code>data-liberation:liberate</code> skill is built so a URL run <em>stops and asks</em>
+which reconstruct path to take before spending money on extraction. That gate exists because
+the choice changes what you capture and how you spend the expensive phase.</p>
+
+<div class="callout decision">
+  <span class="label">How to reason about the choice</span>
+  Ask: <em>does the user need to edit this content as WordPress, or do they need it to look
+  exactly like the original?</em> Editing → blocks. Fidelity-first (and the source is a
+  complex builder site like Wix) → carry. Owned static source on disk → local/theme path,
+  which skips detection entirely.
+</div>
+
+<div class="quiz" data-answer="0">
+  <div class="q">A client's Wix site must look pixel-identical and they won't edit it much. Which path?</div>
+  <ul class="opts">
+    <li><button class="opt">Carry — verbatim HTML and scoped CSS maximize fidelity</button></li>
+    <li><button class="opt">Blocks — native markup is always the safest default</button></li>
+    <li><button class="opt">Local — convert the owned directory without any network</button></li>
+    <li><button class="opt">Theme — scaffold a block theme shell and stop there</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — fidelity-first on a complex builder site is the carry path's sweet spot."
+    data-wrong="Fidelity-first on a complex builder site favors carry. Blocks trades some fidelity for editability; local is for owned on-disk source.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the three reconstruct tools and the one axis they trade on. Then state <em>when</em>
+  in the run the path question is asked, and why it's asked then.
+  <details><summary>Check yourself</summary>
+  <code>liberate_reconstruct_pages</code> (blocks), <code>liberate_reconstruct_pages_carry</code>
+  (carry), <code>liberate_convert_local_site</code> (local/theme). Axis = native blocks ↔
+  verbatim source. Asked right after discovery, before extraction, because it changes what
+  the expensive capture phase needs to collect.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read the path-gate description in the <span class="path">data-liberation:liberate</span>
+  skill, then compare the two handlers
+  <span class="path">src/mcp-server/handlers/reconstruct-pages.ts</span> and
+  <span class="path">…/reconstruct-pages-carry.ts</span> side by side to feel the difference.
+</div>
+
+<p class="ask">Lessons 8–10 drill into each path. Want a decision-tree cheat sheet for the
+choice? Ask and I'll add one to the reference shelf.</p>
+
+<div class="lesson-nav">
+  <a href="0002-three-entry-points.html">← Lesson 2</a>
+  <a href="0004-the-adapter-pattern.html">Lesson 4: The adapter pattern →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0004-the-adapter-pattern.html
+++ b/docs/how-it-works/lessons/0004-the-adapter-pattern.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>4 · The Adapter Pattern</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part II — Extraction</span>
+  <span>Lesson 4 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 04 · Extraction drill</div>
+<h1>The Adapter Pattern</h1>
+<p class="subtitle">One pipeline serves nine platforms because every platform-specific quirk is quarantined behind a uniform three-method interface. This is the seam that keeps the core from rotting into a pile of <code>if (platform === …)</code>.</p>
+
+<p>An <strong>adapter</strong> is a directory under <code>src/adapters/&lt;platform&gt;/</code>
+whose <code>index.ts</code> assembles and exports a <code>PlatformAdapter</code>. The nine:</p>
+
+<pre><code>default  godaddy-wm  hostinger  hubspot  shopify
+squarespace  webflow  weebly  wix</code></pre>
+
+<p><code>webflow/</code> is the smallest reference; <code>shopify/</code> is the fullest
+split (<code>discover.ts</code>, <code>extract.ts</code>, <code>content.ts</code>,
+<code>media.ts</code>, <code>products.ts</code>…). <code>index.ts</code> stays a thin
+assembler.</p>
+
+<h2>The three methods every adapter exposes</h2>
+<div class="flow">
+  <div class="flow-stage">
+    <span class="flow-badge">①</span>
+    <div class="flow-body"><strong>detect</strong> — "is this site mine?" Domain patterns + HTTP
+    fingerprinting (headers + HTML markers). No path-based detection.</div>
+  </div>
+  <div class="flow-stage">
+    <span class="flow-badge">②</span>
+    <div class="flow-body"><strong>discover</strong> — find the URLs: sitemap, nav, URL inventory,
+    archetype counts.</div>
+  </div>
+  <div class="flow-stage">
+    <span class="flow-badge">③</span>
+    <div class="flow-body"><strong>extract</strong> — turn each URL into structured content +
+    products, feeding <code>WxrBuilder</code>, <code>MediaStubStore</code>, products stream.</div>
+  </div>
+</div>
+
+<h2>Detection and resolution are two different steps</h2>
+<p>This trips people up. <strong>Detection</strong> reports a platform id (possibly
+<code>unknown</code>). <strong>Resolution</strong> — <code>resolveAdapter</code> in
+<span class="path">src/adapters/resolve-adapter.ts</span> — maps that id to an actual
+adapter object:</p>
+
+<pre><code>exact id match  →  that adapter
+unknown / unregistered  →  the `default` adapter
+(null only if `default` itself is missing — unreachable in practice)</code></pre>
+
+<div class="callout key">
+  <span class="label">Why the fallback matters</span>
+  Because resolution always lands on <em>some</em> adapter, a "No adapter available"
+  error is unreachable. The <code>default</code> adapter is platform-agnostic:
+  Playwright-rendered HTML → cheerio main-content + media + JSON-LD products. Its own
+  <code>detect()</code> returns <code>false</code> — nothing <em>selects</em> it; it is only
+  ever reached by fallback. Three call sites share this seam (MCP server, the discover UI,
+  the inspect UI), so behavior can't drift between front doors.
+</div>
+
+<h2>The two opt-in seams an adapter can declare</h2>
+<p>Beyond the three methods, an adapter may declare two <em>optional</em> capabilities. Both
+are consumed by <em>later</em> pipeline stages, which stay adapter-agnostic — the handler
+that already resolved the adapter does the wiring. Types live in
+<span class="path">src/adapters/page-actions.ts</span>.</p>
+
+<table>
+  <thead><tr><th>Seam</th><th>Field</th><th>Fires where</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><strong>Capture</strong></td>
+      <td><code>capture?: AdapterCapture</code></td>
+      <td>In <code>screenshotter.ts</code>, <em>before</em> screenshots/HTML/specs are
+      captured. <code>removeSelectors[]</code> strips platform chrome (e.g. Shopify's
+      <code>#upCart</code>) so one removal cleans every artifact. Best-effort.</td>
+    </tr>
+    <tr>
+      <td><strong>Blocks</strong></td>
+      <td><code>blocks?: AdapterBlocks</code></td>
+      <td>Only on the blocks reconstruct path. A content→Gutenberg recipe applied per
+      section and in bulk over post bodies. The theme/carry path never invokes it.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="callout decision">
+  <span class="label">The architectural lesson</span>
+  Platform knowledge is <em>pushed to the edge</em> (the adapter) and the core stages stay
+  generic. When you're tempted to special-case a platform deep in a shared stage, the right
+  move is almost always a new adapter capability + a generic consumer — exactly how
+  <code>capture</code> and <code>blocks</code> are built. That keeps the blast radius of
+  platform quirks to one directory.
+</div>
+
+<div class="quiz" data-answer="3">
+  <div class="q">A site detects as <code>unknown</code>. What happens, and what does its content come from?</div>
+  <ul class="opts">
+    <li><button class="opt">Extraction aborts with a 'No adapter available' error message</button></li>
+    <li><button class="opt">The Wix adapter is tried as the nearest generic match</button></li>
+    <li><button class="opt">Detection retries with looser path-based heuristics enabled</button></li>
+    <li><button class="opt">resolveAdapter falls back to default: Playwright HTML to cheerio</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — resolveAdapter routes unknown to the default adapter, which renders with Playwright then extracts via cheerio + JSON-LD."
+    data-wrong="Resolution always lands on an adapter: unknown → default. The 'no adapter' error is unreachable, and there's no path-based detection.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the three adapter methods, the two optional seams, and the difference between
+  detection and resolution.
+  <details><summary>Check yourself</summary>
+  Methods: detect / discover / extract. Seams: <code>capture</code> (pre-screenshot chrome
+  removal) and <code>blocks</code> (blocks-path recipe). Detection = reports a platform id;
+  resolution = <code>resolveAdapter</code> maps id → adapter, with <code>default</code> as
+  fallback.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/adapters/webflow/index.ts</span> (smallest adapter) to see the
+  assembler shape, then <span class="path">src/adapters/resolve-adapter.ts</span> for the
+  fallback, then <span class="path">src/adapters/page-actions.ts</span> for the two seam types.
+</div>
+
+<p class="ask">Want to walk the Shopify adapter's GraphQL product path, or see exactly what a
+<code>capture</code> recipe strips? Ask.</p>
+
+<div class="lesson-nav">
+  <a href="0003-fork-in-the-road.html">← Lesson 3</a>
+  <a href="0005-capture-and-sectionspec.html">Lesson 5: Capture &amp; SectionSpec →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0005-capture-and-sectionspec.html
+++ b/docs/how-it-works/lessons/0005-capture-and-sectionspec.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>5 · Capture &amp; the SectionSpec</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part II — Extraction</span>
+  <span>Lesson 5 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 05 · Extraction drill</div>
+<h1>Capture &amp; the SectionSpec</h1>
+<p class="subtitle">Screenshots are the obvious output of the capture stage. The <em>quiet</em> output — the <code>SectionSpec</code> — is the one that makes deterministic block reconstruction possible. This is where design becomes data.</p>
+
+<p>The <code>screenshotting</code> stage does more than take pictures. On the settled desktop
+page (1440×900) it runs <code>extractFull</code>, which returns
+<code>{ specs, landmarks }</code> and persists them.</p>
+
+<h2>What gets produced</h2>
+<table>
+  <thead><tr><th>Artifact</th><th>What it is</th></tr></thead>
+  <tbody>
+    <tr><td><code>screenshots/{desktop,mobile}/&lt;slug&gt;.png</code></td><td>Full-page + post-scroll captures.</td></tr>
+    <tr><td><code>html/&lt;slug&gt;.html</code></td><td>The rendered HTML cache.</td></tr>
+    <tr><td><code>screenshots/manifest.json</code></td><td>URL → files join (the only link back to content; nothing is injected into the WXR).</td></tr>
+    <tr><td><code>sections/&lt;slug&gt;.json</code></td><td>The <code>SectionSpec[]</code> + landmark census. <strong>The star of this lesson.</strong></td></tr>
+    <tr><td><code>palette / typography / breakpoints.json</code></td><td>Site-wide design tokens aggregated at run end.</td></tr>
+  </tbody>
+</table>
+
+<h2>The SectionSpec, precisely</h2>
+<p>A <strong>SectionSpec</strong> is a computed-style description of one visual section of a
+page, each carrying a compact CSS <code>selector</code> that re-locates it in the source DOM.
+Reconstruction reads these instead of re-running Playwright. The store is
+<span class="path">src/lib/replicate/section-specs-store.ts</span> (schema v9).</p>
+
+<div class="callout key">
+  <span class="label">Why a cache, and why it's special</span>
+  <code>sections/&lt;slug&gt;.json</code> is a <em>capture-once cache</em>, not shared run
+  state — so unlike the other resume files it needs no lockfile. Each file is independent,
+  written atomically (unique tmp + rename), keyed by <code>slugify(url)</code>, and
+  self-describing (records its <code>sourceUrl</code> + schema version). Reconstruction
+  falls back to a live extract only on a cache miss: absent, corrupt, schema drift, or a
+  slug collision (recorded <code>sourceUrl</code> ≠ requested).
+</div>
+
+<h2>The landmark census</h2>
+<p>The same browser walk that emits section selectors also emits a top-level
+<strong>landmark census</strong>: the tally of <code>main</code> / <code>nav</code> /
+<code>header</code> / <code>footer</code>. Because the selectors and the census come from
+<em>one</em> walk, the later region audit's "did this landmark survive?" join holds <em>by
+construction</em> — they can't disagree about what was on the page.</p>
+
+<div class="callout gotcha">
+  <span class="label">Schema-version discipline</span>
+  Bump <code>SECTION_SPECS_SCHEMA</code> whenever <code>SectionSpec</code>'s shape <em>or</em>
+  the persisted envelope (e.g. the census) changes — stale caches must invalidate instead of
+  silently degrading fidelity. A known failure mode: a schema bump paired with a weak live
+  re-capture can corrupt every spec on a run. The cache-miss path must walk the saved HTML
+  robustly, not half-re-extract.
+</div>
+
+<h2>One spec field worth knowing now: <code>fullBleed</code></h2>
+<p>Page layout <em>defers to the source</em>. A section carrying an image (foreground or
+background, height ≥ 100px) that spans ≥ 92% of the viewport is <code>fullBleed</code>. Any
+non-chrome full-bleed section pushes the page's <code>main</code> layout to full-width;
+otherwise it's constrained. This is independent of <code>heroIsCover</code> (which only
+controls the transparent overlay header). It's a clean example of the design philosophy:
+<em>measure the source, don't guess the layout</em>.</p>
+
+<div class="quiz" data-answer="1">
+  <div class="q">Why does the section cache <em>not</em> need the extraction-log lockfile that the other state files use?</div>
+  <ul class="opts">
+    <li><button class="opt">Because it is written only once at the very end of the run</button></li>
+    <li><button class="opt">Because each per-URL file is independent and atomically written</button></li>
+    <li><button class="opt">Because reconstruction never reads it during an extraction run</button></li>
+    <li><button class="opt">Because it is stored outside the resolved output directory tree</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — it's a per-URL capture-once cache; each file is independent and written tmp+rename, so there's no shared-writer contention to guard."
+    data-wrong="It's not about timing or location. It needs no lockfile because each file is independent per-URL and written atomically — no shared single-writer state to protect.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  What two things does <code>extractFull</code> return, and why does pairing them in one
+  browser walk matter downstream?
+  <details><summary>Check yourself</summary>
+  <code>{ specs, landmarks }</code> — the <code>SectionSpec[]</code> and the landmark census.
+  One walk means the region audit's census↔section join is correct by construction; they
+  can't disagree about the page.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/lib/replicate/section-specs-store.ts</span> (the store +
+  schema), and find <code>extractFull</code> / <code>buildSelector</code> in
+  <span class="path">src/lib/replicate/</span> to see how browser-emitted
+  <code>SelectorParts</code> become a stable Node-side selector.
+</div>
+
+<p class="ask">The <code>selector</code>-building split (browser emits parts, Node builds the
+string) is subtle and load-bearing — ask me to unpack the <code>__name</code> gotcha behind it.</p>
+
+<div class="lesson-nav">
+  <a href="0004-the-adapter-pattern.html">← Lesson 4</a>
+  <a href="0006-resume-state-contract.html">Lesson 6: The resume-state contract →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0006-resume-state-contract.html
+++ b/docs/how-it-works/lessons/0006-resume-state-contract.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>6 · The Resume-State Contract</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part II — Extraction</span>
+  <span>Lesson 6 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 06 · Extraction drill</div>
+<h1>The Resume-State Contract</h1>
+<p class="subtitle">Extraction is expensive and crashes happen. The system survives because five on-disk stores make every stage idempotent. Knowing exactly what each one <em>owns</em> is how you reason about "what happens if this dies halfway."</p>
+
+<p>Four files cooperate to make a run resumable, plus a fifth per-URL cache. The rule:
+<strong>never write to the shared four outside the extraction-log lockfile</strong>
+(<code>mcp-server.ts</code> and <code>ui/discover.tsx</code> bracket the whole pipeline).</p>
+
+<table>
+  <thead><tr><th>File</th><th>Owner</th><th>Owns</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>extraction-log.jsonl</code></td>
+      <td><code>ExtractionLog</code></td>
+      <td>Append-only per-URL dedupe. <strong>Source of truth for "did we process this URL."</strong></td>
+    </tr>
+    <tr>
+      <td><code>session.json</code></td>
+      <td><code>ImportSession</code></td>
+      <td>Stage, original opts, per-entity counts, adapter pagination cursors. Single-writer, atomic rename.</td>
+    </tr>
+    <tr>
+      <td><code>media-stubs.json</code></td>
+      <td><code>MediaStubStore</code></td>
+      <td>Per-asset status (<code>success</code>/<code>error</code>/<code>ignored</code>) + retry cap (default 3) + installed <code>wpPostId</code>.</td>
+    </tr>
+    <tr>
+      <td><code>products.jsonl</code></td>
+      <td>Woo CSV writer</td>
+      <td>Streaming Woo product output, one product per line. <code>openStream({resume:true})</code> appends.</td>
+    </tr>
+    <tr>
+      <td><code>sections/&lt;slug&gt;.json</code></td>
+      <td><code>SectionSpecsStore</code></td>
+      <td>Per-URL capture-once spec cache (Lesson 5). Independent files; <em>no</em> lockfile.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>The pattern behind all of them</h2>
+<p>Each store implements the same idea in its own way: <strong>write so that a crash leaves
+recoverable state, and a re-run skips what's already done.</strong></p>
+<ul>
+  <li><strong>Append-only</strong> (<code>extraction-log.jsonl</code>, <code>products.jsonl</code>)
+  — a partial line is the worst case; resume appends.</li>
+  <li><strong>Atomic rename</strong> (<code>session.json</code>, section files) — a write is
+  all-or-nothing; you never read a half-written file.</li>
+  <li><strong>Status + retry cap</strong> (<code>media-stubs.json</code>) — failures persist
+  immediately and are retried up to a cap, so a flaky CDN doesn't wedge the run.</li>
+</ul>
+
+<div class="callout key">
+  <span class="label">Corruption is never silent</span>
+  A corrupt <code>session.json</code> becomes <code>session.json.corrupt.&lt;ts&gt;</code> —
+  it is preserved, never deleted. This is a recurring value in the codebase: degrade loudly,
+  keep the evidence. The same instinct shows up in the diagnostics artifacts (Lesson 12).
+</div>
+
+<h2>How a stage uses it</h2>
+<p>Adapters call <code>ImportSession.loadOrCreate(outputDir, id, opts, { resume })</code> and
+pass the session into <code>runExtractionLoop</code> via <code>ExtractionLoopOpts.session</code>.
+The shared loop updates stage + per-entity counts automatically. So an adapter author mostly
+gets resumability for free — they emit content; the loop and the stores handle the
+bookkeeping.</p>
+
+<div class="callout decision">
+  <span class="label">Why this is an architecture-grade concern</span>
+  When you evaluate a change to extraction, the question "what does this do to resume?" is
+  load-bearing. A change that writes shared state outside the lockfile, or that makes a store
+  non-idempotent, can corrupt long runs in ways tests rarely catch. The <code>faultpoint</code>
+  crash-harness exists precisely to inject crashes and prove recovery — reach for it when a
+  change touches these stores.
+</div>
+
+<div class="quiz" data-answer="2">
+  <div class="q">Which file is the authoritative answer to "have we already processed this URL?"</div>
+  <ul class="opts">
+    <li><button class="opt"><code>session.json</code> — it holds the per-entity counts</button></li>
+    <li><button class="opt"><code>media-stubs.json</code> — it tracks every fetched asset</button></li>
+    <li><button class="opt"><code>extraction-log.jsonl</code> — append-only per-URL dedupe</button></li>
+    <li><button class="opt"><code>sections/&lt;slug&gt;.json</code> — keyed by the URL slug</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — ExtractionLog's append-only log is the source of truth for URL-level dedupe and resume."
+    data-wrong="session.json tracks stage/counts; the per-URL 'did we do this' source of truth is extraction-log.jsonl.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  List the five stores and one word for what each owns. Then name the three crash-safety
+  techniques and which store uses each.
+  <details><summary>Check yourself</summary>
+  extraction-log (URL-dedupe), session (stage/opts/cursors), media-stubs (asset-status),
+  products (product-stream), sections (spec-cache). Techniques: append-only (log, products);
+  atomic rename (session, sections); status+retry cap (media-stubs).
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read the headers of <span class="path">src/lib/resume-state/extraction-log.ts</span>,
+  <span class="path">…/import-session.ts</span>, and <span class="path">…/media-stubs.ts</span>.
+  Then look at <span class="path">…/faultpoint.ts</span> to see how crashes are injected for
+  testing.
+</div>
+
+<p class="ask">Want me to walk a concrete "crash during downloading-media, then resume"
+trace through all five files? Ask.</p>
+
+<div class="lesson-nav">
+  <a href="0005-capture-and-sectionspec.html">← Lesson 5</a>
+  <a href="0007-the-tick-loop.html">Lesson 7: The tick loop &amp; judgment seam →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0007-the-tick-loop.html
+++ b/docs/how-it-works/lessons/0007-the-tick-loop.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>7 · The Tick Loop &amp; the Judgment Seam</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part III — Reconstruction</span>
+  <span>Lesson 7 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 07 · Reconstruction drill</div>
+<h1>The Tick Loop &amp; the Judgment Seam</h1>
+<p class="subtitle">This is the most distinctive thing about the architecture — and the easiest to miss from the file tree. The default run is not a batch script; it's a streaming loop that deliberately hands reasoning back to an agent at marked boundaries.</p>
+
+<p>The design center of the system: <strong>AI agents are the primary runtime.</strong> The
+default <code>data-liberation &lt;url&gt;</code> command doesn't just run code — it runs a
+<em>watch loop</em> that interleaves deterministic work with agent judgment.</p>
+
+<h2>Two state machines, not one</h2>
+<p>Lesson 1 gave you the persisted <code>ImportStage</code> union. The streaming path has a
+<em>second</em>, finer-grained phase enum that drives live orchestration —
+<code>WatchPhase</code> in <span class="path">src/ui/watch-runner.ts</span>:</p>
+
+<pre><code>resolving-agent → resetting → detecting → discovering
+  → extracting → starting-preview → tick-drain
+  → invoking-judgments → done            (+ error)</code></pre>
+
+<table>
+  <thead><tr><th>Enum</th><th>Role</th></tr></thead>
+  <tbody>
+    <tr><td><code>ImportStage</code></td><td>The <em>persisted resume checkpoint</em> (what's written to <code>session.json</code>).</td></tr>
+    <tr><td><code>WatchPhase</code></td><td>The <em>live orchestration state</em> of the streaming run — finer-grained, not persisted.</td></tr>
+  </tbody>
+</table>
+
+<p>Notice <code>starting-preview</code> runs <em>in parallel</em> with discovery: a Studio
+WordPress site boots while URLs are still being found. The reconstruction has somewhere to
+land before extraction even finishes.</p>
+
+<h2>The judgment seam</h2>
+<p>The heart of it: <code>tick-scheduler</code> (<span class="path">src/lib/streaming/</span>)
+emits a <code>judgmentNeeded[]</code> list. That is the exact line where <strong>deterministic
+code stops and the agent/skill is asked to reason</strong> — to run the replicate / compose /
+design-foundation skills, pick clusters, judge parity.</p>
+
+<div class="callout key">
+  <span class="label">The seam, stated plainly</span>
+  Everything a <em>function</em> can decide, a function decides (detection, selectors,
+  layout type, block canonicalization). Everything that needs <em>judgment</em> —
+  "is this section good enough?", "which representative page stands for this cluster?",
+  "does this match the source?" — is pushed across the <code>judgmentNeeded</code> boundary
+  to the model. The whole system is organized around drawing that line well.
+</div>
+
+<h2>Why this is the architecture decision behind all the others</h2>
+<p>The governing rule: <em>ship AI stages as skills, not SDK calls in <code>src/</code>.</em>
+That's why there are ~38 small deterministic MCP tools instead of a few big "do it all"
+functions. The tools are the <em>vocabulary</em>; the skills are the <em>sentences</em> an
+agent composes. When you design a new capability, the question is: which part is
+deterministic (→ a tool in <code>src/lib</code>) and which part is judgment (→ a step in a
+skill)?</p>
+
+<div class="callout decision">
+  <span class="label">A litmus test you can apply</span>
+  If a proposed feature reads "have the model look at X and decide Y," it belongs in a
+  <em>skill</em> orchestrating tools — not as an LLM call buried in <code>src/</code>. If it
+  reads "given inputs, always produce the same output," it belongs in a deterministic tool.
+  Mixing the two is the smell to catch in review.
+</div>
+
+<div class="quiz" data-answer="0">
+  <div class="q">What is the <code>judgmentNeeded[]</code> list emitted by the tick scheduler?</div>
+  <ul class="opts">
+    <li><button class="opt">The boundary where deterministic code hands reasoning to the agent</button></li>
+    <li><button class="opt">The list of URLs that failed extraction and need a manual retry</button></li>
+    <li><button class="opt">The persisted resume checkpoint written into the session file</button></li>
+    <li><button class="opt">The set of media assets still awaiting download from a CDN</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — it's the seam where code stops and the agent/skill is asked to judge (clusters, parity, compose)."
+    data-wrong="It's not failures or media or the persisted checkpoint. It's the deterministic-vs-judgment boundary handing reasoning to the agent.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the two state machines and which one persists. Then state the litmus test for
+  "deterministic tool vs skill step."
+  <details><summary>Check yourself</summary>
+  <code>ImportStage</code> (persisted resume checkpoint) and <code>WatchPhase</code> (live,
+  not persisted). Litmus: "model looks and decides" → skill orchestrating tools; "same
+  inputs → same output" → deterministic tool in <code>src/lib</code>.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read the <code>WatchPhase</code> enum and loop in
+  <span class="path">src/ui/watch-runner.ts</span>, then the
+  <span class="path">src/lib/streaming/tick-scheduler.ts</span> to see where
+  <code>judgmentNeeded</code> is built and drained.
+</div>
+
+<p class="ask">This seam is the crux of your "what should be a skill vs a tool" calls — want
+to pressure-test a specific feature idea against it together? Ask.</p>
+
+<div class="lesson-nav">
+  <a href="0006-resume-state-contract.html">← Lesson 6</a>
+  <a href="0008-blocks-reconstruction.html">Lesson 8: Blocks reconstruction →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0008-blocks-reconstruction.html
+++ b/docs/how-it-works/lessons/0008-blocks-reconstruction.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>8 · Blocks Reconstruction</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part III — Reconstruction</span>
+  <span>Lesson 8 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 08 · Reconstruction drill</div>
+<h1>Blocks Reconstruction</h1>
+<p class="subtitle">The blocks path turns captured section specs into native Gutenberg markup. Its real sophistication is in how it handles the sections it <em>can't</em> cleanly model — and how it tells you, in writing, every time it falls back.</p>
+
+<p>Tool: <code>liberate_reconstruct_pages</code> →
+<span class="path">src/mcp-server/handlers/reconstruct-pages.ts</span> →
+<span class="path">src/lib/replicate/{reconstruct-pages,page-reconstruct}.ts</span>. It reads
+the <code>SectionSpec[]</code> from the cache (Lesson 5) and emits a block document per page.</p>
+
+<h2>The fallback ladder</h2>
+<p>For each visual section the pipeline tries to produce clean native blocks. When it can't,
+it falls back to a <code>core/html</code> island — but the fallback is <em>gated</em> and
+<em>recorded</em>, never silent.</p>
+
+<div class="flow">
+  <div class="flow-stage"><span class="flow-badge">①</span><div class="flow-body"><strong>Adapter blocks recipe</strong> (if declared) — platform-specific content→blocks, per section and in bulk.</div></div>
+  <div class="flow-stage"><span class="flow-badge">②</span><div class="flow-body"><strong>Native block emit</strong> — structured render into core blocks (columns, headings, images, lists…).</div></div>
+  <div class="flow-stage"><span class="flow-badge">③</span><div class="flow-body"><strong>core/html coverage island</strong> — the fallback, when native coverage drops below floor. Marked <code>lib-coverage-island</code>.</div></div>
+  <div class="flow-stage"><span class="flow-badge">④</span><div class="flow-body"><strong>editable-html conversion</strong> — islands become <code>dla/editable-html</code> by default: visible, styled, editable, byte-identical save.</div></div>
+</div>
+
+<h2>It writes down why it fell back</h2>
+<p>This is the part to internalize. The blocks reconstruction emits three
+<strong>warning-level diagnostic artifacts</strong>, all keyed off the section
+<code>selector</code>, all atomic, all surfaced as tallies in the tool's result (they do
+<em>not</em> flip the run verdict):</p>
+
+<table>
+  <thead><tr><th>Artifact</th><th>Answers</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><code>fallback-diagnostics.json</code></td>
+      <td>"Why did this section become a <code>core/html</code> island?" One record per
+      coverage-gated island: <code>reasonCode</code> (<code>dropped_images</code> |
+      <code>text_coverage_below_floor</code>, media-first precedence),
+      <code>suggestedRepairClass</code>, dropped URLs, coverage, source/emitted previews.</td>
+    </tr>
+    <tr>
+      <td><code>region-audit.json</code></td>
+      <td>"Did every source landmark survive?" Reconciles the landmark census vs what was
+      placed. An actionable landmark mapping to nothing is <code>unassigned</code> — the
+      dropped-nav/footer signal.</td>
+    </tr>
+    <tr>
+      <td><code>asset-triage.json</code></td>
+      <td>Vision-classified decorative-asset verdicts (<code>keep</code>/<code>decoration</code>);
+      decorations are skipped as images pre-build.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="callout key">
+  <span class="label">The design principle here</span>
+  Fidelity loss is made <strong>legible</strong>. Instead of a black-box "best effort," every
+  fallback leaves a structured, selector-keyed record an agent can triage — what fell back,
+  why, and what repair class would fix it. This is what makes the blocks path safe to iterate
+  on: you can <em>see</em> the gaps.
+</div>
+
+<h2>The coverage island marker (a subtle gate)</h2>
+<p>Coverage islands carry a deterministic marker on the opening delimiter —
+<code>&lt;!-- wp:html {"metadata":{"name":"lib-coverage-island"}} --&gt;</code>. This lets the
+install-time <code>wp:html</code> ban accept <em>pipeline</em> islands on theme reinstall
+while still rejecting hand-authored Custom HTML. It's a <em>quality gate, not a security
+boundary</em> — the marker is recognizable, not unforgeable. Knowing that distinction keeps
+you from over-trusting it.</p>
+
+<div class="callout gotcha">
+  <span class="label">The coverage gate's blind spot</span>
+  The coverage gate measures text/image coverage — it is <em>blind to layout breakage</em>.
+  A section can pass coverage while its structure is mangled — coverage looks fine, layout is
+  wrong. This is why coverage alone can't gate aggressive native conversion on complex builder
+  sites. When you reason about quality here, remember coverage ≠ correctness.
+</div>
+
+<div class="quiz" data-answer="3">
+  <div class="q">A section becomes a <code>core/html</code> island. Where do you look to learn <em>why</em>?</div>
+  <ul class="opts">
+    <li><button class="opt"><code>region-audit.json</code> — it lists every dropped landmark</button></li>
+    <li><button class="opt"><code>comparison.json</code> — it scores each viewport's parity</button></li>
+    <li><button class="opt"><code>session.json</code> — it records the stage and any error</button></li>
+    <li><button class="opt"><code>fallback-diagnostics.json</code> — one record per gated island</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — fallback-diagnostics.json carries the reasonCode, dropped images, coverage, and a suggested repair class per island."
+    data-wrong="region-audit is about dropped landmarks; the per-island 'why did this fall back' record is fallback-diagnostics.json.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the three diagnostic artifacts and the one question each answers. Then state why the
+  coverage gate isn't enough on its own.
+  <details><summary>Check yourself</summary>
+  fallback-diagnostics (why this island), region-audit (did landmarks survive), asset-triage
+  (keep/decoration). Coverage measures text/image presence, not layout — it's blind to
+  structural breakage.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/lib/replicate/page-reconstruct.ts</span> for the per-section
+  emit + fallback, and <span class="path">…/fallback-diagnostic.ts</span> +
+  <span class="path">…/region-audit.ts</span> for the pure builders behind the artifacts.
+</div>
+
+<p class="ask">Want to walk a sample <code>fallback-diagnostics.json</code> and triage it
+together? Ask — it's the fastest way to make this concrete.</p>
+
+<div class="lesson-nav">
+  <a href="0007-the-tick-loop.html">← Lesson 7</a>
+  <a href="0009-the-carry-path.html">Lesson 9: The carry path →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0009-the-carry-path.html
+++ b/docs/how-it-works/lessons/0009-the-carry-path.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>9 · The Carry Path</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part III — Reconstruction</span>
+  <span>Lesson 9 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 09 · Reconstruction drill</div>
+<h1>The Carry Path</h1>
+<p class="subtitle">When fidelity is the whole game, you stop interpreting the source and start carrying it. The carry path's craft is in making "ship the original HTML" actually behave inside WordPress — self-hosted, scoped, and de-CDN'd.</p>
+
+<p>Tool: <code>liberate_reconstruct_pages_carry</code> →
+<span class="path">src/mcp-server/handlers/reconstruct-pages-carry.ts</span> →
+<span class="path">src/lib/replicate/{page-reconstruct-carry,html-carry}.ts</span>. It writes a
+<code>&lt;slug&gt;-carry</code> FSE block theme whose page bodies are the sanitized source
+HTML in <code>core/html</code> islands, with the source CSS scoped to avoid bleed.</p>
+
+<h2>The three problems carry has to solve</h2>
+<table>
+  <thead><tr><th>Problem</th><th>Solution</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><strong>CSS bleed</strong> — source CSS would clobber the WP theme and admin.</td>
+      <td>Scope every rule (e.g. <code>:where(body.lib-carry-site) …</code>) — <code>:where()</code> keeps specificity at zero so it layers cleanly.</td>
+    </tr>
+    <tr>
+      <td><strong>CDN dependence</strong> — the replica must not phone home to Wix/Shopify CDNs.</td>
+      <td>Full self-hosting: repoint image variants, pre-pass download extraction-missed images, strip-unused + localize fonts, drop dead preload/builder <code>&lt;link&gt;</code>s.</td>
+    </tr>
+    <tr>
+      <td><strong>Dead interactivity</strong> — source JS reveal/animation leaves content hidden.</td>
+      <td>Un-freeze JS reveals (e.g. <code>:has()</code> nav-reveal), denylist <code>display</code>/<code>visibility</code> in carried CSS so <code>display:none</code> doesn't survive.</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="callout key">
+  <span class="label">The mental model</span>
+  Carry is "the source HTML wearing a WordPress costume." The hard work isn't producing the
+  markup — it's <em>severing every tie to the origin platform</em> (CDN, fonts, builder
+  chrome) and <em>neutralizing the source's own hiding mechanisms</em> so the carried content
+  is actually visible and self-contained.
+</div>
+
+<h2>Chrome fidelity is its own subsystem</h2>
+<p>Headers, footers, and nav are the hardest part of carry, because builder platforms ride
+chrome inline or behind custom elements. Chrome fidelity is a layered strategy:
+<strong>prevent</strong> (rem-base on <code>:root</code>, un-freeze JS reveal),
+<strong>fingerprint</strong> (capture chrome signature), <strong>self-heal</strong>
+(source-vs-build audit). A representative failure mode: a store header collapses when a
+carried <code>:where(body.lib-carry-site) header{display:none}</code> matches the
+WP-injected wrapper <code>&lt;header&gt;</code>; the fix out-specifies it with
+<code>header.wp-block-template-part{display:block!important}</code>.</p>
+
+<div class="callout gotcha">
+  <span class="label">Verify on the LIVE site, not the captured PNG</span>
+  A recurring trap: carry replica screenshots can race the source CSS (false-white) or
+  capture before lazy images load (short screenshots → understated parity scores), and the
+  WP admin bar adds a ~32px offset. These capture artifacts masquerade as regressions. Always
+  verify carry fidelity on the live rendered site with a computed-style probe, not a grep of
+  the DOM or a stale PNG.
+</div>
+
+<h2>Where carry and blocks meet</h2>
+<p>Remember Lesson 3: carry islands convert to <code>dla/editable-html</code> too. And native
+blocks can be <em>spliced</em> into a carried island with the source's own classes at
+<strong>zero pixel delta</strong> — a hybrid that gets carry's fidelity with some of blocks'
+editability. The two paths are not a permanent fork; they're the ends of one spectrum, and the
+editable-island bridge already spans part of it.</p>
+
+<div class="quiz" data-answer="1">
+  <div class="q">Why scope carried CSS with <code>:where(body.lib-carry-site)</code> rather than a plain descendant selector?</div>
+  <ul class="opts">
+    <li><button class="opt">It is shorter to generate and reads more clearly in the output</button></li>
+    <li><button class="opt"><code>:where()</code> contributes zero specificity, so rules layer without fighting</button></li>
+    <li><button class="opt">It is required for the editable-html island conversion to run</button></li>
+    <li><button class="opt">It prevents the source JavaScript from re-hiding the content</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — :where() holds specificity at zero so carried rules scope cleanly without clobbering or being clobbered unpredictably."
+    data-wrong="It's about specificity: :where() is zero-specificity, so scoped carried rules layer predictably instead of winning specificity fights.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the three problems carry must solve and the fix for each. Then state the verification
+  rule that prevents the capture-artifact rabbit hole.
+  <details><summary>Check yourself</summary>
+  CSS bleed → <code>:where()</code> scoping; CDN dependence → full self-hosting (image
+  repoint, missing-media pre-pass, font localize, dead-link strip); dead interactivity →
+  un-freeze JS reveal + denylist display/visibility. Verify on the live site with a
+  computed-style probe, not a stale PNG or DOM grep.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/lib/replicate/html-carry.ts</span> (sanitize + scope + island)
+  and the carry font/media helpers (<span class="path">carry-fonts.ts</span>,
+  <span class="path">carry-missing-media.ts</span>) to see self-hosting in action.
+</div>
+
+<p class="ask">The chrome-collapse failure mode is a goldmine of how CSS cascade fights play
+out here — ask me to walk the full header-rescue trace if you want it.</p>
+
+<div class="lesson-nav">
+  <a href="0008-blocks-reconstruction.html">← Lesson 8</a>
+  <a href="0010-blocks-engine-adoption.html">Lesson 10: The shared blocks engine →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0010-blocks-engine-adoption.html
+++ b/docs/how-it-works/lessons/0010-blocks-engine-adoption.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>10 · The Shared Blocks Engine</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part III — Reconstruction</span>
+  <span>Lesson 10 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 10 · Reconstruction drill</div>
+<h1>The Shared Blocks Engine</h1>
+<p class="subtitle">The deterministic core of "section spec → native blocks" is general — it isn't DLA-specific — so it lives in a separate, reusable package, <code>@automattic/blocks-engine</code>, which DLA consumes. Understanding this seam is understanding how reconstruction is structured.</p>
+
+<p>The pure, deterministic "turn a section into block markup" logic isn't unique to data
+liberation — any "specs → blocks" consumer needs it. So it lives in its own package, and DLA
+is a <em>consumer</em> of that engine plus its own orchestration.</p>
+
+<h2>How the dependency is wired</h2>
+<p>DLA depends on the published package <code>@automattic/blocks-engine</code> (a normal semver
+range, e.g. <code>^0.1.0</code> in <code>package.json</code>). It is an ordinary npm
+dependency — no special checkout required to install DLA.</p>
+
+<h2>The seam: what lives where</h2>
+<table>
+  <thead><tr><th>In the engine</th><th>In DLA</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>The deterministic reconstruct <em>core</em>: <code>reconstructNativeAggregate</code>
+      — the pure section-spec → native-block-aggregate transform.</td>
+      <td>The per-page <em>boundary</em>: <code>reconstructPagePattern</code> lives DLA-side and
+      delegates <em>into</em> the engine core.</td>
+    </tr>
+    <tr>
+      <td>The general block-emit logic any "specs → blocks" consumer needs.</td>
+      <td>The orchestration: capture, resume-state, the carry path, diagnostics, the
+      tick/judgment loop — all DLA.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p><code>reconstructPagePattern</code> is a thin boundary (~200 lines) that hands its core work
+to the engine's single-sourced <code>reconstructNativeAggregate</code>. The engine owns the
+transform; DLA owns where and when it runs.</p>
+
+<div class="callout key">
+  <span class="label">The guardrail: a frozen-output harness</span>
+  The seam is protected by a frozen harness test: the exact reconstruct output is pinned in a
+  fixture. Any divergence — whether from a DLA-side change or an engine version bump — fails the
+  test loudly. That is what makes depending on a shared engine safe: the consumer freezes the
+  precise output it expects, so the shared code can't silently drift under it.
+</div>
+
+<h2>What stays DLA-local (and why that's correct)</h2>
+<p>Not everything is shared. The <em>local</em> emit-blocks path (Lesson 13) keeps a distinct
+strategy rather than using the engine core, because it preserves the owned source DOM instead
+of re-emitting markup from captured specs — a genuinely different transform. The principle:
+share the core where the output is identical; keep strategies separate where they truly differ.</p>
+
+<div class="callout decision">
+  <span class="label">Why this matters for architecture calls</span>
+  When you weigh "shared engine or DLA-local," the test is concrete: can the shared version
+  produce exactly the output the consumer needs, pinned by a frozen harness? If yes, depend on
+  it. If two callers genuinely need different strategies, a forced shared abstraction will
+  leak — keep them separate behind a clean interface instead.
+</div>
+
+<div class="callout gotcha">
+  <span class="label">Test-runner trap</span>
+  Running <code>vitest</code> from the DLA repo root can go red due to <code>.worktrees/*</code>
+  pollution (sibling copies of every test colliding on cwd-relative fixtures). Verify with
+  <code>--dir src</code> or inside a clean worktree, not from a polluted root.
+</div>
+
+<div class="quiz" data-answer="2">
+  <div class="q">What makes it safe for DLA to depend on the engine's <code>reconstructNativeAggregate</code>?</div>
+  <ul class="opts">
+    <li><button class="opt">The engine has far more test coverage than DLA itself does</button></li>
+    <li><button class="opt">The carry path provides a parallel implementation as a backstop</button></li>
+    <li><button class="opt">A frozen harness pins the reconstruct output, catching any drift</button></li>
+    <li><button class="opt">The local emit-blocks path shares the exact same engine core</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — the consumer pins the exact expected output in a frozen fixture, so an engine version bump (or a DLA change) that alters the result fails loudly."
+    data-wrong="Safety comes from the frozen-output harness DLA holds — not from coverage, a carry backstop, or local sharing (the local path deliberately stays distinct).">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  State what lives in the engine vs what lives in DLA, and the guardrail that makes the
+  dependency safe. Then say why the local emit-blocks path stays DLA-local.
+  <details><summary>Check yourself</summary>
+  Engine: deterministic core (<code>reconstructNativeAggregate</code>). DLA: per-page boundary
+  (<code>reconstructPagePattern</code>), carry, capture, resume-state, diagnostics,
+  orchestration. Guardrail: a frozen-output harness pins the reconstruct result. The local path
+  preserves the owned source DOM rather than re-emitting from specs — a different transform.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/lib/replicate/reconstruct-pages.ts</span>
+  (<code>reconstructPagePattern</code>'s delegation) alongside the engine's
+  <code>reconstructNativeAggregate</code>. The <code>@automattic/blocks-engine</code> dependency
+  is declared in <span class="path">package.json</span>.
+</div>
+
+<p class="ask">Want to see exactly what the engine's <code>reconstructNativeAggregate</code>
+signature takes and returns? Ask and we'll read it together.</p>
+
+<div class="lesson-nav">
+  <a href="0009-the-carry-path.html">← Lesson 9</a>
+  <a href="0011-output-artifacts.html">Lesson 11: Output artifacts →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0011-output-artifacts.html
+++ b/docs/how-it-works/lessons/0011-output-artifacts.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>11 · Output Artifacts</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part IV — Output &amp; Quality</span>
+  <span>Lesson 11 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 11 · Output &amp; quality</div>
+<h1>Output Artifacts</h1>
+<p class="subtitle">Three output families, three target formats: content → WXR, products → Woo CSV, assets → self-hosted media. Knowing what each builder guarantees tells you what a downstream WordPress import can rely on.</p>
+
+<h2>Content → WXR</h2>
+<p><code>WxrBuilder</code> (<span class="path">src/lib/wxr/</span>) assembles/appends
+<code>output.wxr</code>, targeting <strong>WXR 1.2</strong> spec compliance. Extraction
+appends per-URL (Lesson 6's append-only pattern); reconstruction rewrites the post
+<code>content:encoded</code> bodies with block markup. The WP block parser is adopted as a
+<em>validate-artifacts oracle</em> — a gate that the emitted block markup actually parses.</p>
+
+<div class="callout key">
+  <span class="label">Never lose source content</span>
+  A first-principles rule in this codebase: preserve <em>all</em> source content verbatim — no
+  truncation, no dedup, no dropping. If the source shows it (even a heading plus an identical
+  paragraph), the output reproduces it. When you review a change that "cleans up" content, that
+  instinct is usually wrong here.
+</div>
+
+<h2>Products → Woo CSV</h2>
+<p>Products stream to <code>products.jsonl</code> (one product per line) and become a
+WooCommerce import CSV. <code>WooProduct</code> has first-class <code>seoTitle</code>,
+<code>seoDescription</code>, <code>costOfGoods</code> fields plus an open <code>meta</code>
+record; the CSV builder always emits the Yoast + cost-of-goods <code>meta:</code> columns,
+plus a column per custom meta key. Shopify specifics worth knowing:</p>
+<ul>
+  <li>Variant weights normalize to <strong>kilograms</strong> regardless of source unit (<code>normalizeWeightToKg</code>).</li>
+  <li>Sale price uses <code>compareAtPrice &gt; price</code> semantics — when set, <code>compareAtPrice</code> becomes <code>regularPrice</code> and <code>price</code> becomes <code>salePrice</code>.</li>
+  <li>With an <code>adminToken</code>, products come via the Admin GraphQL API (pinned <code>2025-04</code>), paginated by a resumable <code>endCursor</code>, falling back to the public JSON API on any failure.</li>
+</ul>
+
+<h2>Assets → self-hosted media</h2>
+<p><code>media-fetch</code> downloads + dedupes; <code>MediaStubStore</code> tracks status
+and the installed <code>wpPostId</code>. Filename collisions get numeric suffixes
+(<code>-2</code>, <code>-3</code>), not hashes. The advanced bit — <strong>SVG survival</strong>:</p>
+<ul>
+  <li>Every downloaded SVG is scanned for risky <code>&lt;use&gt;</code>/<code>&lt;defs&gt;</code> (<code>isRiskySvg</code>) and a PNG sibling is rasterized at 1024px via Playwright.</li>
+  <li>Any library-bound SVG triggers a one-time <code>ensurePlugin(site,'safe-svg')</code>; risky SVGs upload their PNG raster instead.</li>
+</ul>
+
+<div class="callout decision">
+  <span class="label">The join is filesystem-only — by design</span>
+  Nothing about screenshots or media is injected into the WXR. The link from a URL to its
+  screenshots/HTML is <code>screenshots/manifest.json</code>; orchestration correlates by URL
+  between the manifest and <code>output.wxr</code>/<code>products.jsonl</code>. This keeps the
+  WXR a clean, portable content artifact and pushes all the "which file goes with which page"
+  bookkeeping into a sidecar. When you design new outputs, prefer that shape: keep the
+  portable artifact pure, join by URL in a manifest.
+</div>
+
+<h2>The theme shell</h2>
+<p>Under every reconstruct path, the theme <em>shell</em> is emitted deterministically by
+<code>liberate_theme_scaffold</code> and installed by <code>liberate_install_theme</code>.
+The output base resolves (via <code>liberate_paths</code> / <code>paths.ts</code>) to
+<code>~/Studio/_liberations/&lt;host&gt;</code> by default.</p>
+
+<div class="quiz" data-answer="0">
+  <div class="q">How is a page's screenshot associated with its WXR content?</div>
+  <ul class="opts">
+    <li><button class="opt">By URL, via <code>screenshots/manifest.json</code> — nothing is injected into the WXR</button></li>
+    <li><button class="opt">By a media id embedded in the post's <code>content:encoded</code> body</button></li>
+    <li><button class="opt">By a foreign key column written into <code>products.jsonl</code></button></li>
+    <li><button class="opt">By the slug stored inside each <code>sections/&lt;slug&gt;.json</code> file</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — the WXR stays pure; the URL→files join lives in manifest.json and orchestration correlates by URL."
+    data-wrong="Nothing is injected into the WXR. The join is filesystem-only: manifest.json maps URL → files.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the three output families and their target formats. Then state the "never lose source
+  content" rule and the "keep the portable artifact pure" principle in your own words.
+  <details><summary>Check yourself</summary>
+  Content → WXR 1.2 (<code>WxrBuilder</code>); products → Woo CSV (<code>products.jsonl</code>);
+  assets → self-hosted media (<code>media-fetch</code> + <code>MediaStubStore</code>).
+  Preserve all source content verbatim; keep WXR pure and join screenshots/media by URL via a
+  manifest sidecar.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/lib/wxr/</span> (the builder) and
+  <span class="path">src/lib/woo-csv/woo-product-csv.ts</span> (the product columns). For SVG
+  survival, <span class="path">src/lib/media-fetch/svg-raster.ts</span>.
+</div>
+
+<p class="ask">Want the full WooProduct → CSV column mapping as a printable reference card?
+Ask and I'll add it to the shelf.</p>
+
+<div class="lesson-nav">
+  <a href="0010-blocks-engine-adoption.html">← Lesson 10</a>
+  <a href="0012-quality-gates.html">Lesson 12: Quality gates &amp; diagnostics →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0012-quality-gates.html
+++ b/docs/how-it-works/lessons/0012-quality-gates.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>12 · Quality Gates &amp; Diagnostics</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part IV — Output &amp; Quality</span>
+  <span>Lesson 12 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 12 · Output &amp; quality</div>
+<h1>Quality Gates &amp; Diagnostics</h1>
+<p class="subtitle">A migration tool is only as trustworthy as its ability to know when it failed. This last lesson is the system's self-awareness layer — the gates that decide "good enough" and the diagnostics that explain "not yet."</p>
+
+<p>You've met pieces of this across the course. Here it is as one map, because reasoning about
+<em>quality</em> is reasoning about <em>which signal answers which question</em>.</p>
+
+<h2>The two kinds of signal</h2>
+<table>
+  <thead><tr><th></th><th>Verdict gates</th><th>Warning diagnostics</th></tr></thead>
+  <tbody>
+    <tr><td><strong>Job</strong></td><td>Pass/fail the run.</td><td>Explain gaps; never flip the verdict.</td></tr>
+    <tr><td><strong>Examples</strong></td><td><code>validate_artifacts</code>, <code>PARITY_GATE_SCORE</code>, the WP block-parser oracle.</td><td><code>fallback-diagnostics.json</code>, <code>region-audit.json</code>, <code>asset-triage.json</code>.</td></tr>
+    <tr><td><strong>How to read</strong></td><td>Hard stop — fix before shipping.</td><td>Triage queue — what an agent repairs next.</td></tr>
+  </tbody>
+</table>
+
+<h2>Visual parity: <code>comparison.json</code> (v2)</h2>
+<p><code>liberate_compare</code> scores each viewport. The v2 schema adds a <em>height</em>
+signal: each <code>ViewportScore</code> gains <code>originHeight</code>,
+<code>replicaHeight</code>, and <code>heightMismatchRatio</code>. When the ratio exceeds
+<code>HEIGHT_MISMATCH_THRESHOLD</code> (0.02), a magenta-padded full-canvas diff is written —
+<strong>magenta means content-gap, not style drift</strong>. The parity gate proper is
+<code>PARITY_GATE_SCORE = 0.995</code>. v1 files still parse (missing fields = gate disabled).</p>
+
+<div class="callout gotcha">
+  <span class="label">Scores lie when the capture is wrong</span>
+  The single biggest source of <em>false</em> low parity scores is capture artifacts:
+  screenshots taken before lazy images load (short replica → understated score), the WP admin
+  bar's ~32px offset, or a replica PNG racing the source CSS. Before trusting a low score,
+  confirm <code>scrollHeight</code> matched and no admin bar was in frame. This has burned
+  hours — treat a surprising score as "verify the capture" before "fix the code."
+</div>
+
+<h2>Content loss: the QA differ</h2>
+<p><code>liberate_qa</code> → <code>diffContent</code> (<span class="path">src/lib/qa/content-differ.ts</span>)
+measures extraction <em>loss</em> — origin items not present in the WXR (<code>missingImages</code>
+etc.). Crucially it measures loss, <strong>not hallucination</strong>: it tells you what
+failed to make it in, not what was invented. Knowing the direction of the measurement keeps
+you from misreading a clean QA report as "perfect."</p>
+
+<h2>Refine reports: closing the loop</h2>
+<p><code>liberate_refine_report</code> validates <code>refine/&lt;slug&gt;/*.json</code> coverage:
+every finding id must appear in exactly one of <code>applied</code>/<code>skipped</code>;
+orphans fail. This is the bookkeeping that makes an agentic repair loop <em>accountable</em> —
+you can't quietly drop a finding.</p>
+
+<div class="callout key">
+  <span class="label">The philosophy across all of it</span>
+  Degrade <em>loudly</em>, keep the evidence, make loss <em>legible</em>, and separate "did it
+  pass" from "here's what's imperfect." This is the same instinct as the preserved
+  <code>session.json.corrupt.&lt;ts&gt;</code> file (Lesson 6). A tool people trust with their
+  site's content cannot have silent failure modes — and this codebase is built to not have
+  them.
+</div>
+
+<h2>Faithful-recreation enforcement</h2>
+<p>There's a hard visual-parity gate (<code>section-parity.ts</code> + a run-report verdict)
+specifically to stop the shipping skills from flattening "known gaps" into an accepted result.
+The honest-assessment value is encoded in the gate itself: the system is designed to refuse to
+quietly call a degraded recreation "done."</p>
+
+<div class="quiz" data-answer="3">
+  <div class="q">A magenta band appears in a padded comparison diff. What does it indicate?</div>
+  <ul class="opts">
+    <li><button class="opt">A color-palette mismatch between the source and the replica</button></li>
+    <li><button class="opt">A font that failed to self-host and fell back to a system face</button></li>
+    <li><button class="opt">A JavaScript reveal animation that never un-froze on load</button></li>
+    <li><button class="opt">A content-gap: the replica is shorter than the source by &gt; the threshold</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — magenta padding marks a height/content gap (heightMismatchRatio > 0.02), distinct from style drift."
+    data-wrong="Magenta specifically marks a content-gap (height mismatch beyond the threshold), not a style/color/font issue.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Distinguish verdict gates from warning diagnostics with one example of each. Then state what
+  the QA differ measures (and what it does <em>not</em>), and the capture-artifact rule for
+  parity scores.
+  <details><summary>Check yourself</summary>
+  Gate (hard stop): <code>validate_artifacts</code> / <code>PARITY_GATE_SCORE=0.995</code>.
+  Diagnostic (triage, never flips verdict): <code>fallback-diagnostics.json</code>. The QA
+  differ measures extraction <em>loss</em>, not hallucination. Verify the capture
+  (scrollHeight, no admin bar, lazy images loaded) before trusting a low parity score.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/lib/replicate/compare.ts</span> (the v2 height signal +
+  thresholds), <span class="path">src/lib/qa/content-differ.ts</span> (loss measurement), and
+  <span class="path">src/lib/replicate/refine-report.ts</span> (coverage validator).
+</div>
+
+<p class="ask">That's the core spine. Part V drills into five advanced capabilities that
+build on it.</p>
+
+<div class="lesson-nav">
+  <a href="0011-output-artifacts.html">← Lesson 11</a>
+  <a href="0013-local-owned-source-path.html">Lesson 13: The local / owned-source path →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0013-local-owned-source-path.html
+++ b/docs/how-it-works/lessons/0013-local-owned-source-path.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>13 · The Local / Owned-Source Path</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part V — Advanced</span>
+  <span>Lesson 13 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 13 · Advanced capability</div>
+<h1>The Local / Owned-Source Path</h1>
+<p class="subtitle">The third reconstruct path is a different animal: no URL, no detection, no live extraction. You hand it a directory of HTML/CSS/JS you already own, and it produces a block theme. Understanding why it bypasses half the pipeline clarifies what the rest of the pipeline is <em>for</em>.</p>
+
+<p>Front door: the <code>data-liberation:liberate</code> skill routes on <em>input type</em>. A
+<strong>local directory</strong> takes the owned-source path — dispatched inline, no platform
+detection, no network extraction, no path checkpoint. A <strong>URL</strong> takes the remote
+path you've studied so far.</p>
+
+<h2>Two tools, one flow</h2>
+<div class="flow">
+  <div class="flow-stage"><span class="flow-badge">①</span><div class="flow-body"><strong><code>liberate_ingest_local_site</code></strong> — read the owned directory; inventory its HTML pages, CSS, JS, assets.</div></div>
+  <div class="flow-stage"><span class="flow-badge">②</span><div class="flow-body"><strong><code>liberate_convert_local_site</code></strong> — convert that inventory into a live Studio block theme: native nav, page templates, carried CSS/JS, optional data-model.</div></div>
+</div>
+
+<h2>Why it skips detection and extraction</h2>
+<p>The remote pipeline's expensive, fragile stages exist to deal with a site you <em>don't</em>
+control — fingerprint an unknown platform, fight bot defenses, discover URLs, download remote
+media. None of that applies to a folder on disk. So the owned path drops straight to
+reconstruction. This is the cleanest illustration of the two-phase split (Lesson 1): when phase
+one's risk disappears, you keep only phase two.</p>
+
+<div class="callout key">
+  <span class="label">Preserve-DOM, don't re-emit</span>
+  The local path's defining strategy: it <em>preserves the owned source DOM</em> rather than
+  re-emitting markup from captured specs. You wrote that HTML; it's already correct. So the
+  conversion keeps the structure and styling/animation JS, and turns it into a theme around
+  that — the opposite instinct from the blocks path, which re-derives everything from specs.
+  This is exactly why the local emit-blocks strategy stays distinct from the shared engine
+  core (Lesson 10).
+</div>
+
+<h2>From static cards to real WordPress data</h2>
+<p>The sophisticated part: an owned static site often <em>renders its content from JS data</em>
+(a catalog grid, a listings array) or from repeated static-HTML cards. The
+<code>data-liberation:model-local-data</code> skill analyzes that and emits a
+<code>data-model.json</code> — which <code>liberate_convert_local_site</code> consumes to turn
+that data into real WordPress posts + taxonomy + native query loops, <em>while keeping</em> the
+original styling/animation/modal JS.</p>
+
+<div class="callout decision">
+  <span class="label">The architectural payoff</span>
+  This is the difference between "a pretty static replica" and "a real CMS." A JS data grid
+  becomes queryable WordPress posts the owner can edit and extend — without losing the look.
+  When you weigh whether to build modeling for a given source shape, the question is: is the
+  content <em>data</em> wearing a presentation, or is it bespoke layout? Data → model it; bespoke
+  → carry the DOM.
+</div>
+
+<p>Forms convert here too: owned HTML forms become editable Jetpack forms (Lesson 14) on this
+path as well, with conditional plugin install.</p>
+
+<div class="quiz" data-answer="3">
+  <div class="q">Why does the owned-source path skip detection and live extraction entirely?</div>
+  <ul class="opts">
+    <li><button class="opt">Because local directories never contain any JavaScript to run</button></li>
+    <li><button class="opt">Because the block theme is scaffolded before any content loads</button></li>
+    <li><button class="opt">Because detection only works on the nine supported platforms</button></li>
+    <li><button class="opt">Because those stages exist to handle a site you don't control; a folder you own needs neither</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — fingerprinting, bot-defense, URL discovery, and remote media download are all about an uncontrolled remote site. An owned folder drops straight to reconstruction."
+    data-wrong="It's about ownership: detection/extraction exist to handle an uncontrolled remote site. A folder you own needs neither, so it goes straight to phase two.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the two local-path tools, the skill that turns JS data into a data model, and the
+  defining strategy that separates this path from the blocks path.
+  <details><summary>Check yourself</summary>
+  <code>liberate_ingest_local_site</code> + <code>liberate_convert_local_site</code>; the
+  <code>model-local-data</code> skill emits <code>data-model.json</code>. Defining strategy:
+  preserve the owned source DOM rather than re-emit from specs.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/mcp-server/handlers/convert-local-site.ts</span> and the
+  <span class="path">src/lib/replicate/local-site/</span> + <span class="path">local-theme/</span>
+  modules. The <code>data-liberation:model-local-data</code> skill documents the data-model shape.
+</div>
+
+<p class="ask">Want to see what a <code>data-model.json</code> looks like for a JS catalog grid?
+Ask and we'll sketch one.</p>
+
+<div class="lesson-nav">
+  <a href="0012-quality-gates.html">← Lesson 12</a>
+  <a href="0014-forms-to-jetpack.html">Lesson 14: Forms → Jetpack →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0014-forms-to-jetpack.html
+++ b/docs/how-it-works/lessons/0014-forms-to-jetpack.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>14 · Forms → Jetpack</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part V — Advanced</span>
+  <span>Lesson 14 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 14 · Advanced capability</div>
+<h1>Forms → Jetpack</h1>
+<p class="subtitle">A captured contact form is useless as a screenshot — it has to actually submit. The forms capability turns source forms into editable Jetpack forms, and it's a masterclass in why "emit the obvious block" is often wrong.</p>
+
+<h2>Capture, then emit</h2>
+<p>Forms are captured during the <code>extractFull</code> browser walk:
+<code>SectionSpec.forms?: SectionSpecForm[]</code>. Forms with zero recognizable fields are
+omitted entirely; <code>file</code>/<code>hidden</code> fields are skipped and flagged in
+provenance. On the <strong>blocks path</strong>, each form emits a
+<code>jetpack/contact-form</code> with a <code>jetpack/field-*</code> per field kind.</p>
+
+<h2>The submit-button trap (the whole lesson)</h2>
+<p>The obvious choice for the submit control would be <code>jetpack/button</code>. <strong>It's
+wrong, and silently so.</strong> The submit is emitted as a <code>core/button</code> with
+<code>tagName:"button"</code>, <code>type:"submit"</code>, and className
+<code>form-button-submit is-submit</code> — the current Jetpack form-editor grammar.</p>
+
+<div class="callout gotcha">
+  <span class="label">Why never <code>jetpack/button</code></span>
+  <code>jetpack/button</code> lives in the connection-gated extensions loader. On an
+  <em>unconnected</em> install it is <strong>unregistered</strong> and renders to nothing —
+  so the contact form falls back to a server-built button labeled "Submit," <em>losing the
+  captured label</em>. The captured label has to ride in the saved inner HTML of a
+  <code>core/button</code> instead. This is the kind of failure that looks fine in the editor
+  and breaks only on a real unconnected site.
+</div>
+
+<h2>The install dance</h2>
+<p>Emitting the markup isn't enough — the runtime has to support it. When any page's specs
+carry forms, the pipeline calls <code>ensurePlugin(sitePath,'jetpack')</code> <em>and</em>
+<code>wp jetpack module activate contact-form</code>. That second step is essential:</p>
+
+<div class="callout gotcha">
+  <span class="label">Unconnected installs start with all modules inactive</span>
+  An offline/unconnected Jetpack starts with <em>every</em> module off. Without explicitly
+  activating <code>contact-form</code>, you get an empty form wrapper — the markup is correct
+  but nothing renders. Both the plugin-ensure and the module-activate are idempotent and
+  non-fatal (markup still emits if they fail), tallied as <code>jetpackEnsured</code> /
+  <code>jetpackWarning</code> in handler output.
+</div>
+
+<h2>The hoist guard (a cross-feature interaction)</h2>
+<p><code>jetpack/*</code> blocks are <em>excluded</em> from variation hoisting (Lesson 16).
+Here's why it matters: Jetpack's <code>get_form_style()</code> regexes <code>is-style-(\S+)</code>
+off the contact-form className, and an unknown style makes <code>render_label()</code> return
+an empty string — <strong>labels vanish</strong>. So the hoister must never rewrite a
+<code>jetpack/*</code> className. This is a great example of how two independent capabilities
+can collide, and why the codebase encodes the guard explicitly.</p>
+
+<div class="quiz" data-answer="0">
+  <div class="q">Why is the form's submit emitted as <code>core/button</code> and never <code>jetpack/button</code>?</div>
+  <ul class="opts">
+    <li><button class="opt"><code>jetpack/button</code> is unregistered on unconnected installs and renders to nothing, losing the label</button></li>
+    <li><button class="opt"><code>core/button</code> is the only block that supports a submit type at all</button></li>
+    <li><button class="opt"><code>jetpack/button</code> cannot be placed inside a contact-form block</button></li>
+    <li><button class="opt"><code>core/button</code> is required for the variation hoister to skip it</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — jetpack/button is connection-gated and unregistered on unconnected installs; it renders to nothing and the captured label is lost. core/button carries the label in saved inner HTML."
+    data-wrong="The reason is the connection gate: jetpack/button is unregistered on unconnected installs and renders to nothing, losing the label. core/button preserves it.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the two install commands forms trigger and why each is necessary. Then state why
+  <code>jetpack/*</code> blocks must be excluded from variation hoisting.
+  <details><summary>Check yourself</summary>
+  <code>ensurePlugin(site,'jetpack')</code> (the plugin must exist) + <code>wp jetpack module
+  activate contact-form</code> (unconnected installs start all modules off → empty wrapper
+  otherwise). Hoisting a <code>jetpack/*</code> className breaks <code>get_form_style()</code>'s
+  <code>is-style-*</code> regex → labels render empty.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Find the form emit on the blocks path (search <code>jetpack/contact-form</code> in
+  <span class="path">src/lib/replicate/</span>), the <code>ensurePlugin</code> helper in
+  <span class="path">src/lib/preview/ensure-plugin.ts</span>, and the form capture in the
+  <code>extractFull</code> browser walk.
+</div>
+
+<p class="ask">Want the full <code>jetpack/field-*</code> kind mapping (text, email, select,
+textarea…) as a reference card? Ask.</p>
+
+<div class="lesson-nav">
+  <a href="0013-local-owned-source-path.html">← Lesson 13</a>
+  <a href="0015-design-foundations.html">Lesson 15: Design foundations →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0015-design-foundations.html
+++ b/docs/how-it-works/lessons/0015-design-foundations.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>15 · Design Foundations</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part V — Advanced</span>
+  <span>Lesson 15 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 15 · Advanced capability</div>
+<h1>Design Foundations</h1>
+<p class="subtitle">Per-page screenshots capture how the site looks. The design foundation captures how the site's design <em>thinks</em> — the small set of semantic color, type, and spacing roles a coherent theme is built from. This is the bridge from raw measurement to a real <code>theme.json</code>.</p>
+
+<h2>From aggregates to roles</h2>
+<p>The capture stage already produces site-wide raw aggregates (Lesson 5):
+<code>palette.json</code> (dominant colors ranked by usage), <code>typography.json</code> (font
+metrics per selector), <code>breakpoints.json</code> (the union of media-query widths). Those
+are <em>observations</em>, not decisions. The design foundation turns them into
+<strong>semantic roles</strong>: which color is "primary," which is "surface," which type ramp
+is the heading scale, what the spacing rhythm is.</p>
+
+<div class="flow">
+  <div class="flow-stage"><span class="flow-badge">①</span><div class="flow-body"><strong><code>liberate_design_foundation_scaffold</code></strong> — build a partial foundation from the aggregates (the raw, un-interpreted starting point).</div></div>
+  <div class="flow-stage"><span class="flow-badge">②</span><div class="flow-body"><strong><code>data-liberation:design-foundations</code> skill</strong> — interpret the scaffold + aggregate HTML/CSS + representative rendered HTML into a complete, semantic foundation with evidence trails.</div></div>
+  <div class="flow-stage"><span class="flow-badge">③</span><div class="flow-body"><strong><code>liberate_design_foundation_validate</code> / <code>_save</code></strong> — check it against the schema, then persist.</div></div>
+</div>
+
+<h2>Why this is a judgment step, by design</h2>
+<p>Naming roles is exactly the kind of work that sits on the far side of the judgment seam
+(Lesson 7). "Which of these twelve observed colors is the brand primary?" is not a
+deterministic function of the palette — it needs a model looking at the rendered site. So the
+deterministic tools <em>scaffold</em> and <em>validate</em>; the <em>skill</em> does the
+interpretation. That division is the tool-vs-skill litmus test in action.</p>
+
+<div class="callout key">
+  <span class="label">Evidence trails</span>
+  The foundation doesn't just assert "primary = #7a1f1f"; it carries the <em>evidence</em> for
+  each role — where in the captured data that decision came from. This is the same
+  degrade-loudly / make-it-legible value you saw in the diagnostics (Lesson 12): a design
+  decision you can audit beats a magic number.
+</div>
+
+<h2>What consumes it</h2>
+<p>The foundation feeds theme generation — it's the input that lets the reconstructed site share
+one coherent <code>theme.json</code>-level design language instead of a thousand inline styles.
+Call it after liberation, before theme generation.</p>
+
+<div class="callout decision">
+  <span class="label">The architectural value</span>
+  This is what separates "a faithful copy of each page" from "a real, editable theme." Without
+  a foundation, every page carries its own ad-hoc styling. With one, the site has semantic
+  tokens an owner can retune globally — change "primary" once, the whole site follows. When you
+  prioritize fidelity work, remember: foundations are what make the result <em>maintainable</em>,
+  not just accurate.
+</div>
+
+<div class="quiz" data-answer="2">
+  <div class="q">Why is building the design foundation split into deterministic tools plus a skill?</div>
+  <ul class="opts">
+    <li><button class="opt">Because the aggregates are too large to process in a single tool call</button></li>
+    <li><button class="opt">Because skills run faster than deterministic MCP tools on this data</button></li>
+    <li><button class="opt">Because naming semantic roles needs judgment, while scaffold/validate are deterministic</button></li>
+    <li><button class="opt">Because the schema can only be validated from inside a skill context</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — interpreting 'which color is primary' needs a model looking at the rendered site (judgment); scaffolding and schema-validation are deterministic. Classic tool-vs-skill split."
+    data-wrong="It's the judgment seam: role-naming needs a model (skill); scaffold + validate are deterministic (tools). Not about size, speed, or schema mechanics.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the three raw aggregates the foundation interprets, and state which steps are
+  deterministic tools vs the skill. Then say what the foundation makes possible that per-page
+  fidelity alone doesn't.
+  <details><summary>Check yourself</summary>
+  Aggregates: <code>palette.json</code>, <code>typography.json</code>, <code>breakpoints.json</code>.
+  Tools: scaffold + validate + save (deterministic); skill: the semantic interpretation.
+  Payoff: globally retunable semantic tokens → a maintainable theme, not just an accurate copy.
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/lib/design-foundation/</span> (schema + renderer) and the
+  <code>data-liberation:design-foundations</code> skill, which documents the full
+  scaffold → interpret → validate flow and the schema.
+</div>
+
+<p class="ask">Want to walk a real palette/typography aggregate and turn it into roles together?
+That's the fastest way to feel the judgment step. Ask.</p>
+
+<div class="lesson-nav">
+  <a href="0014-forms-to-jetpack.html">← Lesson 14</a>
+  <a href="0016-variation-hoisting.html">Lesson 16: Variation hoisting &amp; the block-fixer →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0016-variation-hoisting.html
+++ b/docs/how-it-works/lessons/0016-variation-hoisting.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>16 · Variation Hoisting &amp; the Block-Fixer</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part V — Advanced</span>
+  <span>Lesson 16 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 16 · Advanced capability</div>
+<h1>Variation Hoisting &amp; the Block-Fixer</h1>
+<p class="subtitle">Two passes that turn raw reconstructed markup into <em>theme-grade</em> markup: one canonicalizes every block so it survives WordPress, the other lifts repeated styling out of instances into reusable block-style variations. Together they're why the output looks hand-authored, not machine-spat.</p>
+
+<h2>The block-fixer: survive the save cycle</h2>
+<p>Reconstructed markup must round-trip through <code>@wordpress/blocks</code> — open it in the
+editor, save it, and the output must be unchanged. The <strong>block-fixer</strong> is the
+canonicalization pass that guarantees this. The practical constraint it imposes:</p>
+
+<div class="callout key">
+  <span class="label">Express sizing in terms the fixer preserves</span>
+  Reconstructed sizing has to be encoded in <em>core attributes and classNames</em>, not inline
+  <code>figure</code> styles — because the fixer (and the theme's <code>height:auto!important</code>
+  resets) will rewrite anything else. If you fight the canonicalizer with inline styles, your
+  dimensions vanish on the first save. Work <em>with</em> the grammar, not around it.
+</div>
+
+<p>The fixer is also defensive about unknown blocks: an unknown <code>jetpack/*</code> block
+passes through grammar-preserved via <code>core/missing</code> with its
+<code>originalContent</code> intact — so a block the fixer doesn't understand is never
+destroyed, just carried.</p>
+
+<h2>Variation hoisting: DRY out the styles</h2>
+<p>Reconstruction often emits the same styling constellation on many instances across the site.
+<strong>Variation hoisting</strong> finds recurring instance-style constellations — the
+threshold is <strong>≥ 3 site-wide, exact match</strong> — and lifts them into
+<code>&lt;theme&gt;/styles/blocks/lib-*.json</code> block-style variations, then strips the
+inline styling from the instances.</p>
+
+<table>
+  <thead><tr><th>Property</th><th>Behavior</th></tr></thead>
+  <tbody>
+    <tr><td>Slug derivation</td><td>Deterministic: block short-name + style groups present, numeric suffix on collision.</td></tr>
+    <tr><td>Failure mode</td><td>Fail-open — if the block-fixer sidecar is unavailable, hoisting is skipped with a warning (markup still ships).</td></tr>
+    <tr><td>Disable</td><td>The <code>variationHoist:false</code> tool option (MCP-only; no CLI flag).</td></tr>
+    <tr><td>Exclusion</td><td><code>jetpack/*</code> blocks are excluded (Lesson 14's label-vanishing trap).</td></tr>
+  </tbody>
+</table>
+
+<div class="callout decision">
+  <span class="label">Why hoisting is worth the complexity</span>
+  Hoisting is the difference between a theme with one editable "card" style used 30 times and a
+  theme with 30 copies of the same inline blob. The former is what a human designer would
+  build — retune the variation once, every instance updates. It's a maintainability multiplier,
+  the same value proposition as design foundations (Lesson 15), applied at the block level.
+</div>
+
+<div class="callout gotcha">
+  <span class="label">Exact-match, ≥ 3 — and why those bounds</span>
+  Hoisting only fires on <em>exact</em> style matches occurring <em>at least three times</em>.
+  That conservatism is deliberate: a near-match hoist would silently change appearance, and a
+  2-instance hoist rarely earns its abstraction. When you reason about extending it (fuzzy
+  matching, lower thresholds), the risk is always the same — hoisting that alters pixels.
+</div>
+
+<div class="quiz" data-answer="1">
+  <div class="q">Why must reconstructed sizing be expressed in core attributes/classNames rather than inline figure styles?</div>
+  <ul class="opts">
+    <li><button class="opt">Inline styles are slower for the browser to parse at render time</button></li>
+    <li><button class="opt">The block-fixer canonicalization (and theme resets) rewrite anything else, dropping the dimensions</button></li>
+    <li><button class="opt">WordPress forbids inline styles inside block markup entirely</button></li>
+    <li><button class="opt">Variation hoisting can only match styles written as inline blobs</button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — the fixer canonicalizes through @wordpress/blocks and theme height:auto resets fight inline figure styles; sizing survives only as core attrs/classNames."
+    data-wrong="It's about the canonicalizer: the block-fixer rewrites non-canonical markup on save, so inline figure-style sizing is lost. Encode it in core attrs/classNames.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  State what the block-fixer guarantees and the constraint it imposes. Then give the variation
+  hoisting threshold and what gets excluded (and why).
+  <details><summary>Check yourself</summary>
+  Fixer: markup survives a save cycle (round-trips through <code>@wordpress/blocks</code>);
+  constraint: sizing in core attrs/classNames, not inline figure styles. Hoist: ≥ 3 exact
+  site-wide matches → <code>styles/blocks/lib-*.json</code>; excludes <code>jetpack/*</code>
+  (className rewrite would empty form labels).
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Find the hoisting logic and the <code>variationHoist</code> option in
+  <span class="path">src/lib/replicate/</span> (search <code>lib-</code> /
+  <code>styles/blocks</code>), and the block-fixer smoke tests
+  (<span class="path">blockFixer.smoke.test.js</span>) for the canonicalization guarantees.
+</div>
+
+<p class="ask">Want to see a before/after of a hoisted constellation — instance markup vs the
+generated <code>lib-*.json</code> variation? Ask.</p>
+
+<div class="lesson-nav">
+  <a href="0015-design-foundations.html">← Lesson 15</a>
+  <a href="0017-shopify-graphql.html">Lesson 17: The Shopify GraphQL path →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/lessons/0017-shopify-graphql.html
+++ b/docs/how-it-works/lessons/0017-shopify-graphql.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>17 · The Shopify GraphQL Product Path</title>
+<link rel="stylesheet" href="../assets/course.css">
+<script src="../assets/quiz.js"></script>
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Part V — Advanced</span>
+  <span>Lesson 17 / 17</span>
+</div>
+
+<div class="wide">
+<div class="lesson-num">Lesson 17 · Advanced capability</div>
+<h1>The Shopify GraphQL Product Path</h1>
+<p class="subtitle">The richest single adapter behavior in the codebase — and the best worked example of the patterns from the whole course: a privileged fast path, a resumable cursor, idempotent output, and a graceful fallback. If you understand this, you understand how an adapter does something hard <em>well</em>.</p>
+
+<h2>Two ways to get products</h2>
+<p>The Shopify adapter has a public JSON path and a privileged GraphQL path. When an
+<code>adminToken</code> is present, <code>shopifyAdapter.extract</code> fetches products via the
+<strong>Shopify Admin GraphQL API</strong> (pinned to <code>2025-04</code>) instead of the
+public JSON API. The token unlocks completeness the public API can't give.</p>
+
+<table>
+  <thead><tr><th>Concern</th><th>How the GraphQL path handles it</th></tr></thead>
+  <tbody>
+    <tr><td>Hostname</td><td>Requires a <code>*.myshopify.com</code> host — throws if a custom storefront domain is derived and <code>shopDomain</code> wasn't passed explicitly.</td></tr>
+    <tr><td>Pagination</td><td>Walks <code>endCursor</code>, stored in <code>session.cursors['shopify:products:endCursor']</code> — <strong>resumable</strong> across crashes.</td></tr>
+    <tr><td>Idempotent output</td><td>Tracks already-emitted handles in <code>session.cursors['shopify:products:emittedHandles']</code> — no duplicate CSV rows across a resume.</td></tr>
+    <tr><td>Safety rails</td><td><code>MAX_PAGES = 10000</code> + a non-advancing-cursor guard to prevent infinite loops.</td></tr>
+    <tr><td>Fallback</td><td>Any GraphQL failure falls back to the JSON API + URL loop — the run never dies on a token/API problem.</td></tr>
+  </tbody>
+</table>
+
+<h2>Every course pattern, in one feature</h2>
+<p>This path is a microcosm. Spot them:</p>
+<ul>
+  <li><strong>Resume-state contract (L6):</strong> the cursor and emitted-handles live in
+  <code>session.cursors</code> — the same single-writer session store, so a crash mid-pagination
+  resumes exactly where it stopped <em>without</em> re-emitting products.</li>
+  <li><strong>Degrade loudly / fail safe (L12):</strong> GraphQL failure doesn't abort — it falls
+  back. But a <em>misconfiguration</em> (custom domain without <code>shopDomain</code>) throws
+  loudly rather than silently producing wrong data.</li>
+  <li><strong>Platform knowledge at the edge (L4):</strong> all of this lives in the Shopify
+  adapter; the shared extraction loop and product CSV writer know nothing about GraphQL.</li>
+</ul>
+
+<div class="callout key">
+  <span class="label">Idempotency is the hard part, not pagination</span>
+  Plenty of code paginates. The subtle achievement here is <em>idempotent</em> streaming output
+  across crashes: <code>products.jsonl</code> appends (L11), and the emitted-handles set ensures
+  a resumed run doesn't double-write a product it already streamed. Pagination cursor +
+  emitted-set together are what make "crash on page 40 of 200, resume cleanly" actually work.
+</div>
+
+<h2>Product modeling specifics worth carrying</h2>
+<ul>
+  <li>Variant weights normalize to <strong>kilograms</strong> regardless of source unit (<code>normalizeWeightToKg</code>).</li>
+  <li>Simple-product sale price uses <code>compareAtPrice &gt; price</code> semantics — when set, <code>compareAtPrice</code> → <code>regularPrice</code> and <code>price</code> → <code>salePrice</code>.</li>
+  <li>Output flows to <code>products.jsonl</code> → Woo CSV with first-class SEO + cost-of-goods meta columns (L11).</li>
+</ul>
+
+<div class="quiz" data-answer="3">
+  <div class="q">What makes the GraphQL product stream safe to resume after a mid-pagination crash?</div>
+  <ul class="opts">
+    <li><button class="opt">It re-fetches all pages from the start and overwrites the output file</button></li>
+    <li><button class="opt">It holds every product in memory until the final page completes</button></li>
+    <li><button class="opt">It falls back to the JSON API, which is inherently idempotent</button></li>
+    <li><button class="opt">The <code>endCursor</code> and emitted-handles set both persist in <code>session.cursors</code></button></li>
+  </ul>
+  <div class="feedback"
+    data-correct="Right — the resumable cursor says where to continue and the emitted-handles set prevents double-writing products already streamed. Both live in the session store."
+    data-wrong="Resume safety comes from persisting both the endCursor (where to continue) and the emitted-handles set (what's already written) in session.cursors — not re-fetching, buffering, or the fallback.">
+  </div>
+</div>
+
+<div class="recall">
+  <span class="label">Retrieval practice</span>
+  Name the two values stored in <code>session.cursors</code> and what each prevents. Then map
+  three earlier course concepts onto this one feature.
+  <details><summary>Check yourself</summary>
+  <code>endCursor</code> (where to resume pagination) + <code>emittedHandles</code> (prevents
+  duplicate output). Concepts: resume-state contract (L6, the session store), degrade-loudly /
+  fallback (L12), platform-knowledge-at-the-edge (L4). Plus idempotent append output (L11).
+  </details>
+</div>
+
+<div class="source-cite">
+  <span class="label">Primary source</span><br>
+  Read <span class="path">src/adapters/shopify/products.ts</span> and
+  <span class="path">…/shopify/extract.ts</span> for the GraphQL path, cursor handling, and the
+  JSON fallback. <code>normalizeWeightToKg</code> and the sale-price semantics live alongside.
+</div>
+
+<p class="ask">That completes the course — all seventeen lessons. Ask me to quiz you across the
+whole thing, drill any lesson, or tie it to a live architecture decision. As your teacher, I'm
+here for the follow-ups.</p>
+
+<div class="lesson-nav">
+  <a href="0016-variation-hoisting.html">← Lesson 16</a>
+  <a href="../index.html">Course home →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/reference/determinism-map.html
+++ b/docs/how-it-works/reference/determinism-map.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Determinism Map · Data Liberation</title>
+<link rel="stylesheet" href="../assets/course.css">
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Determinism Map</span>
+  <span>Reference</span>
+</div>
+
+<div class="wide">
+<h1>Determinism Map</h1>
+<p class="subtitle">Which steps a <em>function</em> decides, which steps a <em>model</em> decides — and the seam between them. This is the architecture's defining line (see <a href="../lessons/0007-the-tick-loop.html">Lesson 7</a>); read the pipeline as two materials joined at the <code>judgmentNeeded[]</code> boundary.</p>
+
+<div class="det-legend">
+  <span><span class="dbadge det">D</span> Deterministic — same inputs → same output; a pure function or a fixed algorithm.</span>
+  <span><span class="dbadge jud">J</span> Judgment — a model/agent looks and decides; lives in a skill, crosses the seam.</span>
+  <span><span class="dbadge mix">M</span> Mixed — deterministic mechanics wrapping (or gated by) a judgment call.</span>
+</div>
+
+<div class="callout key">
+  <span class="label">The rule that draws the line</span>
+  Everything a function <em>can</em> decide, a function decides. Everything that needs taste or
+  perception — "is this good enough?", "which color is the brand primary?", "which page
+  represents this cluster?" — is pushed across the <code>judgmentNeeded[]</code> seam into a
+  skill. The deterministic tools are the <strong>vocabulary</strong>; the skills are the
+  <strong>sentences</strong>. That is why there are ~38 small tools instead of a few big ones.
+</div>
+
+<h2>Phase 1 — Extraction</h2>
+<p>Extraction is <strong>almost entirely deterministic</strong>. It's measurement and capture:
+given a live page, produce the same artifacts. There is no taste involved in reading a sitemap
+or computing a section's bounding box.</p>
+<table>
+  <thead><tr><th></th><th>Stage / step</th><th>Why</th></tr></thead>
+  <tbody>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>detect</strong> — platform fingerprint</td><td>Fixed rules over headers/markers → a platform id.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>discover</strong> — URL inventory</td><td>Sitemap parse + nav walk; reproducible URL set.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>extract</strong> — content + products</td><td>Adapter parses HTML/JSON-LD/GraphQL into structured content.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>download-media</strong></td><td>Fetch + dedupe; SVG-risk scan + raster are rule-based.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>capture</strong> — SectionSpecs, selectors, landmark census, design aggregates</td><td><code>extractFull</code> measures the rendered DOM; the same page yields the same specs.</td></tr>
+  </tbody>
+</table>
+<p class="note">The one judgment that <em>precedes</em> extraction is the path-choice gate
+(blocks vs carry vs theme), made by the operator/agent right after discovery. It's not a
+pipeline stage — it's a decision that configures the pipeline. <span class="dbadge jud">J</span></p>
+
+<h2>The seam</h2>
+<p>Between capture and a finished site sits the streaming <code>tick-scheduler</code>, which
+emits <code>judgmentNeeded[]</code>. Everything <em>before</em> the seam is measurement;
+everything the seam hands out is taste. Reconstruction then alternates between the two.</p>
+
+<h2>Phase 2 — Reconstruction</h2>
+<p>Reconstruction is where the two materials interleave. The <em>emit</em> is deterministic;
+the <em>decisions about what to emit and whether it's good</em> are judgment.</p>
+<table>
+  <thead><tr><th></th><th>Stage / step</th><th>Why</th></tr></thead>
+  <tbody>
+    <tr><td><span class="dbadge jud">J</span></td><td><strong>cluster representative selection</strong></td><td>"Which page stands for this group?" — a model picks.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>blocks emit</strong> — <code>reconstructNativeAggregate</code></td><td>Section spec → native blocks; single-sourced engine core (Lesson 10).</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>carry build</strong> — sanitize + scope + island</td><td>HTML in → scoped <code>core/html</code> out; deterministic transform.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>block-fixer</strong> canonicalization</td><td>Runs markup through <code>@wordpress/blocks</code> — fixed grammar.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>variation hoisting</strong></td><td>Exact-match, ≥3 site-wide → <code>lib-*.json</code>. Pure algorithm.</td></tr>
+    <tr><td><span class="dbadge jud">J</span></td><td><strong>asset triage</strong> — keep / decoration</td><td>Vision model classifies decorative assets.</td></tr>
+    <tr><td><span class="dbadge mix">M</span></td><td><strong>design foundation</strong></td><td>Scaffold + validate are <span class="dbadge det">D</span>; naming semantic roles is <span class="dbadge jud">J</span> (the skill).</td></tr>
+    <tr><td><span class="dbadge jud">J</span></td><td><strong>parity judgment / refine</strong></td><td>"Is this section good enough? what to fix?" — the repair loop.</td></tr>
+    <tr><td><span class="dbadge jud">J</span></td><td><strong>data-model analysis</strong> (local path)</td><td>"Is this content data or bespoke layout?" — <code>model-local-data</code>.</td></tr>
+  </tbody>
+</table>
+
+<h2>Phase 2 — Output &amp; quality</h2>
+<table>
+  <thead><tr><th></th><th>Step</th><th>Why</th></tr></thead>
+  <tbody>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>WXR build · products CSV · media install · theme scaffold/install</strong></td><td>Assembly to fixed formats.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>comparison scoring</strong> (<code>comparison.json</code>)</td><td>Pixel/height math → a number; same images → same score.</td></tr>
+    <tr><td><span class="dbadge det">D</span></td><td><strong>region audit · fallback diagnostics · refine-report validation</strong></td><td>Reconcile/validate against captured truth — pure builders.</td></tr>
+    <tr><td><span class="dbadge mix">M</span></td><td><strong>accept / iterate decision</strong></td><td>The <em>gate</em> (≥ 0.995) is deterministic; deciding whether to keep iterating on a near-miss is judgment.</td></tr>
+  </tbody>
+</table>
+
+<div class="callout decision">
+  <span class="label">Why this map is the one to keep open</span>
+  Every "should this be a tool or a skill?" call is answered here. If a proposed step is
+  reproducible from its inputs, it's a deterministic tool in <code>src/lib</code>. If it needs a
+  model to look and decide, it's a skill step across the seam. The danger zone is an LLM call
+  buried inside a "deterministic" tool — it makes the pipeline unreproducible and untestable.
+  When you review, the <span class="dbadge mix">M</span> rows are where to look hardest: confirm
+  the deterministic and judgment halves are cleanly separated, not entangled.
+</div>
+
+<div class="lesson-nav">
+  <a href="pipeline-map.html">← Pipeline map</a>
+  <a href="../lessons/0007-the-tick-loop.html">Lesson 7: the judgment seam →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/reference/file-map.html
+++ b/docs/how-it-works/reference/file-map.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>File Map · Data Liberation</title>
+<link rel="stylesheet" href="../assets/course.css">
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · File Map</span>
+  <span>Reference · "where does this live?"</span>
+</div>
+
+<div class="wide">
+<h1>File Map</h1>
+<p class="subtitle">Where each concern lives in <code>src/</code>. The fastest way to answer "what does a change to X touch?" — the core question for any architecture call.</p>
+
+<h2>Entry &amp; dispatch</h2>
+<table>
+  <thead><tr><th>Path</th><th>Concern</th></tr></thead>
+  <tbody>
+    <tr><td><code>src/cli.ts</code></td><td>The single binary; dispatches watch / subcommands / <code>mcp</code>.</td></tr>
+    <tr><td><code>src/mcp-server.ts</code></td><td>~38 <code>liberate_*</code> tool registry + handler dispatch map + static adapter imports.</td></tr>
+    <tr><td><code>src/mcp-server/handlers/*</code></td><td>Thin MCP shells over <code>src/lib</code>.</td></tr>
+    <tr><td><code>src/ui/*</code></td><td>Thin CLI runners (Ink). <code>watch-runner.ts</code> = the streaming loop + <code>WatchPhase</code>.</td></tr>
+  </tbody>
+</table>
+
+<h2>Platform edge</h2>
+<table>
+  <tbody>
+    <tr><td><code>src/adapters/&lt;platform&gt;/</code></td><td>9 adapters: default, godaddy-wm, hostinger, hubspot, shopify, squarespace, webflow, weebly, wix.</td></tr>
+    <tr><td><code>src/adapters/resolve-adapter.ts</code></td><td>id → adapter, fallback to <code>default</code>.</td></tr>
+    <tr><td><code>src/adapters/page-actions.ts</code></td><td>The two opt-in seam types: <code>capture</code>, <code>blocks</code>.</td></tr>
+    <tr><td><code>src/adapters/shared.ts</code></td><td>Shared adapter machinery (the big one).</td></tr>
+  </tbody>
+</table>
+
+<h2>Shared core — <code>src/lib/</code></h2>
+<table>
+  <thead><tr><th>Subdir</th><th>Concern</th><th>Lesson</th></tr></thead>
+  <tbody>
+    <tr><td><code>detect-platform/</code></td><td>fingerprint → platform id</td><td>4</td></tr>
+    <tr><td><code>extraction/</code></td><td>sitemap parse, URL classify, request tuning</td><td>4</td></tr>
+    <tr><td><code>html-extract/</code></td><td>HTML → structured content</td><td>4</td></tr>
+    <tr><td><code>browser-kit/</code></td><td>browser/CDP launch + control</td><td>5</td></tr>
+    <tr><td><code>screenshot/</code></td><td>capture + design tokens (palette/typography/breakpoints)</td><td>5</td></tr>
+    <tr><td><code>resume-state/</code></td><td>ExtractionLog, ImportSession, MediaStubStore, faultpoint</td><td>6</td></tr>
+    <tr><td><code>streaming/</code></td><td>tick-scheduler, judgmentNeeded, compose/transform logs, media install</td><td>7</td></tr>
+    <tr><td><code>replicate/</code></td><td><strong>the replica engine</strong>: clustering, section specs, blocks/carry/theme reconstruct, parity, fonts, CSS scoping, variation hoisting</td><td>5,8–10,12,16</td></tr>
+    <tr><td><code>replicate/local-site/</code> · <code>local-theme/</code></td><td>owned-source ingest + convert → block theme</td><td>13</td></tr>
+    <tr><td><code>preview/</code></td><td>Studio site boot + theme/file install</td><td>7</td></tr>
+    <tr><td><code>design-foundation/</code></td><td>semantic design-foundation JSON + renderer</td><td>15</td></tr>
+    <tr><td><code>wxr/</code></td><td>WxrBuilder → output.wxr (WXR 1.2)</td><td>11</td></tr>
+    <tr><td><code>woo-csv/</code></td><td>WooProduct modeling → products.jsonl + CSV</td><td>11</td></tr>
+    <tr><td><code>media-fetch/</code></td><td>download/dedupe; svg-raster (SVG survival)</td><td>11</td></tr>
+    <tr><td><code>import/</code></td><td>WP REST/HTTP import client</td><td>1,11</td></tr>
+    <tr><td><code>wordpress/</code></td><td>WP helpers (block-policy, island markers)</td><td>8</td></tr>
+    <tr><td><code>qa/</code></td><td>content-differ (extraction loss)</td><td>12</td></tr>
+    <tr><td><code>verification/</code></td><td>post-extraction verify (stale CDN, failed pages, missing media)</td><td>12</td></tr>
+    <tr><td><code>probe/</code></td><td>CDP page probing for debugging</td><td>—</td></tr>
+    <tr><td><code>setup/</code></td><td>WP connection validation</td><td>—</td></tr>
+    <tr><td><code>features/</code></td><td>feature detection across a site</td><td>—</td></tr>
+    <tr><td><code>url/</code> · <code>paths.ts</code> · <code>concurrency.ts</code></td><td>URL utils · output base resolution · concurrency caps</td><td>—</td></tr>
+  </tbody>
+</table>
+
+<div class="callout key">
+  <span class="label">The one to internalize</span>
+  <code>src/lib/replicate/</code> is the largest, most consequential subsystem — almost all of
+  Phase 2 lives here. When an architecture question is about reconstruction fidelity, this is
+  the directory. The deterministic reconstruct core (<code>reconstructNativeAggregate</code>)
+  lives in <code>@automattic/blocks-engine</code>; DLA's <code>reconstructPagePattern</code>
+  delegates into it (Lesson 10).
+</div>
+
+<div class="lesson-nav">
+  <a href="pipeline-map.html">← Pipeline map</a>
+  <a href="../index.html">Course home →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/reference/glossary.html
+++ b/docs/how-it-works/reference/glossary.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Glossary · Data Liberation</title>
+<link rel="stylesheet" href="../assets/course.css">
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Glossary</span>
+  <span>Reference</span>
+</div>
+
+<div class="wide">
+<h1>Glossary</h1>
+<p class="subtitle">The canonical language for this course. Every lesson uses these terms — and so should you when you reason about the system out loud.</p>
+
+<h2>The shape of the system</h2>
+
+<p><strong>Data liberation</strong> — Extracting content and design out of a closed web
+platform (Wix, Shopify, Squarespace…) and producing something a self-hosted WordPress site
+can ingest. In this repo, the noun for the whole pipeline.
+<span class="small"><em>Avoid</em>: migration, scraping.</span></p>
+
+<p><strong>Extraction phase</strong> — The first half: turn a live URL into on-disk
+artifacts (<code>output.wxr</code>, <code>products.jsonl</code>, screenshots, design
+sidecars). Owned by <code>ImportSession</code> stages.
+<span class="small"><em>Avoid</em>: crawling, harvesting.</span></p>
+
+<p><strong>Reconstruction phase</strong> — The second half: turn those artifacts into a
+real, styled WordPress site (a block theme + imported content). Three paths exist.
+<span class="small"><em>Avoid</em>: rebuild, generation.</span></p>
+
+<p><strong>Adapter</strong> — A per-platform module under <code>src/adapters/&lt;platform&gt;/</code>
+exposing <code>detect</code> / <code>discover</code> / <code>extract</code>. The seam that
+lets one pipeline serve nine platforms.
+<span class="small"><em>Avoid</em>: plugin, driver, connector.</span></p>
+
+<p><strong>Resolve (an adapter)</strong> — Picking the adapter for a detected platform via
+<code>resolveAdapter</code>; <code>unknown</code> or unregistered platforms fall back to the
+<code>default</code> adapter. Detection and resolution are separate steps.</p>
+
+<h2>The three reconstruct paths</h2>
+
+<p><strong>Blocks path</strong> — Reconstruct each page into <em>native Gutenberg block
+markup</em> from its captured section specs. Most "WordPress-native," editable; tool =
+<code>liberate_reconstruct_pages</code>.
+<span class="small"><em>Avoid</em>: native path, block reconstruction (loosely).</span></p>
+
+<p><strong>Carry path</strong> — Carry sanitized source HTML + scoped CSS <em>verbatim</em>
+into <code>core/html</code> islands; highest pixel fidelity, least native; tool =
+<code>liberate_reconstruct_pages_carry</code>.
+<span class="small"><em>Avoid</em>: passthrough, clone.</span></p>
+
+<p><strong>Theme / local path</strong> — Convert an <em>owned local static-site directory</em>
+(no network extraction) into a live block theme; tool = <code>liberate_convert_local_site</code>.
+<span class="small"><em>Avoid</em>: just "local" without qualifier.</span></p>
+
+<h2>Capture & specs</h2>
+
+<p><strong>SectionSpec</strong> — A captured, computed-style description of one visual
+section of a page (with a CSS <code>selector</code> that re-locates it in the source DOM).
+The unit blocks-path reconstruction consumes. Cached in <code>sections/&lt;slug&gt;.json</code>.</p>
+
+<p><strong>Landmark census</strong> — The per-page tally of <code>main</code>/<code>nav</code>/<code>header</code>/<code>footer</code>
+captured in the same browser walk as the section specs; consumed by the region audit to
+catch dropped chrome.</p>
+
+<p><strong>Carried HTML / island</strong> — Source HTML wrapped in a <code>core/html</code>
+block. A <strong>coverage island</strong> is one the pipeline emitted as a fallback (marked
+<code>lib-coverage-island</code>). Islands convert to <strong>editable-html</strong>
+(<code>dla/editable-html</code>) by default — visible, styled, editable, byte-identical save.</p>
+
+<h2>Resume-state stores</h2>
+
+<p><strong>Resume-state file</strong> — A crash-safe, capture-once on-disk store that makes a
+stage idempotent. Five of them: <code>extraction-log.jsonl</code>, <code>session.json</code>,
+<code>media-stubs.json</code>, <code>products.jsonl</code>, <code>sections/&lt;slug&gt;.json</code>.</p>
+
+<p><strong>Faultpoint</strong> — An injectable crash marker used to test that resume-state
+recovers correctly mid-pipeline.</p>
+
+<h2>The agent-in-the-loop</h2>
+
+<p><strong>Watch loop</strong> — The default streaming run (<code>data-liberation &lt;url&gt;</code>):
+extract per-URL while a Studio preview boots, driven by <code>watch-runner.ts</code> through
+<code>WatchPhase</code> states.</p>
+
+<p><strong>Tick / judgment seam</strong> — The boundary where the deterministic
+<code>tick-scheduler</code> emits <code>judgmentNeeded[]</code> and hands reasoning to the
+agent/skill. The line between "code decides" and "model decides."</p>
+
+<h2>Output & quality</h2>
+
+<p><strong>WXR</strong> — WordPress eXtended RSS, the XML export format DLA produces (targets
+WXR 1.2). Built/appended by <code>WxrBuilder</code> into <code>output.wxr</code>.</p>
+
+<p><strong>Block-fixer</strong> — The canonicalization pass that runs reconstructed markup
+through <code>@wordpress/blocks</code> so it survives a save cycle. Reconstructed sizing must
+be expressed in terms it preserves.</p>
+
+<p><strong>Parity gate</strong> — A visual-comparison threshold (<code>PARITY_GATE_SCORE = 0.995</code>)
+that decides whether a rebuilt page matches the source closely enough.</p>
+
+<p><strong>Design foundation</strong> — A semantic JSON of color/typography/spacing roles
+distilled from the captured design sidecars (<code>palette.json</code>, <code>typography.json</code>,
+<code>breakpoints.json</code>), consumed by theme generation. Roles are <em>decisions</em>; the
+sidecars are <em>observations</em>.</p>
+
+<h2>Advanced capabilities</h2>
+
+<p><strong>Variation hoisting</strong> — Lifting recurring instance-style constellations (≥ 3
+exact site-wide matches) into reusable block-style variations at
+<code>styles/blocks/lib-*.json</code>, stripping the inline styling from instances. Fail-open;
+excludes <code>jetpack/*</code>.</p>
+
+<p><strong>ensurePlugin / module-activate</strong> — The conditional install dance: a capability
+(SVG, forms) triggers a one-time idempotent plugin ensure, and for Jetpack forms also
+<code>wp jetpack module activate contact-form</code> (unconnected installs start with all
+modules off).</p>
+
+<p><strong>Owned-source path</strong> — The local reconstruct path: an owned directory of
+HTML/CSS/JS converted to a block theme with no detection or network extraction, preserving the
+source DOM. See <em>Theme / local path</em> above. <code>data-model.json</code> turns JS-rendered
+data into real WordPress posts + query loops.</p>
+
+<p><strong>GraphQL product path</strong> — Shopify's privileged extraction (with an
+<code>adminToken</code>): Admin GraphQL API, resumable <code>endCursor</code>, idempotent
+<code>emittedHandles</code>, JSON-API fallback on any failure.</p>
+
+<div class="lesson-nav">
+  <a href="../index.html">← Course home</a>
+  <a href="determinism-map.html">Determinism map →</a>
+</div>
+</div>
+</body>
+</html>

--- a/docs/how-it-works/reference/pipeline-map.html
+++ b/docs/how-it-works/reference/pipeline-map.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pipeline Map · Data Liberation</title>
+<link rel="stylesheet" href="../assets/course.css">
+</head>
+<body>
+<div class="masthead">
+  <span><a href="../index.html">Data Liberation</a> · Pipeline Map</span>
+  <span>Reference · prints on one page</span>
+</div>
+
+<div class="wide">
+<h1>Pipeline Map</h1>
+<p class="subtitle">The whole flow on one page. Pin it up.</p>
+
+<div class="det-legend">
+  <span><span class="dbadge det">D</span> deterministic</span>
+  <span><span class="dbadge jud">J</span> judgment (agent/skill)</span>
+  <span><span class="dbadge mix">M</span> mixed</span>
+  <span>— full rationale on the <a href="determinism-map.html">Determinism Map →</a></span>
+</div>
+
+<h2>Phase 1 — Extraction (persisted as <code>ImportStage</code>)</h2>
+<p class="small">Extraction is measurement — almost entirely <span class="dbadge det">D</span>.</p>
+<pre><code>initial → discovering → extracting → downloading-media → screenshotting → finalizing → complete
+                                                                              (error from any stage)</code></pre>
+<div class="flow">
+  <div class="flow-stage"><span class="flow-badge">detect</span><div class="flow-body"><span class="dbadge det">D</span> platform fingerprint → id <span class="artifact">(adapter recorded in session.json)</span></div></div>
+  <div class="flow-stage"><span class="flow-badge">disc.</span><div class="flow-body"><span class="dbadge det">D</span> adapter.discover → URL inventory, nav, archetypes</div></div>
+  <div class="flow-stage"><span class="flow-badge">extract</span><div class="flow-body"><span class="dbadge det">D</span> adapter.extract per-URL → <span class="artifact">output.wxr · extraction-log.jsonl · products.jsonl · media-stubs.json</span></div></div>
+  <div class="flow-stage"><span class="flow-badge">media</span><div class="flow-body"><span class="dbadge det">D</span> media-fetch download+dedupe (SVG→safe-svg/raster) → <span class="artifact">media files</span></div></div>
+  <div class="flow-stage"><span class="flow-badge">shots</span><div class="flow-body"><span class="dbadge det">D</span> extractFull on settled page → <span class="artifact">screenshots/ · html/ · sections/&lt;slug&gt;.json · palette/typography/breakpoints.json · manifest.json</span></div></div>
+</div>
+<p class="note"><span class="dbadge jud">J</span> The path-choice gate (blocks vs carry vs theme) is decided by the operator/agent right after discovery — a decision that <em>configures</em> the pipeline, not a stage in it.</p>
+
+<h2>Streaming orchestration · the seam (live, <code>WatchPhase</code> — not persisted)</h2>
+<pre><code>resolving-agent → resetting → detecting → discovering → extracting
+   → starting-preview → tick-drain → invoking-judgments → done   (+ error)
+                              │
+                              └─ tick-scheduler emits judgmentNeeded[]  ← the agent/skill seam</code></pre>
+<p class="small"><span class="dbadge jud">J</span> <code>judgmentNeeded[]</code> is the line where deterministic code hands reasoning to the agent (cluster reps, parity, compose).</p>
+
+<h2>Phase 2 — Reconstruction (three paths)</h2>
+<p class="small">The <em>emit</em> is <span class="dbadge det">D</span>; <em>what to emit &amp; whether it's good</em> is <span class="dbadge jud">J</span>.</p>
+<table>
+  <thead><tr><th>Path</th><th>Tool</th><th>Output</th></tr></thead>
+  <tbody>
+    <tr><td><span class="dbadge det">D</span> Blocks</td><td><code>liberate_reconstruct_pages</code></td><td>native Gutenberg blocks from section specs</td></tr>
+    <tr><td><span class="dbadge det">D</span> Carry</td><td><code>liberate_reconstruct_pages_carry</code></td><td>verbatim HTML + scoped CSS in core/html islands, <code>&lt;slug&gt;-carry</code> theme</td></tr>
+    <tr><td><span class="dbadge det">D</span> Theme/local</td><td><code>liberate_convert_local_site</code></td><td>owned local dir → live block theme (no network)</td></tr>
+  </tbody>
+</table>
+<p>Theme shell under all paths (<span class="dbadge det">D</span>): <code>liberate_theme_scaffold</code> → <code>liberate_install_theme</code>.
+Native core delegates to engine <code>reconstructNativeAggregate</code> (single-sourced in <code>@automattic/blocks-engine</code>).</p>
+<table>
+  <thead><tr><th></th><th>Reconstruction judgment steps</th></tr></thead>
+  <tbody>
+    <tr><td><span class="dbadge jud">J</span></td><td>cluster representative selection · parity / refine · asset triage (vision) · data-model analysis (local)</td></tr>
+    <tr><td><span class="dbadge mix">M</span></td><td>design foundation (scaffold/validate = D, role-naming = J)</td></tr>
+  </tbody>
+</table>
+
+<h2>Resume-state stores (capture-once)</h2>
+<table>
+  <thead><tr><th>File</th><th>Owns</th><th>Crash-safety</th></tr></thead>
+  <tbody>
+    <tr><td><code>extraction-log.jsonl</code></td><td>URL dedupe (source of truth)</td><td>append-only</td></tr>
+    <tr><td><code>session.json</code></td><td>stage, opts, counts, cursors</td><td>atomic rename (+ <code>.corrupt.&lt;ts&gt;</code>)</td></tr>
+    <tr><td><code>media-stubs.json</code></td><td>asset status + wpPostId</td><td>status + retry cap (3)</td></tr>
+    <tr><td><code>products.jsonl</code></td><td>Woo products (one/line)</td><td>append (resume:true)</td></tr>
+    <tr><td><code>sections/&lt;slug&gt;.json</code></td><td>SectionSpec cache + census</td><td>atomic, independent (no lockfile)</td></tr>
+  </tbody>
+</table>
+
+<h2>Quality signals</h2>
+<table>
+  <thead><tr><th>Kind</th><th>Artifact / constant</th><th>Question</th></tr></thead>
+  <tbody>
+    <tr><td>Gate</td><td><code>PARITY_GATE_SCORE = 0.995</code></td><td>does it match the source?</td></tr>
+    <tr><td>Gate</td><td><code>validate_artifacts</code> / block-parser oracle</td><td>does the markup parse?</td></tr>
+    <tr><td>Diag</td><td><code>comparison.json</code> v2 (height, magenta=content-gap, ratio>0.02)</td><td>where's the visual gap?</td></tr>
+    <tr><td>Diag</td><td><code>fallback-diagnostics.json</code></td><td>why did this section fall back?</td></tr>
+    <tr><td>Diag</td><td><code>region-audit.json</code></td><td>did every landmark survive?</td></tr>
+    <tr><td>Diag</td><td><code>asset-triage.json</code></td><td>keep or decoration?</td></tr>
+    <tr><td>Loss</td><td><code>liberate_qa</code> / content-differ</td><td>what didn't make it in? (loss, not hallucination)</td></tr>
+  </tbody>
+</table>
+
+<p>Output base: <code>~/Studio/_liberations/&lt;host&gt;</code> (resolve via <code>liberate_paths</code>).</p>
+
+<div class="lesson-nav">
+  <a href="determinism-map.html">← Determinism map</a>
+  <a href="file-map.html">File map →</a>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a self-contained interactive course at `docs/how-it-works/` that explains the whole `data-liberation-agent` pipeline as a navigable map — **17 lessons** (conceptual scaffold → code drill) plus a **glossary**, **pipeline map**, **determinism map**, and **file map**.

It's a companion to the existing prose docs (`docs/how-it-works.md`, `docs/flow.md`), aimed at onboarding and at reasoning about architecture decisions.

## What's inside

- **Part I — Scaffold:** the two-phase extract→reconstruct spine; three entry points (CLI watch / subcommands / MCP); the blocks-vs-carry-vs-local fork.
- **Part II — Extraction:** the adapter pattern + its two opt-in seams; capture & the `SectionSpec`; the five resume-state stores.
- **Part III — Reconstruction:** the tick/judgment seam (agent-in-the-loop); blocks reconstruction + diagnostics; the carry path; the shared `@automattic/blocks-engine` seam.
- **Part IV — Output & Quality:** WXR / Woo CSV / media output; quality gates vs warning diagnostics.
- **Part V — Advanced:** local/owned-source path, Forms→Jetpack, design foundations, variation hoisting & the block-fixer, the Shopify GraphQL product path.
- **Reference shelf:** glossary, pipeline map, determinism map (every stage badged deterministic / judgment / mixed), file map.

Each lesson cites real source files by repo-relative path and ends with a retrieval-practice prompt. All pages share one stylesheet + a small quiz widget under `assets/`.

## How to view

- **Rendered, zero setup:** the links in [`docs/how-it-works/README.md`](docs/how-it-works/README.md) route through `htmlpreview.github.io` (this repo is public). They resolve once this lands on `main`.
- **Full interactivity (quizzes) / offline:** clone and open `docs/how-it-works/index.html` in a browser.
- GitHub itself shows `.html` as source — hence the htmlpreview links and the Markdown README as the browsable entry point.

## Notes

- Docs-only; no source or behavior changes.
- htmlpreview renders HTML+CSS reliably; the quiz JavaScript may not run under it (loads JS from raw GitHub). If we want guaranteed interactivity from a URL, enabling **GitHub Pages** for `docs/how-it-works/` is the follow-up.
