### PR TITLE
Adopt blocks-engine 0.2.2 with structured strategy on the blocks path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@automattic/blocks-engine": "^0.1.0",
+        "@automattic/blocks-engine": "^0.2.2",
         "@modelcontextprotocol/sdk": "^1.27.0",
         "@wordpress/block-serialization-default-parser": "^5.47.0",
         "acorn": "^8.17.0",
@@ -58,90 +58,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@ariakit/components": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.3.tgz",
-      "integrity": "sha512-l22VB1g0Dz6zrKyDjykg8uXemUGolaeJjcLKf9XY5iSxzuU0PZTLSmRfJFq4pjTHsRroL4HM96f6J0Pivu2oOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/store": "0.1.3",
-        "@ariakit/utils": "0.1.3"
-      }
-    },
-    "node_modules/@ariakit/react-components": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.2.0.tgz",
-      "integrity": "sha512-hoAwGSh5xQ0va4oWSTOmoNIIDS+90eVzg6XceCC9WMyhRn1I1YVluxCqltZ9UY+6vzu7PpJDvC4g5N2rmCh6og==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/components": "0.1.3",
-        "@ariakit/react-store": "0.1.3",
-        "@ariakit/react-utils": "0.1.3",
-        "@ariakit/store": "0.1.3",
-        "@ariakit/utils": "0.1.3",
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@ariakit/react-store": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.3.tgz",
-      "integrity": "sha512-x8kjHcDoEkTX5bu3qkSfnvRCZuqXtjQZ1seohIWq8NPAfB0qe6q3GlGwCVCXw62Tlcf44SwxpuRQYQyj0/eurw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/react-utils": "0.1.3",
-        "@ariakit/store": "0.1.3",
-        "@ariakit/utils": "0.1.3",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@ariakit/react-utils": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.3.tgz",
-      "integrity": "sha512-eaqLU+7lknPWzcWK7CYQw9Mu52c6If3jc8wm08Fw/hobOCeeG97Z865PQeNYQMK7BYqb01ByVNaIPEWYwcPkfw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/store": "0.1.3",
-        "@ariakit/utils": "0.1.3"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@ariakit/store": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.3.tgz",
-      "integrity": "sha512-EAKGIUbHGKH9Kx53ae17+5l/b/z1VUKqiyHcV675AKn1ed1qsLEHX2KovFf+eHLtGBgINSd0NXv11LIe3x/uFA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/utils": "0.1.3"
-      }
-    },
-    "node_modules/@ariakit/utils": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.3.tgz",
-      "integrity": "sha512-OMdM631rIiDLYr1nnd1vtGyLvlYt08APMa2TJACA8Myn80PF+XtH9ZLBXTVUuUnlrYVyY2duX+EOkg6z9/NeCA==",
-      "license": "MIT"
-    },
-    "node_modules/@arraypress/waveform-player": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@arraypress/waveform-player/-/waveform-player-1.2.1.tgz",
-      "integrity": "sha512-PsgOZStUN+1GnY0tujbwk2PYE3HMT/Vl3wEvunqH16hIJWzisf8GEngy5EbswTAjQ1aV3Tk4XBkAskc8eslY1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/arraypress"
-      }
-    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -188,17 +104,11 @@
       "license": "MIT"
     },
     "node_modules/@automattic/blocks-engine": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@automattic/blocks-engine/-/blocks-engine-0.1.0.tgz",
-      "integrity": "sha512-3eAknzPA1DUEKPfBd1U9NMZ7OsHerrSjIXY9rE/6khDMeUKk7AYhgdDkD8Oemr0ZOX+qe6aFe+GLE8lNBNbcew==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@automattic/blocks-engine/-/blocks-engine-0.2.2.tgz",
+      "integrity": "sha512-1d2C7QAhDJfaDlrDdkECE7bUkPttYUHmXizwgCPxZwVQhm8P5MTM99pvWYjh2+NsDRkQK7ZA1xHDNY5iEMW0gQ==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@wordpress/block-editor": "15.15.0",
-        "@wordpress/block-library": "9.42.0",
-        "@wordpress/block-serialization-default-parser": "5.47.0",
-        "@wordpress/blocks": "15.15.0",
-        "@wordpress/data": "10.42.0",
-        "@wordpress/hooks": "4.42.0",
         "cheerio": "1.2.0",
         "domhandler": "5.0.3",
         "jsdom": "29.0.1"
