### PR TITLE
Liberate a site from a bare URL

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,10 +19,11 @@ if (args[0] === 'mcp') {
   console.log('0.1.0');
 } else if (args[0] === '--help' || args.length === 0) {
   console.log(`
-  data-liberation — Extract content from closed web platforms into WXR files
+  data-liberation — Liberate any website into a complete, portable HTML site
 
   Usage:
-    data-liberation <url>              Extract content from a website
+    data-liberation <url>              Liberate a website into a portable HTML site
+    data-liberation extract <url>      Extract content into a WXR file (WordPress path)
     data-liberation inspect <url>      Inspect a site before extraction
     data-liberation import <wxr-file>  Import WXR file to WordPress
     data-liberation qa <wxr-file>        Compare WXR against source site
@@ -33,6 +34,12 @@ if (args[0] === 'mcp') {
     data-liberation design-foundation <outputDir>  Build/validate design-foundation.json (agent fallback)
     data-liberation mcp                Start MCP server (stdio transport)
     data-liberation --version          Show version
+
+  Liberate options:
+    --output <dir>       Output base directory (default: <Studio root>/_liberations; override with --output or DLA_OUTPUT_DIR)
+    --resume             Reuse artifacts already on disk instead of recapturing
+    --screenshots        Also capture full-page + scrolled PNG screenshots
+    --no-serve           Write the site and exit without serving it locally
 
   Extract options:
     --output <dir>       Output directory (default: <Studio root>/_liberations/<hostname>; override with --output or DLA_OUTPUT_DIR)
@@ -268,10 +275,10 @@ if (args[0] === 'mcp') {
 
   const { runImport } = await import('./ui/import.js');
   runImport({ wxrFile, site: site as string, username: username as string, token: token as string, dryRun, delay, verbose, only, importAuthors });
-} else {
-  const url = args.find((a: string) => !a.startsWith('-'));
+} else if (args[0] === 'extract') {
+  const url = args.slice(1).find((a: string) => !a.startsWith('-'));
   if (!url) {
-    console.error('Error: URL required. Run with --help for usage.');
+    console.error('Error: URL required. Usage: data-liberation extract <url>');
     process.exit(1);
   }
 
@@ -339,5 +346,44 @@ if (args[0] === 'mcp') {
     // Legacy batch path. Pre-streaming behavior: discover → extract → screenshot.
     const { runDiscover } = await import('./ui/discover.js');
     runDiscover(url, { outputDir, dryRun, resume, verbose, delay, limit, token, cdpPort, adminToken, shopDomain, nonInteractive, screenshots, screenshotsConcurrency });
+  }
+} else {
+  // A bare URL means full-site HTML liberation: every retained route becomes a
+  // portable local site that runs on its own.
+  const url = args.find((a: string) => !a.startsWith('-'));
+  if (!url) {
+    console.error('Error: URL required. Run with --help for usage.');
+    process.exit(1);
+  }
+
+  const { liberateSite } = await import('./ui/liberate.js');
+  const result = await liberateSite({
+    url,
+    outputBase: getArg('--output') || resolveOutputBase(),
+    resume: args.includes('--resume'),
+    screenshots: args.includes('--screenshots'),
+    serve: !args.includes('--no-serve'),
+    log: (message) => process.stderr.write(`${message}\n`),
+  });
+
+  const notes = [
+    result.routesSkipped ? `${result.routesSkipped} reused` : '',
+    result.routesFailed ? `${result.routesFailed} failed` : '',
+  ].filter(Boolean);
+  console.log(
+    `Liberated ${result.routesCaptured + result.routesSkipped}/${result.routesDiscovered} routes` +
+      (notes.length ? ` (${notes.join(', ')})` : ''),
+  );
+  console.log(`Site: ${result.websiteDir}`);
+
+  const server = result.server;
+  if (server) {
+    console.log(`Serving: ${server.url}`);
+    console.log('Press Ctrl+C to stop.');
+    const stop = () => {
+      void server.close().then(() => process.exit(0));
+    };
+    process.once('SIGINT', stop);
+    process.once('SIGTERM', stop);
   }
 }

--- a/src/ui/liberate.test.ts
+++ b/src/ui/liberate.test.ts
@@ -1,0 +1,115 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { captureWebsite } from '../lib/capture.js';
+import { liberateSite } from './liberate.js';
+import type { StaticServer } from '../lib/replicate/local-site/static-server.js';
+
+vi.mock( '../lib/capture.js', () => ( { captureWebsite: vi.fn() } ) );
+
+const root = join( process.cwd(), '.tmp-test' );
+
+let server: StaticServer | null = null;
+const dirs: string[] = [];
+
+afterEach( async () => {
+	if ( server ) await server.close();
+	server = null;
+	for ( const dir of dirs.splice( 0 ) ) rmSync( dir, { recursive: true, force: true } );
+} );
+
+function liberatedSite( outputDir: string ): void {
+	const websiteDir = join( outputDir, 'website' );
+	mkdirSync( websiteDir, { recursive: true } );
+	writeFileSync(
+		join( websiteDir, 'index.html' ),
+		'<h1>Home</h1><a href="/about/">About</a><link rel="stylesheet" href="/site.css">'
+	);
+	writeFileSync( join( websiteDir, 'about.html' ), '<h1>About</h1>' );
+	writeFileSync( join( websiteDir, 'site.css' ), 'body{color:red}' );
+}
+
+describe( 'liberateSite', () => {
+	it( 'turns a URL into a runnable local site with working routes', async () => {
+		mkdirSync( root, { recursive: true } );
+		const outputBase = mkdtempSync( join( root, 'liberate-' ) );
+		dirs.push( outputBase );
+		vi.mocked( captureWebsite ).mockImplementationOnce( async ( options ) => {
+			liberatedSite( options.outputDir );
+			return {
+				artifactPath: join( options.outputDir, 'artifact.json' ),
+				captureReceiptPath: join( options.outputDir, 'capture-receipt.json' ),
+				outputDir: options.outputDir,
+				summary: {
+					routesDiscovered: 2,
+					routesCaptured: 2,
+					routesSkipped: 0,
+					routesFailed: 0,
+					durationMs: 10,
+				},
+				failures: [],
+				discoveryDiagnostics: [],
+				provenance: { provider: 'data-liberation/browser-capture', platform: 'wix' },
+			};
+		} );
+
+		const result = await liberateSite( { url: 'https://example.com/', outputBase } );
+		server = result.server;
+
+		expect( vi.mocked( captureWebsite ).mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			url: 'https://example.com/',
+			outputDir: join( outputBase, 'example.com' ),
+		} );
+		expect( result.websiteDir ).toBe( join( outputBase, 'example.com', 'website' ) );
+		expect( result.routesCaptured ).toBe( 2 );
+		expect( result.routesSkipped ).toBe( 0 );
+		expect( server ).not.toBeNull();
+
+		const get = async ( path: string ) => {
+			const response = await fetch( `${ server!.url }${ path }` );
+			return { status: response.status, body: await response.text() };
+		};
+		expect( await get( '/' ) ).toMatchObject( { status: 200, body: expect.stringContaining( 'Home' ) } );
+		expect( await get( '/about/' ) ).toMatchObject( {
+			status: 200,
+			body: expect.stringContaining( 'About' ),
+		} );
+		expect( await get( '/site.css' ) ).toMatchObject( {
+			status: 200,
+			body: expect.stringContaining( 'color:red' ),
+		} );
+	} );
+
+	it( 'writes the site without serving when serving is disabled', async () => {
+		mkdirSync( root, { recursive: true } );
+		const outputBase = mkdtempSync( join( root, 'liberate-' ) );
+		dirs.push( outputBase );
+		vi.mocked( captureWebsite ).mockImplementationOnce( async ( options ) => {
+			liberatedSite( options.outputDir );
+			return {
+				artifactPath: join( options.outputDir, 'artifact.json' ),
+				captureReceiptPath: join( options.outputDir, 'capture-receipt.json' ),
+				outputDir: options.outputDir,
+				summary: {
+					routesDiscovered: 1,
+					routesCaptured: 1,
+					routesSkipped: 0,
+					routesFailed: 0,
+					durationMs: 5,
+				},
+				failures: [],
+				discoveryDiagnostics: [],
+				provenance: { provider: 'data-liberation/browser-capture', platform: 'wix' },
+			};
+		} );
+
+		const result = await liberateSite( {
+			url: 'https://example.com/',
+			outputBase,
+			serve: false,
+		} );
+
+		expect( result.server ).toBeNull();
+		expect( result.websiteDir ).toBe( join( outputBase, 'example.com', 'website' ) );
+	} );
+} );

--- a/src/ui/liberate.ts
+++ b/src/ui/liberate.ts
@@ -1,0 +1,68 @@
+// src/ui/liberate.ts
+//
+// URL -> complete, portable HTML site. This is the product's primary path:
+// liberate every retained route into a self-contained site directory and hand
+// back a runnable local copy. No WordPress, Studio, or destination-specific
+// step participates here — the HTML on disk is the contract.
+//
+import { join } from 'node:path';
+import { captureWebsite } from '../lib/capture.js';
+import { siteOutputDir } from '../lib/paths.js';
+import { startStaticServer } from '../lib/replicate/local-site/static-server.js';
+import type { StaticServer } from '../lib/replicate/local-site/static-server.js';
+
+export interface LiberateOptions {
+	url: string;
+	/** Base directory; the site lands in a per-source subdirectory. */
+	outputBase: string;
+	resume?: boolean;
+	/** Capture PNG screenshots alongside the HTML. Default: false. */
+	screenshots?: boolean;
+	/** Serve the liberated site over HTTP. Default: true. */
+	serve?: boolean;
+	log?: ( message: string ) => void;
+}
+
+export interface LiberateResult {
+	outputDir: string;
+	websiteDir: string;
+	routesDiscovered: number;
+	routesCaptured: number;
+	/** Routes already on disk and reused instead of recaptured. */
+	routesSkipped: number;
+	routesFailed: number;
+	/** Running local server, or null when serving is disabled. */
+	server: StaticServer | null;
+}
+
+export async function liberateSite( options: LiberateOptions ): Promise< LiberateResult > {
+	const log = options.log ?? ( () => {} );
+	const outputDir = siteOutputDir( options.outputBase, options.url );
+
+	const capture = await captureWebsite( {
+		url: options.url,
+		outputDir,
+		resume: options.resume,
+		captureImages: options.screenshots,
+		onProgress: ( progress ) => {
+			if ( progress.phase === 'capturing' && progress.total ) {
+				log(
+					`[liberate] ${ progress.current ?? 0 }/${ progress.total } ${ progress.url ?? '' }`.trim()
+				);
+				return;
+			}
+			log( `[liberate] ${ progress.phase }` );
+		},
+	} );
+
+	const websiteDir = join( outputDir, 'website' );
+	return {
+		outputDir,
+		websiteDir,
+		routesDiscovered: capture.summary.routesDiscovered,
+		routesCaptured: capture.summary.routesCaptured,
+		routesSkipped: capture.summary.routesSkipped,
+		routesFailed: capture.summary.routesFailed,
+		server: options.serve === false ? null : await startStaticServer( websiteDir ),
+	};
+}


### PR DESCRIPTION
## Summary

A bare URL now means full-site HTML liberation.

```bash
data-liberation https://example.com/
```

This captures every retained route into a portable HTML site and serves it locally, so the result is runnable immediately with no WordPress, Studio, Blocks Engine, or Static Site Importer step involved. HTML on disk is the contract.

- `liberateSite()` resolves the per-source output directory, runs portable capture, and serves the site directory.
- Local serving reuses the existing sandboxed clean-URL static server, so routes such as `/about/` resolve the same way they did on the source.
- Output reports captured, reused, and failed routes, plus the site path and local URL.
- `--no-serve` writes the site and exits for scripted use.
- The previous WXR content extraction keeps its full behavior and flags behind the explicit `extract` subcommand.

## Verification

Real end-to-end run against a live site:

```
$ node dist/cli.js https://example.com/ --output <tmp>
Liberated 1/1 routes
Site: <tmp>/example.com/website
Serving: http://127.0.0.1:56153
$ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:56153/
200
```

The served page returned the liberated `Example Domain` document, and a resumed run reported `Liberated 1/1 routes (1 reused)`.

- `npm run build`
- `npm test` (297 files passed, 1 skipped; 3,023 tests passed, 1 todo)
- `npm run test:package`
- `npm audit --omit=dev` (0 vulnerabilities)
- `npx tsc --noEmit`
- New deterministic coverage proves a URL becomes a runnable local site whose home page, clean-URL route, and stylesheet all resolve.

## Notes

Naming is intentionally unchanged in this PR. The internal `capture` vocabulary becomes liberation vocabulary in a separate mechanical rename so this diff stays reviewable.

## AI assistance

OpenAI GPT-5.6-Sol was used through OpenCode to map the CLI flow, implement the liberation path, add coverage, run the live end-to-end verification, and prepare this pull request. Chris Huber directed and reviewed the work.