### PR TITLE
Remove stub commands that shadow skills

### DIFF
--- a/commands/adapt.md
+++ b/commands/adapt.md
@@ -1,6 +1,0 @@
----
-name: adapt
-description: Build a new platform adapter to extract content from an unsupported platform
----
-
-Run the adapt skill to add extraction support for a new platform (Blogger, Ghost, Weebly, etc.).

--- a/commands/diagnose.md
+++ b/commands/diagnose.md
@@ -1,6 +1,0 @@
----
-name: diagnose
-description: Debug failed or low-quality extractions by analyzing logs and probing the source site
----
-
-Run the diagnose skill to investigate extraction failures, identify root causes, and fix them.

--- a/commands/liberate.md
+++ b/commands/liberate.md
@@ -1,6 +1,0 @@
----
-name: liberate
-description: Extract content from a website into a WordPress-compatible WXR file
----
-
-Run the liberate skill to extract content from a closed web platform.

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -1,6 +1,0 @@
----
-name: qa
-description: Compare extracted WXR content against the original source site and fix discrepancies
----
-
-Run the QA skill to verify extraction quality. Compares each page in the WXR against its original source URL, reports content gaps, and optionally fixes them.


### PR DESCRIPTION
## Summary

Ports the command cleanup from Automattic/studio#4682 into the standalone Data Liberation Agent repository.

The plugin declared commands and skills with the same `adapt`, `diagnose`, `liberate`, and `qa` names. Claude surfaces both as slash commands, but the command variants were one-line stubs that could bypass the routing and required checkpoints in the full skill workflows. Removing the stubs leaves the skills as the single authoritative entry point.

Matthew Batchelder remains the commit author for the original change.

## Verification

- `npm run build`
- `npm test` (296 files passed, 1 skipped; 3,019 tests passed, 1 todo)
- `npm run test:package`
- `npm audit --omit=dev` (0 vulnerabilities)
- `git diff --check`

## AI assistance

OpenAI GPT-5.6-Sol was used through OpenCode to inspect the standalone and Studio histories, port the exact four-file deletion, run verification, preserve original authorship, and prepare this pull request. Chris Huber reviewed and directed the work.