@@ -208,23 +118,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@ariakit/react": {
-      "version": "0.4.30",
-      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.30.tgz",
-      "integrity": "sha512-7QAS4uAoSp1Avekp1ve8xLRPm4E7wLIQFfYM08cHfgMfBBGQGkxrXFqP3QmqEMTUa99H4ZHK9unL05+752cBhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@ariakit/react-components": "0.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ariakit"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@automattic/blocks-engine/node_modules/@asamuzakjp/css-color": {
@@ -353,5310 +246,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "extraneous": true,
-      "license": "MIT",
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@floating-ui/react-dom": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@react-spring/animated": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
-      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@react-spring/core": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
-      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-spring/donate"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@react-spring/shared": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
-      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/rafz": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@react-spring/web": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
-      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/core": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/block-editor": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.15.0.tgz",
-      "integrity": "sha512-2IBkb17gOWW0mvZQewzB/0g+ANTrg00/U7AnAYmx/ldU6EP9dEINcfRCiTBRA4Z7d4oaQW9cpFdKVI255U1Syg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.42.0",
-        "@wordpress/api-fetch": "^7.42.0",
-        "@wordpress/base-styles": "^6.18.0",
-        "@wordpress/blob": "^4.42.0",
-        "@wordpress/block-serialization-default-parser": "^5.42.0",
-        "@wordpress/blocks": "^15.15.0",
-        "@wordpress/commands": "^1.42.0",
-        "@wordpress/components": "^32.4.0",
-        "@wordpress/compose": "^7.42.0",
-        "@wordpress/data": "^10.42.0",
-        "@wordpress/dataviews": "^13.1.0",
-        "@wordpress/date": "^5.42.0",
-        "@wordpress/deprecated": "^4.42.0",
-        "@wordpress/dom": "^4.42.0",
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/escape-html": "^3.42.0",
-        "@wordpress/global-styles-engine": "^1.9.0",
-        "@wordpress/hooks": "^4.42.0",
-        "@wordpress/html-entities": "^4.42.0",
-        "@wordpress/i18n": "^6.15.0",
-        "@wordpress/icons": "^12.0.0",
-        "@wordpress/image-cropper": "^1.6.0",
-        "@wordpress/interactivity": "^6.42.0",
-        "@wordpress/is-shallow-equal": "^5.42.0",
-        "@wordpress/keyboard-shortcuts": "^5.42.0",
-        "@wordpress/keycodes": "^4.42.0",
-        "@wordpress/notices": "^5.42.0",
-        "@wordpress/preferences": "^4.42.0",
-        "@wordpress/priority-queue": "^3.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "@wordpress/rich-text": "^7.42.0",
-        "@wordpress/style-engine": "^2.42.0",
-        "@wordpress/token-list": "^3.42.0",
-        "@wordpress/upload-media": "^0.27.0",
-        "@wordpress/url": "^4.42.0",
-        "@wordpress/warning": "^3.42.0",
-        "@wordpress/wordcount": "^4.42.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "deepmerge": "^4.3.0",
-        "diff": "^4.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "parsel-js": "^1.1.2",
-        "postcss": "^8.4.21",
-        "postcss-prefix-selector": "^1.16.0",
-        "postcss-urlrebase": "^1.4.0",
-        "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^5.0.6",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/block-library": {
-      "version": "9.42.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-9.42.0.tgz",
-      "integrity": "sha512-dEKby/j3MSEE4KNGR2IlSC3u4QzGyCHEhkQLYR3oD2aCCFt11jOwONsncJG2qsr94ujiK8gZTy9JDNW5Dj0s4g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@arraypress/waveform-player": "1.2.1",
-        "@wordpress/a11y": "^4.42.0",
-        "@wordpress/api-fetch": "^7.42.0",
-        "@wordpress/autop": "^4.42.0",
-        "@wordpress/base-styles": "^6.18.0",
-        "@wordpress/blob": "^4.42.0",
-        "@wordpress/block-editor": "^15.15.0",
-        "@wordpress/blocks": "^15.15.0",
-        "@wordpress/components": "^32.4.0",
-        "@wordpress/compose": "^7.42.0",
-        "@wordpress/core-data": "^7.42.0",
-        "@wordpress/data": "^10.42.0",
-        "@wordpress/date": "^5.42.0",
-        "@wordpress/deprecated": "^4.42.0",
-        "@wordpress/dom": "^4.42.0",
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/escape-html": "^3.42.0",
-        "@wordpress/hooks": "^4.42.0",
-        "@wordpress/html-entities": "^4.42.0",
-        "@wordpress/i18n": "^6.15.0",
-        "@wordpress/icons": "^12.0.0",
-        "@wordpress/interactivity": "^6.42.0",
-        "@wordpress/interactivity-router": "^2.42.0",
-        "@wordpress/keyboard-shortcuts": "^5.42.0",
-        "@wordpress/keycodes": "^4.42.0",
-        "@wordpress/latex-to-mathml": "^1.10.0",
-        "@wordpress/notices": "^5.42.0",
-        "@wordpress/patterns": "^2.42.0",
-        "@wordpress/primitives": "^4.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "@wordpress/reusable-blocks": "^5.42.0",
-        "@wordpress/rich-text": "^7.42.0",
-        "@wordpress/server-side-render": "^6.18.0",
-        "@wordpress/upload-media": "^0.27.0",
-        "@wordpress/url": "^4.42.0",
-        "@wordpress/viewport": "^6.42.0",
-        "@wordpress/wordcount": "^4.42.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "fast-average-color": "^9.1.1",
-        "fast-deep-equal": "^3.1.3",
-        "html-react-parser": "5.2.11",
-        "memize": "^2.1.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.47.0.tgz",
-      "integrity": "sha512-xRZ026shHpau7VWDXLGBvfaU6s/yC1efzOGKiDGZ0fbTbTQcr09ma7ToaDyCiHIfMoSu9lMYnriLLOEKVht8Sg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/blocks": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.15.0.tgz",
-      "integrity": "sha512-xUlxCqIV8UuH5MjtPQBnxEwvhe2CCrZ+WqGJ+ffLxQQGHbe513zXl8sr79FdE2noec4Bj8VdOp1oH8zlESQEUA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.42.0",
-        "@wordpress/blob": "^4.42.0",
-        "@wordpress/block-serialization-default-parser": "^5.42.0",
-        "@wordpress/data": "^10.42.0",
-        "@wordpress/deprecated": "^4.42.0",
-        "@wordpress/dom": "^4.42.0",
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/hooks": "^4.42.0",
-        "@wordpress/html-entities": "^4.42.0",
-        "@wordpress/i18n": "^6.15.0",
-        "@wordpress/is-shallow-equal": "^5.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "@wordpress/rich-text": "^7.42.0",
-        "@wordpress/shortcode": "^4.42.0",
-        "@wordpress/warning": "^3.42.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.7.0",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "showdown": "^1.9.1",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.49.0.tgz",
-      "integrity": "sha512-lEaISg3cpqn6AgPn/WBZSPsiwKZoCU2xfMQbvDtzGldN70Er40Frgf35xnFk/thlXUxL/L9dIB7a7wkZcOQ68w==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/preferences": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "clsx": "^2.1.1",
-        "cmdk": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/commands/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/components": {
-      "version": "32.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.6.0.tgz",
-      "integrity": "sha512-MpOr0mGTkKDRjxK5LKm86Uoj9p9Z6KkrvhkNVi5zVKCftyHVMK+tun7wL2Qn/JZVLbxZpB1kW5sJ5aMf3T2ToA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.22",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "2.0.8",
-        "@types/gradient-parser": "1.1.0",
-        "@types/highlight-words-core": "1.2.1",
-        "@types/react": "^18.3.27",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.44.0",
-        "@wordpress/base-styles": "^6.20.0",
-        "@wordpress/compose": "^7.44.0",
-        "@wordpress/date": "^5.44.0",
-        "@wordpress/deprecated": "^4.44.0",
-        "@wordpress/dom": "^4.44.0",
-        "@wordpress/element": "^6.44.0",
-        "@wordpress/escape-html": "^3.44.0",
-        "@wordpress/hooks": "^4.44.0",
-        "@wordpress/html-entities": "^4.44.0",
-        "@wordpress/i18n": "^6.17.0",
-        "@wordpress/icons": "^12.2.0",
-        "@wordpress/is-shallow-equal": "^5.44.0",
-        "@wordpress/keycodes": "^4.44.0",
-        "@wordpress/primitives": "^4.44.0",
-        "@wordpress/private-apis": "^1.44.0",
-        "@wordpress/rich-text": "^7.44.0",
-        "@wordpress/warning": "^3.44.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "csstype": "^3.2.3",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/components/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/compose": {
-      "version": "7.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
-      "integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.46.0",
-        "@wordpress/dom": "^4.46.0",
-        "@wordpress/element": "^6.46.0",
-        "@wordpress/is-shallow-equal": "^5.46.0",
-        "@wordpress/keycodes": "^4.46.0",
-        "@wordpress/priority-queue": "^3.46.0",
-        "@wordpress/undo-manager": "^1.46.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.49.0.tgz",
-      "integrity": "sha512-kKDpZ196QEvcjK5PUz0EwxQXBDaXCFHHCpl/ZBIOV8hdBR6KBSn632J8RMlBlLFnOzzunnHrYPE9Q0LDeygYuA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/block-editor": "^15.22.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/sync": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "equivalent-key-map": "^0.2.2",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/block-editor": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.22.0.tgz",
-      "integrity": "sha512-Brbe0tyL3ekEku6ljbZCTfMFyL3WmIiS55YCsU3zp4LxO9GdY754mzpVkS9/Rzc/pyBSvQJ1mGqSLEOkEMJrRw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/commands": "^1.49.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/global-styles-engine": "^1.16.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/image-cropper": "^1.13.0",
-        "@wordpress/interactivity": "^6.49.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/notices": "^5.49.0",
-        "@wordpress/preferences": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-engine": "^2.49.0",
-        "@wordpress/token-list": "^3.49.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/upload-media": "^0.34.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "@wordpress/wordcount": "^4.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "deepmerge": "^4.3.1",
-        "diff": "^8.0.3",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "parsel-js": "^1.1.2",
-        "postcss": "^8.4.38",
-        "postcss-prefix-selector": "^1.16.0",
-        "postcss-urlrebase": "^1.4.0",
-        "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^5.4.2",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.49.0.tgz",
-      "integrity": "sha512-Zn2+vJN82kHiuJ8Fd7m1gllM9iqhGPU21QBczS0ac/ixuqd1W4H0ho4JKIiiTr1YLrbZ/QGJccWU4Te84vXbqw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/blocks": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.22.0.tgz",
-      "integrity": "sha512-+L0+NOuu4ZErYb8pA2tAiWLWuWdG+UU8RhWPXJ4RccQPtjuOvPZlvwgECSY5YxmduImsRefDrIwlBzqqqA17CA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.49.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/shortcode": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.9.3",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "marked": "^18.0.3",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/dataviews": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.0.0.tgz",
-      "integrity": "sha512-d+0tCa0xWP1QXbEdXesp0wlthRmSAXtp1X0bkVnlDlJdGbY2s7crgUMALQJ/R37Wkch3B1IdNBaa8GM+nc3z1A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/upload-media": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.34.0.tgz",
-      "integrity": "sha512-kUTpZQo+29cbEnxc2S5cKCnxaKkeLlkMqmxPAfvmVgKc+hJF2F00ChEJyd9P5ksLk/+woEtuYOKNr7ohqfob7g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/preferences": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/vips": "^2.2.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/@wordpress/vips": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.2.0.tgz",
-      "integrity": "sha512-3GC+P/SC5/tqshTUe1vAARVpL/sCQU3Qvn6nmECfEldJY5ViBUM+yW0jcqNVkcMCd6WQsjSHcwozgx6BjtHCqg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/worker-threads": "^1.9.0",
-        "wasm-vips": "^0.0.18"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/core-data/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/data": {
-      "version": "10.42.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.42.0.tgz",
-      "integrity": "sha512-YHBnNmMSclYvCS6QjwmbtdpGVbN4v0VZIq25n4a6HxG0Co6LTnvhAvgtnw+NZpEiDHibH8JcSjbCQEBtToWSFQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^7.42.0",
-        "@wordpress/deprecated": "^4.42.0",
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/is-shallow-equal": "^5.42.0",
-        "@wordpress/priority-queue": "^3.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "@wordpress/redux-routine": "^5.42.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/dataviews": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-13.1.0.tgz",
-      "integrity": "sha512-nZQux6jhcgKQhkD+eBwC9YojA2xWerutShUvPWyBu6mLhArGWUSYniuX1An8rhSMkm6nwju7Omgui7BdvqJhhw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.21",
-        "@wordpress/base-styles": "^6.18.0",
-        "@wordpress/components": "^32.4.0",
-        "@wordpress/compose": "^7.42.0",
-        "@wordpress/data": "^10.42.0",
-        "@wordpress/date": "^5.42.0",
-        "@wordpress/deprecated": "^4.42.0",
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/i18n": "^6.15.0",
-        "@wordpress/icons": "^12.0.0",
-        "@wordpress/keycodes": "^4.42.0",
-        "@wordpress/primitives": "^4.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "@wordpress/ui": "^0.9.0",
-        "@wordpress/warning": "^3.42.0",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^4.1.0",
-        "deepmerge": "4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/dataviews/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/icons": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-12.2.0.tgz",
-      "integrity": "sha512-Fiw7bmfHDNPjTdCrBF23/9K0VN/GUi73d2ZPZaeWdXhTmIX62T9KYvb1c+WnlBkX7GpXgJO6Q8mypQCY9mw5SQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^6.44.0",
-        "@wordpress/primitives": "^4.44.0",
-        "change-case": "4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.13.0.tgz",
-      "integrity": "sha512-I0vxBdP6NtstFYYeWVqU7QQUdjauJpSQMdof1Z7FQE7Joj3Z99SxeD0KjavOXvQLYvqXz7sb2sf2DkEGIWJX6Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "clsx": "^2.1.1",
-        "dequal": "^2.0.3",
-        "react-easy-crop": "^5.4.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/image-cropper/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.49.0.tgz",
-      "integrity": "sha512-Md7+yO1CCUMqMD5ChpPoRQ5GJ+DAsXs0eEJIFrQXbU63QsIYwIdylT6+WelfWDeB2cLCodjWg0j1vL1S1kjvEw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/keycodes": "^4.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/keycodes": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.49.0.tgz",
-      "integrity": "sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/i18n": "^6.22.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.49.0.tgz",
-      "integrity": "sha512-Jwk6xudutgVC5ZPGMo4lzg+SMl+XNI05NigagqIV86bkzoLqtqyfJoDS5n1ncr17Ock++KFS5lHvrzXOvsmXLQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/data": "^10.49.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/notices/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.49.0.tgz",
-      "integrity": "sha512-R57FvRdCUPna0lnRUAi5Ll73DOs1r0orIdnVJGsGcD5vykb48IXcH/IljWZKkIf714BlRyMKiS69JZIAQEdQQw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/block-editor": "^15.22.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/core-data": "^7.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/notices": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/url": "^4.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/block-editor": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.22.0.tgz",
-      "integrity": "sha512-Brbe0tyL3ekEku6ljbZCTfMFyL3WmIiS55YCsU3zp4LxO9GdY754mzpVkS9/Rzc/pyBSvQJ1mGqSLEOkEMJrRw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/commands": "^1.49.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/global-styles-engine": "^1.16.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/image-cropper": "^1.13.0",
-        "@wordpress/interactivity": "^6.49.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/notices": "^5.49.0",
-        "@wordpress/preferences": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-engine": "^2.49.0",
-        "@wordpress/token-list": "^3.49.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/upload-media": "^0.34.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "@wordpress/wordcount": "^4.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "deepmerge": "^4.3.1",
-        "diff": "^8.0.3",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "parsel-js": "^1.1.2",
-        "postcss": "^8.4.38",
-        "postcss-prefix-selector": "^1.16.0",
-        "postcss-urlrebase": "^1.4.0",
-        "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^5.4.2",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.49.0.tgz",
-      "integrity": "sha512-Zn2+vJN82kHiuJ8Fd7m1gllM9iqhGPU21QBczS0ac/ixuqd1W4H0ho4JKIiiTr1YLrbZ/QGJccWU4Te84vXbqw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/blocks": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.22.0.tgz",
-      "integrity": "sha512-+L0+NOuu4ZErYb8pA2tAiWLWuWdG+UU8RhWPXJ4RccQPtjuOvPZlvwgECSY5YxmduImsRefDrIwlBzqqqA17CA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.49.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/shortcode": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.9.3",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "marked": "^18.0.3",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/dataviews": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.0.0.tgz",
-      "integrity": "sha512-d+0tCa0xWP1QXbEdXesp0wlthRmSAXtp1X0bkVnlDlJdGbY2s7crgUMALQJ/R37Wkch3B1IdNBaa8GM+nc3z1A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/upload-media": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.34.0.tgz",
-      "integrity": "sha512-kUTpZQo+29cbEnxc2S5cKCnxaKkeLlkMqmxPAfvmVgKc+hJF2F00ChEJyd9P5ksLk/+woEtuYOKNr7ohqfob7g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/preferences": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/vips": "^2.2.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/@wordpress/vips": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.2.0.tgz",
-      "integrity": "sha512-3GC+P/SC5/tqshTUe1vAARVpL/sCQU3Qvn6nmECfEldJY5ViBUM+yW0jcqNVkcMCd6WQsjSHcwozgx6BjtHCqg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/worker-threads": "^1.9.0",
-        "wasm-vips": "^0.0.18"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/patterns/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.49.0.tgz",
-      "integrity": "sha512-EGyLxOD3bCZgm1zqNKLQu3u9XN7iVfZbwTDTVB74eHx3pQEismQrdODnObLmc5Uw4T+XYUUYBoRwnJSOzKSRpQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/preferences/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/primitives": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.49.0.tgz",
-      "integrity": "sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.49.0.tgz",
-      "integrity": "sha512-Wo22Lib8TYN3hsL0izfJDa53wSCiYouR2kdpCWwcMcGC0JHzc9xCC+MpUzHDVdmKhLVW/FIFtI1N9vjnDtPyPA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/block-editor": "^15.22.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/core-data": "^7.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/notices": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/block-editor": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.22.0.tgz",
-      "integrity": "sha512-Brbe0tyL3ekEku6ljbZCTfMFyL3WmIiS55YCsU3zp4LxO9GdY754mzpVkS9/Rzc/pyBSvQJ1mGqSLEOkEMJrRw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/commands": "^1.49.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/dataviews": "^17.0.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/global-styles-engine": "^1.16.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/image-cropper": "^1.13.0",
-        "@wordpress/interactivity": "^6.49.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keyboard-shortcuts": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/notices": "^5.49.0",
-        "@wordpress/preferences": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-engine": "^2.49.0",
-        "@wordpress/token-list": "^3.49.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/upload-media": "^0.34.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "@wordpress/wordcount": "^4.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "deepmerge": "^4.3.1",
-        "diff": "^8.0.3",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "parsel-js": "^1.1.2",
-        "postcss": "^8.4.38",
-        "postcss-prefix-selector": "^1.16.0",
-        "postcss-urlrebase": "^1.4.0",
-        "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^5.4.2",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.49.0.tgz",
-      "integrity": "sha512-Zn2+vJN82kHiuJ8Fd7m1gllM9iqhGPU21QBczS0ac/ixuqd1W4H0ho4JKIiiTr1YLrbZ/QGJccWU4Te84vXbqw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/blocks": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.22.0.tgz",
-      "integrity": "sha512-+L0+NOuu4ZErYb8pA2tAiWLWuWdG+UU8RhWPXJ4RccQPtjuOvPZlvwgECSY5YxmduImsRefDrIwlBzqqqA17CA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.49.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/shortcode": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.9.3",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "marked": "^18.0.3",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/dataviews": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.0.0.tgz",
-      "integrity": "sha512-d+0tCa0xWP1QXbEdXesp0wlthRmSAXtp1X0bkVnlDlJdGbY2s7crgUMALQJ/R37Wkch3B1IdNBaa8GM+nc3z1A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/upload-media": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.34.0.tgz",
-      "integrity": "sha512-kUTpZQo+29cbEnxc2S5cKCnxaKkeLlkMqmxPAfvmVgKc+hJF2F00ChEJyd9P5ksLk/+woEtuYOKNr7ohqfob7g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/preferences": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0",
-        "@wordpress/vips": "^2.2.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/vips": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-2.2.0.tgz",
-      "integrity": "sha512-3GC+P/SC5/tqshTUe1vAARVpL/sCQU3Qvn6nmECfEldJY5ViBUM+yW0jcqNVkcMCd6WQsjSHcwozgx6BjtHCqg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/worker-threads": "^1.9.0",
-        "wasm-vips": "^0.0.18"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/reusable-blocks/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/rich-text": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.49.0.tgz",
-      "integrity": "sha512-RDH3dAnPTimIXYEdJ5+20KyJgmCeEDouA4Hi1Jhl1fiAzjjH1lNcwgs9eNQzaagqQTLfvvWOPX62rkFJnSvvvw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "colord": "^2.9.3",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-6.25.0.tgz",
-      "integrity": "sha512-me6c6LwF721F534z7n/nBbnjIIRM/iPddMMdjnVH6AhM1lpCK46uCmehq9vA5HTMyyyKFsAOXGCcFOT1uCz54Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/components": "^36.0.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/url": "^4.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/base-styles": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
-      "integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.49.0.tgz",
-      "integrity": "sha512-Zn2+vJN82kHiuJ8Fd7m1gllM9iqhGPU21QBczS0ac/ixuqd1W4H0ho4JKIiiTr1YLrbZ/QGJccWU4Te84vXbqw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/blocks": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.22.0.tgz",
-      "integrity": "sha512-+L0+NOuu4ZErYb8pA2tAiWLWuWdG+UU8RhWPXJ4RccQPtjuOvPZlvwgECSY5YxmduImsRefDrIwlBzqqqA17CA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.49.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/shortcode": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.9.3",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "marked": "^18.0.3",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
-      "version": "36.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
-      "integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.4.29",
-        "@date-fns/utc": "^2.1.1",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/css": "^11.13.5",
-        "@emotion/react": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/styled": "^11.14.1",
-        "@emotion/utils": "^1.4.2",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "^1.1.0",
-        "@types/highlight-words-core": "^1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/base-styles": "^10.1.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/date": "^5.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/ui": "^0.16.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.9.3",
-        "csstype": "^3.2.3",
-        "date-fns": "^4.1.0",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.15.0",
-        "gradient-parser": "^1.1.1",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.6.1",
-        "react-day-picker": "^9.7.0",
-        "remove-accents": "^0.5.0",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/icons": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
-      "integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/primitives": "^4.49.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/theme": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
-      "integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "esbuild": "^0.27.2",
-        "postcss": "^8.0.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2",
-        "vite": "^7.3.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "stylelint": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/@wordpress/ui": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
-      "integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.5.0",
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/icons": "^15.0.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/primitives": "^4.49.0",
-        "@wordpress/style-runtime": "^0.5.0",
-        "@wordpress/theme": "^0.16.0",
-        "clsx": "^2.1.1",
-        "tabbable": "^6.4.0"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/server-side-render/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/style-engine": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.49.0.tgz",
-      "integrity": "sha512-U3T2Ss3UtTqBnd6UpFRhDCQyB4XDG1HJbR5tWDx6UjbjgadeAX5+8WqnZumeWd5H/ZRax1WFLs8eqKvRUZA2mA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/theme": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.9.0.tgz",
-      "integrity": "sha512-jxskNZVvWHIswQvWvswaNIAkBpXwdFcocBYxTWQnYgvb0QAEYsKsnqYMulZPrz/Dk4c+GF7ptwdLxb3rry9tcg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "colorjs.io": "^0.6.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
-        "stylelint": "^16.8.2"
-      },
-      "peerDependenciesMeta": {
-        "stylelint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/ui": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.9.0.tgz",
-      "integrity": "sha512-PXx0CU5ngJOaC69ylhyyS33Ac4njVudGMkrPjXuRd6cXZeizD3q6KO0ws1ECtm4FYlrWv5YvYyNhT5salP9hTg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@base-ui/react": "^1.2.0",
-        "@wordpress/a11y": "^4.42.0",
-        "@wordpress/compose": "^7.42.0",
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/i18n": "^6.15.0",
-        "@wordpress/icons": "^12.0.0",
-        "@wordpress/keycodes": "^4.42.0",
-        "@wordpress/primitives": "^4.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "@wordpress/theme": "^0.9.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/ui/node_modules/@base-ui/react": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-      "integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@base-ui/utils": "0.3.1",
-        "@floating-ui/react-dom": "^2.1.8",
-        "@floating-ui/utils": "^0.2.11",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@date-fns/tz": "^1.2.0",
-        "@types/react": "^17 || ^18 || ^19",
-        "date-fns": "^4.0.0",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@date-fns/tz": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        },
-        "date-fns": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.6"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/ui/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "extraneous": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/upload-media": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.27.0.tgz",
-      "integrity": "sha512-p14rxOwpr5URUpqKPDhg+lIPhEek9d0XjvXOL8PPEAB0RcaBF6utBrmMtdxTdRfOqbQ4KBoIM5NrkLrBT6h0og==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/blob": "^4.42.0",
-        "@wordpress/compose": "^7.42.0",
-        "@wordpress/data": "^10.42.0",
-        "@wordpress/element": "^6.42.0",
-        "@wordpress/i18n": "^6.15.0",
-        "@wordpress/preferences": "^4.42.0",
-        "@wordpress/private-apis": "^1.42.0",
-        "@wordpress/url": "^4.42.0",
-        "@wordpress/vips": "^1.2.0",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/viewport": {
-      "version": "6.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.49.0.tgz",
-      "integrity": "sha512-JZibnYTgB7oYdp4CKmmb8ovhRmw9qFTBLI7FuGv0QZ0NUh5k2mDKVzP29VcnDb16f/CNMeJU60ZuCQq7/rcr+w==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/element": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/viewport/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/viewport/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/@wordpress/viewport/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/cmdk": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
-      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "^1.1.1",
-        "@radix-ui/react-dialog": "^1.1.6",
-        "@radix-ui/react-id": "^1.1.0",
-        "@radix-ui/react-primitive": "^2.0.2"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/cmdk/node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.17.tgz",
-      "integrity": "sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-context": "1.1.4",
-        "@radix-ui/react-dismissable-layer": "1.1.13",
-        "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.10",
-        "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-portal": "1.1.12",
-        "@radix-ui/react-presence": "1.1.6",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-slot": "1.3.0",
-        "@radix-ui/react-use-controllable-state": "1.2.3",
-        "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.7.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@automattic/blocks-engine/node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -5680,75 +269,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/framer-motion": {
-      "version": "11.18.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
-      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^11.18.1",
-        "motion-utils": "^11.18.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/@automattic/blocks-engine/node_modules/html-encoding-sniffer": {
@@ -5824,95 +344,6 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/@automattic/blocks-engine/node_modules/path-to-regexp": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "license": "MIT"
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/re-resizable": {
-      "version": "6.11.2",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
-      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/react-autosize-textarea": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
-      "integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
-      "license": "MIT",
-      "dependencies": {
-        "autosize": "^4.0.2",
-        "line-height": "^0.3.1",
-        "prop-types": "^15.5.6"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/react-colorful": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.7.0.tgz",
-      "integrity": "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/react-easy-crop": {
-      "version": "5.5.7",
-      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.7.tgz",
-      "integrity": "sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==",
-      "license": "MIT",
-      "dependencies": {
-        "normalize-wheel": "^1.0.1",
-        "tslib": "^2.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.4.0",
-        "react-dom": ">=16.4.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/@automattic/blocks-engine/node_modules/tldts": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
@@ -5955,24 +386,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@automattic/blocks-engine/node_modules/use-memo-one": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@automattic/blocks-engine/node_modules/wasm-vips": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.18.tgz",
-      "integrity": "sha512-AJyCvxZj/3qceKNnh+YyEobu/IaJFoPN7x7SxyyHmYBS3kASMqJqxQEuN0ZHKQDWsCJ8armfx4Tq3uKrNc+nMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=17.0.0"
-      }
-    },
     "node_modules/@automattic/blocks-engine/node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -6003,173 +416,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.29.7",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-globals": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.7"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/template": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
-        "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
-        "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.29.7",
-        "@babel/helper-validator-identifier": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@base-ui/utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
-      "integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2",
-        "@floating-ui/utils": "^0.2.11",
-        "reselect": "^5.2.0",
-        "use-sync-external-store": "^1.6.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^17 || ^18 || ^19",
-        "react": "^17 || ^18 || ^19",
-        "react-dom": "^17 || ^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/@bramus/specificity": {
@@ -6323,189 +569,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@date-fns/tz": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
-      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
-      "license": "MIT"
-    },
-    "node_modules/@date-fns/utc": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-2.1.1.tgz",
-      "integrity": "sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/runtime": "^7.18.3",
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.3.3",
-        "babel-plugin-macros": "^3.1.0",
-        "convert-source-map": "^1.5.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-root": "^1.1.0",
-        "source-map": "^0.5.7",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "stylis": "4.2.0"
-      }
-    },
-    "node_modules/@emotion/css": {
-      "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
-      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.2"
-      }
-    },
-    "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/react": {
-      "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/cache": "^11.14.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2",
-        "@emotion/weak-memoize": "^0.4.0",
-        "hoist-non-react-statics": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/hash": "^0.9.2",
-        "@emotion/memoize": "^0.9.0",
-        "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.2",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/styled": {
-      "version": "11.14.1",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
-      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.13.5",
-        "@emotion/is-prop-valid": "^1.3.0",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
-        "@emotion/utils": "^1.4.2"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.0.0-rc.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
-      "license": "MIT"
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
@@ -6513,6 +576,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6529,6 +593,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6545,6 +610,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6561,6 +627,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6577,6 +644,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6593,6 +661,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6609,6 +678,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6625,6 +695,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6641,6 +712,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6657,6 +729,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6673,6 +746,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6689,6 +763,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6705,6 +780,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6721,6 +797,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6737,6 +814,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6753,6 +831,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6769,6 +848,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6785,6 +865,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6801,6 +882,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6817,6 +899,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6833,6 +916,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6849,6 +933,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6865,6 +950,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6881,6 +967,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6897,6 +984,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6913,6 +1001,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6939,31 +1028,6 @@
         }
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
-      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
-      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.7.5",
-        "@floating-ui/utils": "^0.2.11"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
-      "license": "MIT"
-    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -6976,40 +1040,12 @@
         "hono": "^4"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -7063,338 +1099,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/@preact/signals": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.4.tgz",
-      "integrity": "sha512-TPMkStdT0QpSc8FpB63aOwXoSiZyIrPsP9Uj347KopdS6olZdAYeeird/5FZv/M1Yc1ge5qstub2o8VDbvkT4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@preact/signals-core": "^1.7.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      },
-      "peerDependencies": {
-        "preact": "10.x"
-      }
-    },
-    "node_modules/@preact/signals-core": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.3.tgz",
-      "integrity": "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
-      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
-      "license": "MIT"
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
-      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
-      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
-      "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/primitive": "1.1.4",
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-use-callback-ref": "1.1.2",
-        "@radix-ui/react-use-escape-keydown": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
-      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
-      "integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.3",
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-use-callback-ref": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-id": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
-      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
-      "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.6",
-        "@radix-ui/react-use-layout-effect": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
-      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
-      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
-      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
-      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
-      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.3",
-        "@radix-ui/react-use-layout-effect": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
-      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
-      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@react-spring/rafz": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
-      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
-      "license": "MIT"
-    },
-    "node_modules/@react-spring/types": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
-      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
-      "license": "MIT"
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -7402,6 +1106,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7415,6 +1120,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7428,6 +1134,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7441,6 +1148,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7454,6 +1162,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7467,6 +1176,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7480,6 +1190,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7496,6 +1207,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7512,6 +1224,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7528,6 +1241,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7544,6 +1258,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7560,6 +1275,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7576,6 +1292,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7592,6 +1309,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7608,6 +1326,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7624,6 +1343,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7640,6 +1360,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7656,6 +1377,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7672,6 +1394,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7688,6 +1411,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7701,6 +1425,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7714,6 +1439,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7727,6 +1453,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7740,6 +1467,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7753,57 +1481,12 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@tabby_ai/hijri-converter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
-      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@tannin/compile": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
-      "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tannin/evaluate": "^1.2.0",
-        "@tannin/postfix": "^1.1.0"
-      }
-    },
-    "node_modules/@tannin/evaluate": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
-      "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
-      "license": "MIT"
-    },
-    "node_modules/@tannin/plural-forms": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
-      "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tannin/compile": "^1.1.0"
-      }
-    },
-    "node_modules/@tannin/postfix": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
-      "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
-      "license": "MIT"
-    },
-    "node_modules/@tannin/sprintf": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.3.3.tgz",
-      "integrity": "sha512-RwARl+hFwhzy0tg9atWcchLFvoQiOh4rrP7uG2N5E4W80BPCUX0ElcUR9St43fxB9EfjsW2df9Qp+UsTbvQDjA==",
-      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -7827,32 +1510,14 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/gradient-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-1.1.0.tgz",
-      "integrity": "sha512-SaEcbgQscHtGJ1QL+ajgDTmmqU2f6T+00jZRcFlVHUW2Asivc84LNUev/UQFyu117AsdyrtI+qpwLvgjJXJxmw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/highlight-words-core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.1.tgz",
-      "integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/mousetrap": {
-      "version": "1.6.15",
-      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
-      "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -7867,12 +1532,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
     },
     "node_modules/@types/pixelmatch": {
       "version": "5.2.6",
@@ -7894,12 +1553,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -7908,24 +1561,6 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@use-gesture/core": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
-      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
-      "license": "MIT"
-    },
-    "node_modules/@use-gesture/react": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
-      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@use-gesture/core": "10.3.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -8043,819 +1678,11 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@wordpress/a11y": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.49.0.tgz",
-      "integrity": "sha512-owb2VJYS54F6R0cjxZzb/Jp+ogGaMpSkuZAWG8VqMW6I8PnFCva+6H4PP3flF7QnaiCvvgEIl2grsSJmUm9O7g==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/dom-ready": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/api-fetch": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.49.0.tgz",
-      "integrity": "sha512-SJTVvKAfpXScMoo3NTrY8PPlY2r+nQ9cF+In7mdoHtm9bZrSwYlGCgXGkzNGcTWEjAcu+hzzdj60gcnejPKoJA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/url": "^4.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/autop": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.49.0.tgz",
-      "integrity": "sha512-2JmZWZI5GLLEoRdU1HO8zXUBi+2GR29cjoAomFdGqyr79zNqxpjHoZX0DH9auvMReSm9op8Dq97rSK+4aaQ0zQ==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/base-styles": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.20.0.tgz",
-      "integrity": "sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blob": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.49.0.tgz",
-      "integrity": "sha512-SZNwHk48d9+FNv8LzWJ3PPE9UbJb6BDuiE2sLEv8EvpxWAEQylJmkfWvC3Weegrdz1fn9SeBgtQevjMqfde8uQ==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/block-serialization-default-parser": {
       "version": "5.49.0",
       "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.49.0.tgz",
       "integrity": "sha512-Zn2+vJN82kHiuJ8Fd7m1gllM9iqhGPU21QBczS0ac/ixuqd1W4H0ho4JKIiiTr1YLrbZ/QGJccWU4Te84vXbqw==",
       "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/date": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.49.0.tgz",
-      "integrity": "sha512-6Q7tvwjwNI2W0KDIATd4WAOc1n5Ppp/v/ofOwPjvaXr/9O4s2fsduR//ziQL3c5a5oYohCIsNHSHmOic+/Jofg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/deprecated": "^4.49.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/deprecated": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.49.0.tgz",
-      "integrity": "sha512-xK0l4psQpjpyIeE++Aml8tLLNeRN4vEjmBaCd6VbNqbbluW8LzZJtV60JATH8blcW5MaGCGl7rlpSevaBjp0hQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/hooks": "^4.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dom": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.49.0.tgz",
-      "integrity": "sha512-ysZvqyw1PvClTWqVwLzsE7cqfYU+QppJwu2Ji/rUGyFL9WSNdMIgIQhJWZMBiw0gBtD/uuiQe7OoVJfEGw0JYw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/deprecated": "^4.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dom-ready": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.49.0.tgz",
-      "integrity": "sha512-faTCKkv9zjxKKq5RNmA20piRog14+KgAy7/Pw1hbxB1JCsimxFr7f+Vg268TIFbWQJiqX1S+YuKySFGQ/hpk8Q==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/element": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
-      "integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.46.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/element/node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@wordpress/element/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/element/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/element/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@wordpress/element/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/@wordpress/escape-html": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.49.0.tgz",
-      "integrity": "sha512-eOSPRJhmocfi/hztIlbCXbksg54VWIvrbfRbS7AsHY8BelbMyP4YUGEXCZf2jqf5beMB/jqulcsNLsYJ/wC+yw==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.16.0.tgz",
-      "integrity": "sha512-fopMEmf/nwwe2JFlnk2t158bBHAPUnmXEctCFdQyUboi2Zb7VuY+bam4YQ9hhuP4wRhJHWPCyt+ZOrHgST1OBA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/blocks": "^15.22.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/style-engine": "^2.49.0",
-        "colord": "^2.9.3",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/blocks": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.22.0.tgz",
-      "integrity": "sha512-+L0+NOuu4ZErYb8pA2tAiWLWuWdG+UU8RhWPXJ4RccQPtjuOvPZlvwgECSY5YxmduImsRefDrIwlBzqqqA17CA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/autop": "^4.49.0",
-        "@wordpress/blob": "^4.49.0",
-        "@wordpress/block-serialization-default-parser": "^5.49.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/html-entities": "^4.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/rich-text": "^7.49.0",
-        "@wordpress/shortcode": "^4.49.0",
-        "@wordpress/warning": "^3.49.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.9.3",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "marked": "^18.0.3",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^14.0.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/compose": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
-      "integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "change-case": "^4.1.2",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/data": {
-      "version": "10.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
-      "integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/is-shallow-equal": "^5.49.0",
-        "@wordpress/priority-queue": "^3.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/redux-routine": "^5.49.0",
-        "deepmerge": "^4.3.1",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^5.0.1",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/element": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
-      "integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@types/react": "^18.3.27",
-        "@types/react-dom": "^18.3.1",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/keycodes": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.49.0.tgz",
-      "integrity": "sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/i18n": "^6.22.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/rich-text": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.49.0.tgz",
-      "integrity": "sha512-RDH3dAnPTimIXYEdJ5+20KyJgmCeEDouA4Hi1Jhl1fiAzjjH1lNcwgs9eNQzaagqQTLfvvWOPX62rkFJnSvvvw==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/compose": "^8.2.0",
-        "@wordpress/data": "^10.49.0",
-        "@wordpress/deprecated": "^4.49.0",
-        "@wordpress/dom": "^4.49.0",
-        "@wordpress/element": "^8.1.0",
-        "@wordpress/escape-html": "^3.49.0",
-        "@wordpress/i18n": "^6.22.0",
-        "@wordpress/keycodes": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "colord": "^2.9.3",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27",
-        "react": "^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/@wordpress/style-engine": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.49.0.tgz",
-      "integrity": "sha512-U3T2Ss3UtTqBnd6UpFRhDCQyB4XDG1HJbR5tWDx6UjbjgadeAX5+8WqnZumeWd5H/ZRax1WFLs8eqKvRUZA2mA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.3.27"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/use-memo-one": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
-      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/global-styles-engine/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/@wordpress/hooks": {
-      "version": "4.42.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.42.0.tgz",
-      "integrity": "sha512-isdznPKo+LEAGrP/o6SnWjxKYKn4KNzb5dmpnYPTbLh13gE/p8KctpLyzMsgR2GBXF8soAL+hpXMxxKoTQSabA==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/html-entities": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.49.0.tgz",
-      "integrity": "sha512-/ZYK6CPks3VAGFQZ+h56jOy4LB4CC1ZB1SMVY3eeUPStyH84YSz7nTa2P7gw/4uGJhaITMQCmFl7yGFPQOROtg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/i18n": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.22.0.tgz",
-      "integrity": "sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.49.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interactivity": {
-      "version": "6.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.49.0.tgz",
-      "integrity": "sha512-hGgqxXfkSEHFdQ+AnFvnBERlNT7B1+l7yYahRPhBA3jms1JNsB0DZZDSpUq292T5yxfuV6hD5uebFpucS0PsCA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@preact/signals": "^1.3.0",
-        "@preact/signals-core": "^1.7.0",
-        "preact": "^10.29.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interactivity-router": {
-      "version": "2.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity-router/-/interactivity-router-2.49.0.tgz",
-      "integrity": "sha512-72A3GnAIDkWKD8Y6CimOOlVjLYDXNtH8awsOGg+yGALzZrH2GekVfUQ0AdIctH+gzA5PanNGF5t7yGKOVHGsgA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/a11y": "^4.49.0",
-        "@wordpress/interactivity": "^6.49.0",
-        "es-module-lexer": "^1.5.4"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.49.0.tgz",
-      "integrity": "sha512-pKvFYoExyT/A5h0Y5wLYs+8gQRaisJps2YF0jICo/LOfXR+TF8mYLH2txrA8ZCDGS0FPLSPjMxAl9hjUGrELRg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/latex-to-mathml": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.17.0.tgz",
-      "integrity": "sha512-LlbDP0JCWhu3LTiu7B8h31QsItyJ+akh1HKY2qt/d1M41shfLuiqzRZUERKDM9ZM6MDHBr0Kcm/devDFWXnSAg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "temml": "^0.10.33"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/priority-queue": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.49.0.tgz",
-      "integrity": "sha512-UcVHYan6qYvDNTFEwEnPBU9I1SnImLjEh54ISgqvvndc7jfxtdi+Akwj2kgxeLRY+bsXzMQr6byD/x4dw56yqA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/private-apis": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.49.0.tgz",
-      "integrity": "sha512-tGmX0XknlknSFB3UpoRQHnXW+4FufotTXYln+aXeHTFGcOuW3jSi8d8VZx7LCjUY1jqA8hCDf1vOHXW3FDcErQ==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/redux-routine": {
-      "version": "5.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.49.0.tgz",
-      "integrity": "sha512-pisFM/iQv23hmrBkWwlQZoMtqR3wXWoaAAf9d++laxlPRkFNfe/AG7gUK9tljhk5k6lP9pdeet4t+qSeQPDxpg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/shortcode": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.49.0.tgz",
-      "integrity": "sha512-RG+uTFRjbBxdFNy6S6AEnafC6LeFfcxombbPf+F++/DidCwNw3xUe1TYl5jkda7j2ywTGwopk0VC2vtqG2ZXwQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/style-runtime": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
-      "integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=20.10.0",
-        "npm": ">=10.2.3"
-      }
-    },
-    "node_modules/@wordpress/sync": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.49.0.tgz",
-      "integrity": "sha512-qjMcjVNk4Zzr6LYEvoNBmZU/ja9jSLPOUhVwIls818LJr7lLs2mMf47gpqFpYv7M0GIDl63zRbQHUFuEPmJHfA==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/api-fetch": "^7.49.0",
-        "@wordpress/hooks": "^4.49.0",
-        "@wordpress/private-apis": "^1.49.0",
-        "@wordpress/undo-manager": "^1.49.0",
-        "diff": "^8.0.3",
-        "fast-deep-equal": "^3.1.3",
-        "lib0": "^0.2.99",
-        "y-protocols": "^1.0.7",
-        "yjs": "^13.6.29"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/sync/node_modules/@wordpress/hooks": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
-      "integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/sync/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@wordpress/token-list": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.49.0.tgz",
-      "integrity": "sha512-J1wgnWSEcQQcEOI0TJv1orP1eGa5nuo85hqhIptuQBYEU3vRqCTOn6z73xIJ5R0tWi+8pkedJQxl170zJ/Aifg==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/undo-manager": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.49.0.tgz",
-      "integrity": "sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.49.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/url": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.49.0.tgz",
-      "integrity": "sha512-u9Mbph1qh3ZUm2p1HC267frFA1Eg4edC9tagfACxU79p77SKp3loiwfRPM64i50xna8S0wfPwBr0oLF00NawvQ==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/vips": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-1.6.0.tgz",
-      "integrity": "sha512-TiQYzS5L2hVk6H9Xpk0tSzMu0cpCLUXNCXioiM/LZ2SvzP9ibwp+uXp2QwI2SS32aO06OeECaCJx+qgbIimv3A==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@wordpress/worker-threads": "^1.6.0",
-        "wasm-vips": "^0.0.16"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/warning": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.49.0.tgz",
-      "integrity": "sha512-00KmZy5kT8vm48HKNQxsgiq3GXdgaPGClneMFTe9EWjop9Ghyq8MaYIqjYY75eOgPTFVcKKQyXK9/DAAQxsQuA==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/wordcount": {
-      "version": "4.49.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.49.0.tgz",
-      "integrity": "sha512-4UkZySzJKxnu4t0+t+nxW/j+8pOPbc96dp7/v1SffAdGRABik7V7vEpvL9NN3e1FiZgrbtwdWK2P4zsvJzMg9w==",
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/worker-threads": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.9.0.tgz",
-      "integrity": "sha512-UAOns1u+ZljgJtbv07kSIWzVCUSXCxk5KDSQgw4Sx5MKOHqcuNoF9p8HorE5DiAOgJA01CxxXLs03peTF65X6Q==",
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "comctx": "^1.4.3"
-      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -8980,18 +1807,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/aria-hidden": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -9012,27 +1827,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/autosize": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
-      "integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ==",
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
       }
     },
     "node_modules/bidi-js": {
@@ -9151,45 +1945,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "license": "MIT",
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/capital-case": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
-      "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -9217,26 +1972,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/change-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
-      "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "capital-case": "^1.0.4",
-        "constant-case": "^3.0.4",
-        "dot-case": "^3.0.4",
-        "header-case": "^2.0.4",
-        "no-case": "^3.0.4",
-        "param-case": "^3.0.4",
-        "pascal-case": "^3.1.2",
-        "path-case": "^3.0.4",
-        "sentence-case": "^3.0.4",
-        "snake-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/check-error": {
@@ -9346,96 +2081,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -9446,59 +2091,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-      "license": "MIT"
-    },
-    "node_modules/colorjs.io": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
-      "integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/color"
-      }
-    },
-    "node_modules/comctx": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.7.5.tgz",
-      "integrity": "sha512-0fsxsxr1Hg2T99wOIteUbsJOX6jMmnhAJepcVRqNRMWpcbxRhbm2+0R8qEuQEaE4gWjfdXaKeAGYAn0yeElylQ==",
-      "license": "MIT"
-    },
-    "node_modules/computed-style": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
-      "integrity": "sha512-WpAmaKbMNmS3OProfHIdJiNleNJdgUrJfbKArXua28QF7+0CoZjlLn0lp6vlc+dl5r2/X9GQiQRQQU4BzSa69w=="
-    },
-    "node_modules/constant-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
-      "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case": "^2.0.2"
       }
     },
     "node_modules/content-disposition": {
@@ -9522,12 +2114,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "license": "MIT"
     },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
@@ -9571,31 +2157,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -9683,6 +2244,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -9698,22 +2260,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/date-fns": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
-      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -9732,15 +2278,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -9757,15 +2294,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -9773,30 +2301,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT"
-    },
-    "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-serializer": {
@@ -9854,16 +2358,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -9884,12 +2378,6 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
-    "node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "license": "MIT"
-    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -9897,15 +2385,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/encoding-sniffer": {
@@ -9945,21 +2424,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/equivalent-key-map": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
-      "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
-      "license": "MIT"
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -9982,6 +2446,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -10010,7 +2475,7 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -10174,15 +2639,6 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/fast-average-color": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.5.2.tgz",
-      "integrity": "sha512-FbaU8iPTPljP7tmnVhXbCyASNw/zxnmaNDf88gn5pTXlNvejl9w4FapeWMh6UNDwIjhJJU28EPfQWwW032YgPA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10248,7 +2704,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -10281,24 +2737,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/find-root": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-      "license": "MIT"
-    },
-    "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/forwarded": {
@@ -10342,15 +2780,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-east-asian-width": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
@@ -10387,15 +2816,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -10409,16 +2829,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/gettext-parser": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
-      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-      "license": "MIT",
-      "dependencies": {
-        "encoding": "^0.1.12",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -10429,14 +2839,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gradient-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-1.1.1.tgz",
-      "integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-symbols": {
@@ -10463,37 +2865,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/header-case": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
-      "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
-      "license": "MIT",
-      "dependencies": {
-        "capital-case": "^1.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/highlight-words-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
-      "integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==",
-      "license": "MIT"
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/hono": {
       "version": "4.12.27",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
@@ -10501,53 +2872,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
-      }
-    },
-    "node_modules/hpq": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.4.0.tgz",
-      "integrity": "sha512-ycJQMRaRPBcfnoT1gS5I1XCvbbw9KO94Y0vkwksuOjcJMqNZtb03MF2tCItLI2mQbkZWSSeFinoRDPmjzv4tKg==",
-      "license": "MIT"
-    },
-    "node_modules/html-dom-parser": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.2.tgz",
-      "integrity": "sha512-9nD3Rj3/FuQt83AgIa1Y3ruzspwFFA54AJbQnohXN+K6fL1/bhcDQJJY5Ne4L4A163ADQFVESd/0TLyNoV0mfg==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "5.0.3",
-        "htmlparser2": "10.0.0"
-      }
-    },
-    "node_modules/html-dom-parser/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/html-dom-parser/node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -10561,27 +2885,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/html-react-parser": {
-      "version": "5.2.11",
-      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.11.tgz",
-      "integrity": "sha512-WnSQVn/D1UTj64nSz5y8MriL+MrbsZH80Ytr1oqKqs8DGZnphWY1R1pl3t7TY3rpqTSu+FHA21P80lrsmrdNBA==",
-      "license": "MIT",
-      "dependencies": {
-        "domhandler": "5.0.3",
-        "html-dom-parser": "5.1.2",
-        "react-property": "2.0.2",
-        "style-to-js": "1.1.21"
-      },
-      "peerDependencies": {
-        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
-        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/htmlparser2": {
@@ -10675,22 +2978,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
@@ -10774,12 +3061,6 @@
         "react": ">=18.0.0"
       }
     },
-    "node_modules/inline-style-parser": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
-      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
-      "license": "MIT"
-    },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
@@ -10796,27 +3077,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -10849,15 +3109,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -10887,16 +3138,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "license": "MIT",
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
     },
     "node_modules/jose": {
       "version": "6.2.3",
@@ -10954,24 +3195,6 @@
         }
       }
     },
-    "node_modules/jsesc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -10984,91 +3207,12 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/lib0": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
-      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
-      "license": "MIT",
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
-    "node_modules/line-height": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
-      "integrity": "sha512-YExecgqPwnp5gplD2+Y8e8A5+jKpr25+DzMbFdI1/1UAr0FJrTFv4VkHLf8/6B590i1wUPJWMKKldkd/bdQ//w==",
-      "license": "MIT",
-      "dependencies": {
-        "computed-style": "~0.1.3"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
-    },
-    "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/loose-envify/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -11085,18 +3229,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/marked": {
-      "version": "18.0.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
-      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -11122,12 +3254,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/memize": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.1.tgz",
-      "integrity": "sha512-8Nl+i9S5D6KXnruM03Jgjb+LwSupvR13WBr4hJegaaEyobvowCVupi79y2WSiWvO1mzBWxPwEYE5feCe8vyA5w==",
-      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
@@ -11175,48 +3301,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.48",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
-      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
-      "license": "MIT",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/motion-dom": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
-      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^11.18.1"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
-      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
-      "license": "MIT"
-    },
-    "node_modules/mousetrap": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
-      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
-      "license": "Apache-2.0 WITH LLVM-exception"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11249,22 +3333,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "license": "MIT",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/normalize-wheel": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
-      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -11342,87 +3410,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/papaparse": {
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
       "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==",
       "license": "MIT"
-    },
-    "node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -11473,22 +3465,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/parsel-js": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/parsel-js/-/parsel-js-1.2.3.tgz",
-      "integrity": "sha512-kJHFmSNnujpusFfVEXjNaoJ09VYHF8Ih0aVUn7Clu+Ug8AFoA2wx7Ezh17JfW4+vhm/lauAd9A+//uFkmydZtQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/LeaVerou"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/leaverou"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -11498,16 +3474,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -11515,25 +3481,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/path-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
-      "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -11560,12 +3507,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
-    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -11574,15 +3515,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pathe": {
@@ -11612,7 +3544,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11718,15 +3650,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-prefix-selector": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.1.tgz",
-      "integrity": "sha512-Umxu+FvKMwlY6TyDzGFoSUnzW+NOfMBLyC1tAkIjgX+Z/qGspJeRjVC903D7mx7TuBpJlwti2ibXtWuA7fKMeQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "postcss": ">4 <9"
-      }
-    },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
@@ -11739,51 +3662,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/postcss-urlrebase": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
-      "integrity": "sha512-rRaxMmWvXrn8Rk1PqsxmaJwldRHsr0WbbASKKCZYxXwotHkM/5X/6IrwaEe8pdzpbNGCEY86yhYMN0MhgOkADA==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3.0"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
-    },
-    "node_modules/preact": {
-      "version": "10.29.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.3.tgz",
-      "integrity": "sha512-D9NL1GAnJZhc3RndVs4gDdxEeU9TcHgywMrhhOsnpdlvFjdbx0gAsLUnH6JEhlJH5giL7Tx5biWPUSEXE/HPzw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -11876,63 +3754,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-day-picker": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
-      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@date-fns/tz": "^1.4.1",
-        "@tabby_ai/hijri-converter": "1.0.5",
-        "date-fns": "^4.1.0",
-        "date-fns-jalali": "4.1.0-0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/gpbl"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-day-picker/node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
-    "node_modules/react-property": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
-      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
-      "license": "MIT"
-    },
     "node_modules/react-reconciler": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
@@ -11948,108 +3769,6 @@
         "react": "^19.2.0"
       }
     },
-    "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-remove-scroll-bar": "^2.3.7",
-        "react-style-singleton": "^2.2.3",
-        "tslib": "^2.1.0",
-        "use-callback-ref": "^1.3.3",
-        "use-sidecar": "^1.1.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
-      "license": "MIT",
-      "dependencies": {
-        "react-style-singleton": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "get-nonce": "^1.0.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
-    "node_modules/rememo": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
-      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
-      "license": "MIT"
-    },
-    "node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
-      "license": "MIT"
-    },
-    "node_modules/requestidlecallback": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
-      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
-      "license": "MIT"
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12057,48 +3776,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "license": "ISC"
-    },
-    "node_modules/reselect": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
-      "license": "MIT"
-    },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/restore-cursor": {
@@ -12121,7 +3798,7 @@
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -12185,32 +3862,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rungen": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
-      "integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
-      "license": "MIT"
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -12261,17 +3912,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/sentence-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
-      "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3",
-        "upper-case-first": "^2.0.2"
-      }
-    },
     "node_modules/serve-static": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
@@ -12290,12 +3930,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -12322,18 +3956,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/showdown": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
-      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "yargs": "^14.2"
-      },
-      "bin": {
-        "showdown": "bin/showdown.js"
       }
     },
     "node_modules/side-channel": {
@@ -12432,12 +4054,6 @@
         "deno": ">=1.4"
       }
     },
-    "node_modules/simple-html-tokenizer": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
-      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
-      "license": "MIT"
-    },
     "node_modules/single-file-cli": {
       "version": "2.0.83",
       "resolved": "https://registry.npmjs.org/single-file-cli/-/single-file-cli-2.0.83.tgz",
@@ -12470,25 +4086,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/snake-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
-      "license": "MIT",
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -12594,52 +4191,10 @@
         "anynum": "^1.0.1"
       }
     },
-    "node_modules/style-to-js": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
-      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "style-to-object": "1.0.14"
-      }
-    },
-    "node_modules/style-to-object": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
-      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
-      "license": "MIT",
-      "dependencies": {
-        "inline-style-parser": "0.2.7"
-      }
-    },
-    "node_modules/stylis": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
-      "license": "MIT"
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "license": "MIT"
-    },
-    "node_modules/tabbable": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
-      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
       "license": "MIT"
     },
     "node_modules/tagged-tag": {
@@ -12652,24 +4207,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tannin": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
-      "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tannin/plural-forms": "^1.1.0"
-      }
-    },
-    "node_modules/temml": {
-      "version": "0.10.34",
-      "resolved": "https://registry.npmjs.org/temml/-/temml-0.10.34.tgz",
-      "integrity": "sha512-f3b5CaPwPvMviA+CtHy0qoIGWvzpRrNpXmGRc/Y1jc9gAYy+xOlndJFyn7Vfcz7cBcS8QRvv8z0EEH59sHCQxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.13.0"
       }
     },
     "node_modules/terminal-size": {
@@ -12702,7 +4239,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -12800,17 +4337,11 @@
         "node": ">=18"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
-    },
     "node_modules/tsx": {
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -12829,6 +4360,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12912,7 +4444,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -12924,95 +4456,11 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/upper-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
-      "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/upper-case-first": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
-      "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-node-es": "^1.1.0",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -13027,7 +4475,7 @@
       "version": "7.3.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
@@ -13125,6 +4573,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13220,15 +4669,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/wasm-vips": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.16.tgz",
-      "integrity": "sha512-4/bEq8noAFt7DX3VT+Vt5AgNtnnOLwvmrDbduWfiv9AV+VYkbUU4f9Dam9e6khRqPinyClFHCqiwATTTJEiGwA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.4.0"
-      }
-    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -13289,12 +4729,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -13424,138 +4858,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
-    },
-    "node_modules/y-protocols": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
-      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.85"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "peerDependencies": {
-        "yjs": "^13.0.0"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-      "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^15.0.1"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
-      "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yjs": {
-      "version": "13.6.31",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
-      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.99"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
     },
     "node_modules/yoga-layout": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@automattic/blocks-engine": "^0.1.0",
+    "@automattic/blocks-engine": "^0.2.2",
     "@modelcontextprotocol/sdk": "^1.27.0",
     "@wordpress/block-serialization-default-parser": "^5.47.0",
     "acorn": "^8.17.0",

--- a/src/lib/replicate/page-reconstruct.test.ts
+++ b/src/lib/replicate/page-reconstruct.test.ts
@@ -1137,17 +1137,39 @@ describe('reconstructPagePattern — section-level media recovery (no island for
     expect(r.provenanceFlags.some((f) => f.includes('html-fallback'))).toBe(false);
   });
 
-  it('does NOT recover a remote-CDN image — the section still islands', () => {
-    // A non-uploads URL cannot be emitted as a block image (the gate bans remote
-    // CDN URLs), so the island remains the only loss-free form.
+  it('renders a native missing-media placeholder for an un-migrated remote-CDN image (no leak, no island)', () => {
+    // Under the structured strategy the section renders natively. A non-uploads
+    // image URL cannot ship (the gate bans remote CDN URLs), so it becomes a
+    // native missing-media placeholder rather than leaking the URL — the heading
+    // survives, there is no remote URL, and no verbatim island.
     const s = section({
       headings: ['Our Story'],
       images: [{ url: 'https://cdn.test/photo.jpg', sourceUrl: 'https://cdn.test/photo.jpg', alt: '', kind: 'img', width: 800, height: 600 }],
       sectionHtml: '<section><h2>Our Story</h2><img src="https://cdn.test/photo.jpg"/></section>',
     } as Partial<SectionSpec>);
     const r = reconstructPagePattern([s], opts);
-    expect(r.body).toContain('<!-- wp:html {"metadata":{"name":"lib-coverage-island"}} -->');
+    expect(r.body).not.toContain('cdn.test'); // no remote URL leak
+    expect(r.body).toContain('Our Story'); // heading preserved
     expect(r.provenanceFlags.some((f) => /media-recovered/.test(f))).toBe(false);
+  });
+
+  it('rewrites a native wp:image remote src via mediaUrlMap (no remote leak past the gate)', () => {
+    // The engine's native reconstruction emits the source <img src> verbatim
+    // (a remote CDN variant URL), which it does NOT route through mediaUrlMap —
+    // only the island path does. reconstructPagePattern must apply a media
+    // post-pass so the migrated upload URL replaces the remote one; otherwise a
+    // hasUnmigratedRemoteAsset gate failure ships on every native image page.
+    const remote =
+      'https://static.wixstatic.com/media/abc123~mv2.jpg/v1/fill/w_680,h_510,q_90/abc123~mv2.jpg';
+    const s = section({
+      headings: ['Our Team'],
+      images: [{ url: remote, sourceUrl: remote, alt: '', kind: 'img', width: 680, height: 510 }],
+      sectionHtml: `<section><h2>Our Team</h2><img src="${remote}" alt=""/></section>`,
+    } as Partial<SectionSpec>);
+    const mediaUrlMap = new Map([[remote, '/wp-content/uploads/2026/06/abc123.jpg']]);
+    const r = reconstructPagePattern([s], { ...opts, mediaUrlMap });
+    expect(r.body).toContain('/wp-content/uploads/2026/06/abc123.jpg');
+    expect(r.body).not.toContain('static.wixstatic.com');
   });
 
   it('does NOT recover a sub-90px decorative glyph — the section still islands', () => {
@@ -1575,15 +1597,19 @@ describe('reconstructPagePattern — captured forms → jetpack blocks', () => {
     expect(r.body).not.toContain('jetpack/');
   });
 
-  it('does NOT double the form when the section falls back to a core/html island (v1: island keeps the verbatim source form)', () => {
+  it('renders the captured form once as a native jetpack/contact-form (no island doubling)', () => {
+    // Under the structured strategy the section renders natively, so the captured
+    // form becomes a single jetpack/contact-form. There is no verbatim island, so
+    // the historical island+jetpack double-form risk does not arise; the
+    // un-migrated image degrades to a native missing-media placeholder.
     const s = section({
       headings: ['Get in Touch'],
-      images: [img('https://cdn.example.test/never-migrated.jpg')], // non-WP image → dropped → island
+      images: [img('https://cdn.example.test/never-migrated.jpg')], // un-migrated image → native placeholder
       sectionHtml: '<section><h2>Get in Touch</h2><form><input type="email"/></form></section>',
       forms: [contactForm],
     });
     const r = reconstructPagePattern([s], opts);
-    expect(r.provenanceFlags.some((f) => f.includes('html-fallback'))).toBe(true);
-    expect(r.body).not.toContain('jetpack/contact-form');
+    expect(r.body).not.toContain('lib-coverage-island'); // native, not islanded
+    expect((r.body.match(/<!-- wp:jetpack\/contact-form/g) || []).length).toBe(1); // exactly one form (opening delimiter)
   });
 });

--- a/src/lib/replicate/page-reconstruct.ts
+++ b/src/lib/replicate/page-reconstruct.ts
@@ -31,6 +31,8 @@ import type { PaletteToken } from './footer-color.js';
 import {
   type FallbackDiagnostic,
   reconstructNativeAggregate,
+  rewriteMediaUrls,
+  structuredStrategy,
   sanitizePatternHeaderField,
   type FontFamilyToken,
   type NativeSectionDecision,
@@ -173,7 +175,16 @@ export function reconstructPagePattern(
     '\n' +
     ' * Categories: featured\n * Inserter: false\n */\n?>\n';
 
-  const bodyMarkup = sectionMarkup.join('\n\n') + '\n';
+  // Media post-pass: the engine's native reconstruction emits source <img src>
+  // / url() verbatim (the source CDN/variant URL) and routes ONLY island media
+  // through mediaUrlMap — so a native wp:image keeps its remote URL and trips
+  // the hasUnmigratedRemoteAsset gate. Rewrite the assembled body against the
+  // run's source→upload map so migrated images resolve locally. Island URLs are
+  // already local (not source keys) → no-op, so this is safe to apply globally.
+  const rawBodyMarkup = sectionMarkup.join('\n\n') + '\n';
+  const bodyMarkup = opts.mediaUrlMap
+    ? rewriteMediaUrls(rawBodyMarkup, opts.mediaUrlMap)
+    : rawBodyMarkup;
   const effectiveFallbackDiagnostics = recipeApplied ? fallbackDiagnostics : aggregate.fallbackDiagnostics;
   const heroIsCover = sectionMarkup.length > 0 && /^\s*<!-- wp:cover\b/.test(sectionMarkup[0]);
   return {
@@ -192,6 +203,12 @@ export function reconstructPagePattern(
 
 function renderOptionsFrom(opts: ReconstructOptions): SectionRenderOptions {
   return {
+    // The blocks reconstruct path carries NO source CSS, so it must select the
+    // interpretive structured strategy — clean, theme-styled canonical blocks built
+    // from the SectionSpec (renderCover/renderCardGrid/…), self-contained and not
+    // dependent on carried source classes. The engine default (preserve-dom) is for
+    // the carried-CSS paths (local-convert, theme-carry) and would render unstyled here.
+    strategy: structuredStrategy,
     ...(opts.mediaUrlMap ? { mediaUrlMap: opts.mediaUrlMap } : {}),
     ...(opts.convertedSections ? { convertedSections: opts.convertedSections } : {}),
     ...(opts.paletteTokens ? { paletteTokens: opts.paletteTokens } : {}),

--- a/src/lib/replicate/validate-artifacts.test.ts
+++ b/src/lib/replicate/validate-artifacts.test.ts
@@ -144,6 +144,30 @@ describe('validateArtifacts — provenance evasions (regression)', () => {
     }] });
     expect(r.ok).toBe(false);
   });
+
+  it('passes a heading that differs from its source entry only by inter-segment whitespace', () => {
+    // The engine's native reconstruction emits adjacent inline nodes (e.g. an
+    // email <span> followed by a phone <span>) with a normalized space between
+    // them, while the captured spec concatenated the same two nodes with NO
+    // separator. Same source text, different whitespace — must NOT fail.
+    const r = validateArtifacts({ patterns: [{
+      slug: 'site/section-1',
+      php: `<!-- wp:heading --><h2>dsm@swiftlumber.com 251-446-4123</h2><!-- /wp:heading -->`,
+      spec: { interactionModel: 'cta', expectedText: ['dsm@swiftlumber.com251-446-4123'], expectedAssets: [] },
+    }] });
+    expect(r.ok).toBe(true);
+  });
+
+  it('still rejects scattered words even under whitespace-insensitive matching', () => {
+    // Guard: the whitespace fallback must not let "win award" stitch across two
+    // separate entries (the cross-entry rejection above must survive).
+    const r = validateArtifacts({ patterns: [{
+      slug: 'site/section-1',
+      php: `<!-- wp:heading --><h2>Win Award</h2><!-- /wp:heading -->`,
+      spec: { interactionModel: 'cta', expectedText: ['we win', 'award every year'], expectedAssets: [] },
+    }] });
+    expect(r.ok).toBe(false);
+  });
 });
 
 describe('validateArtifacts — body-copy provenance (paraphrase hard-fails)', () => {

--- a/src/lib/replicate/validate-artifacts.ts
+++ b/src/lib/replicate/validate-artifacts.ts
@@ -282,6 +282,15 @@ export function validateArtifacts(input: ArtifactInput): ValidationReport {
       const inSingleEntry = allowedEntries.some((e) => e.includes(h));
       if (inSingleEntry) continue;
       if (matchesConsecutiveEntries(h, allowedEntries)) continue;
+      // Whitespace-insensitive fallback: the engine's native reconstruction
+      // emits adjacent inline nodes (e.g. an email <span> next to a phone
+      // <span>) separated by a normalized space, while the captured spec may
+      // have concatenated the same nodes with NO separator — same source text,
+      // different inter-segment whitespace. Compare with all whitespace stripped
+      // so the two reconcile. This stays per-ENTRY (it never joins entries), so
+      // the cross-entry "win award" rejection above is preserved.
+      const hTight = h.replace(/\s+/g, '');
+      if (allowedEntries.some((e) => e.replace(/\s+/g, '').includes(hTight))) continue;
       fail(`heading "${h}" not found in source spec (provenance)`);
     }
 


### PR DESCRIPTION
Updates `@automattic/blocks-engine` to **^0.2.2** and wires the blocks reconstruct path to the engine's new opt-in `structuredStrategy`, restoring the pre-preserve-DOM blocks-path fidelity. Depends on [blocks-engine#382](https://github.com/Automattic/blocks-engine/pull/382) (published as 0.2.2).

## Why
The engine default (`defaultReconstructStrategy`, preserve-DOM) keeps source classes and therefore needs carried source CSS to render. The blocks reconstruct path carries **no** source CSS, so the default rendered unstyled (e.g. a Wix homepage stacked to ~20× the source height). `structuredStrategy` interprets the `SectionSpec` into clean, theme-styled canonical blocks (`renderCover`/`renderCardGrid`/…) that render from the theme alone.

Local-convert and theme-carry paths are **unchanged** — they stay on the engine default, which is byte-identical.

## Changes
- `@automattic/blocks-engine` `^0.1.0` → `^0.2.2` (+ lockfile; the bundled runtime also shrinks the install footprint).
- Blocks path (`reconstructPagePattern`) selects `structuredStrategy`.
- **Media fix:** `rewriteMediaUrls` post-pass so native `wp:image` variant URLs resolve to the migrated upload — the engine routes only island media through `mediaUrlMap`, so native images otherwise leaked the source CDN URL and tripped the remote-asset gate.
- **Provenance fix:** whitespace-insensitive heading containment in `validateArtifacts` — a heading that differs from its captured source entry only by inter-segment whitespace (e.g. an email/phone pair the engine joins with a space) now passes; the per-entry check is preserved, so cross-entry word-stitching still fails.
- Reconciles two island-era test expectations to the structured native output (un-migrated remote image → native missing-media placeholder; captured form → single native `jetpack/contact-form`).

## Test plan
- `tsc` clean; full suite green (1597). Wiring `structuredStrategy` auto-recovered 19 of the 21 strategy-sensitive tests; 2 stale island-era expectations updated.
- Dogfood (swiftlumber, Wix): blocks path now reconstructs gate-passing structured blocks (1 cover / column blocks / gallery, 0 preserved source classes, 0 islands, 0 remote URLs) and renders theme-styled chrome + `wp:cover` hero + gallery at ~source height. Restaurant local-convert path still 0.999 (default strategy, unaffected).