### PR TITLE
Compare a liberated copy to its source at unsampled widths

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,7 @@ if (args[0] === 'mcp') {
     data-liberation inspect <url>      Inspect a site before extraction
     data-liberation import <wxr-file>  Import WXR file to WordPress
     data-liberation qa <wxr-file>        Compare WXR against source site
+    data-liberation check <dir>          Compare a liberated copy to its source at unsampled widths
     data-liberation verify <output-dir>  Verify extraction results
     data-liberation setup                Validate WordPress connection
     data-liberation preview <outputDir>  Preview extraction in Studio
@@ -145,6 +146,16 @@ if (args[0] === 'mcp') {
 
   const { runQaUi } = await import('./ui/qa.js');
   runQaUi({ wxrFile, fix });
+
+} else if (args[0] === 'check') {
+  const directory = args[1];
+  if (!directory || directory.startsWith('-')) {
+    console.error('Error: directory required. Usage: data-liberation check <dir>');
+    process.exit(1);
+  }
+  const { runCheck } = await import('./ui/check.js');
+  const report = await runCheck(directory);
+  process.exit(report.pass ? 0 : 1);
 
 } else if (args[0] === 'verify') {
   const outputDir = args[1] || getArg('--output') || resolveOutputBase();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,11 +24,11 @@ if (args[0] === 'mcp') {
   Usage:
     data-liberation <url>              Liberate a website into a portable HTML site
     data-liberation publish <dir>      Publish a liberated site (--to spacefast)
+    data-liberation compare <dir>      Compare a liberated copy to its source at unsampled widths
     data-liberation extract <url>      Extract content into a WXR file (WordPress path)
     data-liberation inspect <url>      Inspect a site before extraction
     data-liberation import <wxr-file>  Import WXR file to WordPress
     data-liberation qa <wxr-file>        Compare WXR against source site
-    data-liberation check <dir>          Compare a liberated copy to its source at unsampled widths
     data-liberation verify <output-dir>  Verify extraction results
     data-liberation setup                Validate WordPress connection
     data-liberation preview <outputDir>  Preview extraction in Studio
@@ -51,10 +51,9 @@ if (args[0] === 'mcp') {
     --token <token>      Publish into your own account (or SPACEFAST_TOKEN).
                          Without it the publish is anonymous and returns a claim link.
 
-  Publish options:
-    --to <target>        Where to publish. Targets: spacefast (default)
-    --token <token>      Publish into your own account (or SPACEFAST_TOKEN).
-                         Without it the publish is anonymous and returns a claim link.
+  Compare options:
+    --screenshots        Write source/liberated/diff PNGs as evidence. Pixel score
+                         never decides pass/fail.
 
   Extract options:
     --output <dir>       Output directory (default: ~/data-liberation/<hostname>; override with --output or DLA_OUTPUT_DIR)
@@ -147,15 +146,25 @@ if (args[0] === 'mcp') {
   const { runQaUi } = await import('./ui/qa.js');
   runQaUi({ wxrFile, fix });
 
-} else if (args[0] === 'check') {
+} else if (args[0] === 'compare' || args[0] === 'check') {
   const directory = args[1];
-  if (!directory || directory.startsWith('-')) {
-    console.error('Error: directory required. Usage: data-liberation check <dir>');
-    process.exit(1);
+  const second = args[2];
+  if (second && !second.startsWith('-')) {
+    const { compareScreenshotDirs } = await import('./lib/screenshot/compare.js');
+    const result = await compareScreenshotDirs({ originDir: directory, replicaDir: second });
+    for (const r of result.results) {
+      console.log(`${r.pathname}  desktop=${r.desktop.score?.toFixed(3) ?? r.desktop.status}  mobile=${r.mobile.score?.toFixed(3) ?? r.mobile.status}`);
+    }
+    console.log(`\nWrote ${join(second, 'comparison.json')}`);
+  } else {
+    if (!directory || directory.startsWith('-')) {
+      console.error('Error: directory required. Usage: data-liberation compare <dir> [--screenshots]');
+      process.exit(1);
+    }
+    const { runCompare } = await import('./ui/compare.js');
+    const report = await runCompare(directory, { screenshots: args.includes('--screenshots') });
+    process.exit(report.pass ? 0 : 1);
   }
-  const { runCheck } = await import('./ui/check.js');
-  const report = await runCheck(directory);
-  process.exit(report.pass ? 0 : 1);
 
 } else if (args[0] === 'verify') {
   const outputDir = args[1] || getArg('--output') || resolveOutputBase();
@@ -226,21 +235,6 @@ if (args[0] === 'mcp') {
   await runScreenshotCli({
     url, output: output!, types, limit, concurrency, browserRestartEvery, cdpPort, force, verbose, urlsFile, nonInteractive,
   });
-
-} else if (args[0] === 'compare') {
-  // TODO: expose --viewports / --diff-output-dir flags (the MCP handler already supports them).
-  const originDir = args[1];
-  const replicaDir = args[2];
-  if (!originDir || !replicaDir || originDir.startsWith('-') || replicaDir.startsWith('-')) {
-    console.error('Error: usage: data-liberation compare <originScreenshotsDir> <replicaScreenshotsDir>');
-    process.exit(1);
-  }
-  const { compareScreenshotDirs } = await import('./lib/screenshot/compare.js');
-  const result = await compareScreenshotDirs({ originDir, replicaDir });
-  for (const r of result.results) {
-    console.log(`${r.pathname}  desktop=${r.desktop.score?.toFixed(3) ?? r.desktop.status}  mobile=${r.mobile.score?.toFixed(3) ?? r.mobile.status}`);
-  }
-  console.log(`\nWrote ${join(replicaDir, 'comparison.json')}`);
 
 } else if (args[0] === 'freeze-spike') {
   const originUrl = getArg('--origin-url');

--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkFidelity, checkWidthsFor, resolveCheckDirectory } from './check.js';
+import type { LayoutObservation } from './score.js';
+
+const dirs: string[] = [];
+afterEach( () => {
+	for ( const dir of dirs.splice( 0 ) ) rmSync( dir, { recursive: true, force: true } );
+} );
+
+function liberatedRun(): string {
+	const dir = mkdtempSync( join( tmpdir(), 'dla-check-' ) );
+	dirs.push( dir );
+	mkdirSync( join( dir, 'website' ), { recursive: true } );
+	writeFileSync( join( dir, 'website', 'index.html' ), '<h1>Home</h1>' );
+	writeFileSync(
+		join( dir, 'capture-receipt.json' ),
+		JSON.stringify( { source: { url: 'https://example.com/' }, websiteRoot: 'website' } )
+	);
+	return dir;
+}
+
+const obs = ( viewport: number, extra: Partial< LayoutObservation > = {} ): LayoutObservation => ( {
+	viewport,
+	title: 'Home',
+	textChars: 10,
+	widestImage: viewport,
+	docWidth: viewport,
+	overflow: false,
+	externalHosts: [],
+	...extra,
+} );
+
+describe( 'resolveCheckDirectory', () => {
+	it( 'accepts the run directory printed by liberation', () => {
+		const run = liberatedRun();
+		expect( resolveCheckDirectory( run ).websiteDir ).toBe( join( run, 'website' ) );
+	} );
+
+	it( 'accepts the website directory itself', () => {
+		const run = liberatedRun();
+		expect( resolveCheckDirectory( join( run, 'website' ) ).receiptPath ).toBe(
+			join( run, 'capture-receipt.json' )
+		);
+	} );
+
+	it( 'rejects a directory with no receipt', () => {
+		const dir = mkdtempSync( join( tmpdir(), 'dla-check-' ) );
+		dirs.push( dir );
+		expect( () => resolveCheckDirectory( dir ) ).toThrow( /capture-receipt/ );
+	} );
+} );
+
+describe( 'checkWidthsFor', () => {
+	it( 'drops widths the sweep already sampled', () => {
+		expect( checkWidthsFor( [ 1440, 1600, 1920 ] ) ).toEqual( [ 1728 ] );
+	} );
+} );
+
+describe( 'checkFidelity', () => {
+	it( 'scores injected observations at each unsampled width', async () => {
+		const seen: number[] = [];
+		const report = await checkFidelity( {
+			directory: liberatedRun(),
+			observe: async ( _source, _local, viewport ) => {
+				seen.push( viewport );
+				return { source: obs( viewport ), liberated: obs( viewport ) };
+			},
+		} );
+		expect( seen ).toEqual( [ 1600, 1728 ] );
+		expect( report.pass ).toBe( true );
+		expect( report.sourceUrl ).toBe( 'https://example.com/' );
+	} );
+
+	it( 'fails the report when any viewport freezes', async () => {
+		const report = await checkFidelity( {
+			directory: liberatedRun(),
+			widths: [ 1600 ],
+			observe: async ( _source, _local, viewport ) => ( {
+				source: obs( viewport ),
+				liberated: obs( viewport, { widestImage: 1440 } ),
+			} ),
+		} );
+		expect( report.pass ).toBe( false );
+		expect( report.failed ).toBe( 1 );
+	} );
+} );

--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PNG } from 'pngjs';
 import { afterEach, describe, expect, it } from 'vitest';
 import { checkFidelity, checkWidthsFor, resolveCheckDirectory } from './check.js';
 import type { LayoutObservation } from './score.js';
@@ -85,5 +86,29 @@ describe( 'checkFidelity', () => {
 		} );
 		expect( report.pass ).toBe( false );
 		expect( report.failed ).toBe( 1 );
+	} );
+
+	it( 'records a pixel score as evidence without letting it fail the gate', async () => {
+		const black = new PNG( { width: 4, height: 4 } );
+		const white = new PNG( { width: 4, height: 4 } );
+		for ( let i = 0; i < black.data.length; i += 4 ) {
+			black.data[ i + 3 ] = 255;
+			white.data[ i ] = 255;
+			white.data[ i + 1 ] = 255;
+			white.data[ i + 2 ] = 255;
+			white.data[ i + 3 ] = 255;
+		}
+		const report = await checkFidelity( {
+			directory: liberatedRun(),
+			widths: [ 1600 ],
+			observe: async ( _source, _local, viewport ) => ( {
+				source: obs( viewport ),
+				liberated: obs( viewport ),
+				sourcePng: PNG.sync.write( black ),
+				liberatedPng: PNG.sync.write( white ),
+			} ),
+		} );
+		expect( report.pass ).toBe( true );
+		expect( report.scores[ 0 ]?.notes.join( ' ' ) ).toMatch( /evidence, not a gate/ );
 	} );
 } );

--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -1,0 +1,168 @@
+// src/lib/fidelity/check.ts
+//
+// Compare a liberated copy against its live source at viewports the capture
+// sweep never sampled. Measuring only at the capture width would certify the
+// freeze we already shipped once.
+//
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { chromium, type Page } from 'playwright';
+import { startStaticServer } from '../replicate/local-site/static-server.js';
+import { DEFAULT_SWEEP_WIDTHS } from '../screenshot/fluid-capture.js';
+import { scoreReport, scoreViewport, type LayoutObservation, type ViewportScore } from './score.js';
+
+/**
+ * Widths the learning sweep does not visit. 1600 and 1728 sit above the
+ * capture width and are what exposed the freeze. 900 is omitted on purpose:
+ * per-device sources switch documents by CSS at the detected floor, while a
+ * desktop-UA load of the live source does not, so that width compares two
+ * different designs.
+ */
+export const DEFAULT_CHECK_WIDTHS = [ 1600, 1728 ];
+
+export type ObservePair = (
+	sourceUrl: string,
+	localUrl: string,
+	viewport: number
+) => Promise< { source: LayoutObservation; liberated: LayoutObservation } >;
+
+export interface FidelityCheckOptions {
+	directory: string;
+	widths?: number[];
+	/** Pathnames to check, e.g. `/` and `/about/`. Default: homepage only. */
+	routes?: string[];
+	settleMs?: number;
+	log?: ( ( message: string ) => void ) | undefined;
+	observe?: ObservePair;
+}
+
+export interface FidelityReport {
+	sourceUrl: string;
+	websiteDir: string;
+	widths: number[];
+	routes: string[];
+	scores: ViewportScore[];
+	pass: boolean;
+	failed: number;
+	passed: number;
+}
+
+interface CaptureReceipt {
+	source?: { url?: string };
+}
+
+export function resolveCheckDirectory( directory: string ): {
+	websiteDir: string;
+	receiptPath: string;
+} {
+	const absolute = resolve( directory );
+	if ( ! existsSync( absolute ) || ! statSync( absolute ).isDirectory() ) {
+		throw new Error( `Not a directory: ${ absolute }` );
+	}
+	const nestedReceipt = join( absolute, 'capture-receipt.json' );
+	const nestedWebsite = join( absolute, 'website' );
+	if ( existsSync( nestedReceipt ) && existsSync( nestedWebsite ) ) {
+		return { websiteDir: nestedWebsite, receiptPath: nestedReceipt };
+	}
+	const parentReceipt = join( absolute, '..', 'capture-receipt.json' );
+	if ( existsSync( parentReceipt ) ) {
+		return { websiteDir: absolute, receiptPath: parentReceipt };
+	}
+	throw new Error(
+		`No capture-receipt.json next to ${ absolute }. Point check at a liberated run directory.`
+	);
+}
+
+export function checkWidthsFor( sampled: number[] = DEFAULT_SWEEP_WIDTHS ): number[] {
+	return DEFAULT_CHECK_WIDTHS.filter( ( width ) => ! sampled.includes( width ) );
+}
+
+async function observePage(
+	page: Page,
+	url: string,
+	viewport: number,
+	settleMs: number,
+	localOrigin: string | null
+): Promise< LayoutObservation > {
+	const external = new Set< string >();
+	const onRequest = ( request: { url: () => string } ): void => {
+		if ( ! localOrigin ) return;
+		const href = request.url();
+		if ( href.startsWith( 'data:' ) || href.startsWith( 'blob:' ) || href.startsWith( localOrigin ) ) return;
+		try {
+			external.add( new URL( href ).host );
+		} catch {
+			/* ignore unparseable */
+		}
+	};
+	page.on( 'request', onRequest );
+	try {
+		await page.goto( url, { waitUntil: 'domcontentloaded', timeout: 60_000 } ).catch( () => {} );
+		await page.waitForTimeout( settleMs );
+		const measured = await page.evaluate( () => {
+			const images = [ ...document.querySelectorAll( 'img' ) ]
+				.map( ( image ) => image.getBoundingClientRect() )
+				.filter( ( rect ) => rect.width > 50 && rect.height > 50 );
+			return {
+				title: document.title,
+				textChars: ( document.body?.innerText ?? '' ).replace( /\s+/g, ' ' ).trim().length,
+				widestImage: images.length
+					? Math.round( Math.max( ...images.map( ( rect ) => rect.width ) ) )
+					: null,
+				docWidth: document.documentElement.scrollWidth,
+				overflow: document.documentElement.scrollWidth > window.innerWidth,
+			};
+		} );
+		return { viewport, ...measured, externalHosts: [ ...external ].sort() };
+	} finally {
+		page.off( 'request', onRequest );
+	}
+}
+
+export async function checkFidelity( options: FidelityCheckOptions ): Promise< FidelityReport > {
+	const log = options.log ?? ( () => {} );
+	const { websiteDir, receiptPath } = resolveCheckDirectory( options.directory );
+	const receipt = JSON.parse( readFileSync( receiptPath, 'utf8' ) ) as CaptureReceipt;
+	const sourceUrl = receipt.source?.url;
+	if ( ! sourceUrl ) throw new Error( `capture-receipt.json has no source.url: ${ receiptPath }` );
+
+	const widths = options.widths ?? checkWidthsFor();
+	const routes = options.routes ?? [ '/' ];
+	const settleMs = options.settleMs ?? 4000;
+
+	let observe = options.observe;
+	const server = observe ? null : await startStaticServer( websiteDir );
+	const browser = observe ? null : await chromium.launch();
+	const page = browser ? await browser.newPage() : null;
+	if ( ! observe ) {
+		observe = async ( sourceHref, localHref, viewport ) => {
+			if ( ! page ) throw new Error( 'browser page missing' );
+			await page.setViewportSize( { width: viewport, height: 900 } );
+			return {
+				source: await observePage( page, sourceHref, viewport, settleMs, null ),
+				liberated: await observePage( page, localHref, viewport, settleMs, new URL( localHref ).origin ),
+			};
+		};
+	}
+
+	const scores: ViewportScore[] = [];
+	try {
+		for ( const route of routes ) {
+			const sourceHref = new URL( route, sourceUrl ).href;
+			const localHref = `${ server?.url ?? 'http://liberated.invalid' }${
+				route.startsWith( '/' ) ? route : `/${ route }`
+			}`;
+			for ( const width of widths ) {
+				log( `[check] ${ route } @ ${ width }px` );
+				const pair = await observe( sourceHref, localHref, width );
+				scores.push( scoreViewport( pair.source, pair.liberated ) );
+			}
+		}
+	} finally {
+		await browser?.close();
+		await server?.close();
+	}
+
+	const summary = scoreReport( scores );
+	return { sourceUrl, websiteDir, widths, routes, scores, ...summary };
+}

--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -5,10 +5,11 @@
 // freeze we already shipped once.
 //
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { chromium, type Page } from 'playwright';
 import { startStaticServer } from '../replicate/local-site/static-server.js';
 import { DEFAULT_SWEEP_WIDTHS } from '../screenshot/fluid-capture.js';
+import { writePixelEvidence } from './evidence.js';
 import { scoreReport, scoreViewport, type LayoutObservation, type ViewportScore } from './score.js';
 
 /**
@@ -24,7 +25,12 @@ export type ObservePair = (
 	sourceUrl: string,
 	localUrl: string,
 	viewport: number
-) => Promise< { source: LayoutObservation; liberated: LayoutObservation } >;
+) => Promise< {
+	source: LayoutObservation;
+	liberated: LayoutObservation;
+	sourcePng?: Buffer;
+	liberatedPng?: Buffer;
+} >;
 
 export interface FidelityCheckOptions {
 	directory: string;
@@ -32,6 +38,8 @@ export interface FidelityCheckOptions {
 	/** Pathnames to check, e.g. `/` and `/about/`. Default: homepage only. */
 	routes?: string[];
 	settleMs?: number;
+	/** Write source/liberated/diff PNGs. Never used as pass/fail. */
+	screenshots?: boolean;
 	log?: ( ( message: string ) => void ) | undefined;
 	observe?: ObservePair;
 }
@@ -138,10 +146,17 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 		observe = async ( sourceHref, localHref, viewport ) => {
 			if ( ! page ) throw new Error( 'browser page missing' );
 			await page.setViewportSize( { width: viewport, height: 900 } );
-			return {
-				source: await observePage( page, sourceHref, viewport, settleMs, null ),
-				liberated: await observePage( page, localHref, viewport, settleMs, new URL( localHref ).origin ),
-			};
+			const source = await observePage( page, sourceHref, viewport, settleMs, null );
+			const sourcePng = options.screenshots ? await page.screenshot() : undefined;
+			const liberated = await observePage(
+				page,
+				localHref,
+				viewport,
+				settleMs,
+				new URL( localHref ).origin
+			);
+			const liberatedPng = options.screenshots ? await page.screenshot() : undefined;
+			return { source, liberated, sourcePng, liberatedPng };
 		};
 	}
 
@@ -153,9 +168,21 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 				route.startsWith( '/' ) ? route : `/${ route }`
 			}`;
 			for ( const width of widths ) {
-				log( `[check] ${ route } @ ${ width }px` );
+				log( `[compare] ${ route } @ ${ width }px` );
 				const pair = await observe( sourceHref, localHref, width );
-				scores.push( scoreViewport( pair.source, pair.liberated ) );
+				const score = scoreViewport( pair.source, pair.liberated );
+				if ( pair.sourcePng && pair.liberatedPng ) {
+					const evidenceDir = join( dirname( receiptPath ), 'compare', String( width ) );
+					const evidence = writePixelEvidence( evidenceDir, pair.sourcePng, pair.liberatedPng );
+					if ( 'score' in evidence ) {
+						score.notes.push(
+							`pixel ${ evidence.score.toFixed( 4 ) } (evidence, not a gate) → ${ evidence.diffPath }`
+						);
+					} else {
+						score.notes.push( evidence.error );
+					}
+				}
+				scores.push( score );
 			}
 		}
 	} finally {

--- a/src/lib/fidelity/evidence.test.ts
+++ b/src/lib/fidelity/evidence.test.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PNG } from 'pngjs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { writePixelEvidence } from './evidence.js';
+
+const dirs: string[] = [];
+afterEach( () => {
+	for ( const dir of dirs.splice( 0 ) ) rmSync( dir, { recursive: true, force: true } );
+} );
+
+function png( width: number, height: number, fill: [ number, number, number, number ] ): Buffer {
+	const image = new PNG( { width, height } );
+	for ( let i = 0; i < image.data.length; i += 4 ) {
+		image.data[ i ] = fill[ 0 ]!;
+		image.data[ i + 1 ] = fill[ 1 ]!;
+		image.data[ i + 2 ] = fill[ 2 ]!;
+		image.data[ i + 3 ] = fill[ 3 ]!;
+	}
+	return PNG.sync.write( image );
+}
+
+describe( 'writePixelEvidence', () => {
+	it( 'writes the pair and a diff, and scores identical shots as 1', () => {
+		const dir = mkdtempSync( join( tmpdir(), 'dla-evidence-' ) );
+		dirs.push( dir );
+		const shot = png( 8, 8, [ 0, 0, 0, 255 ] );
+		const result = writePixelEvidence( dir, shot, shot );
+		expect( result ).toMatchObject( { score: 1 } );
+		if ( 'diffPath' in result ) expect( readFileSync( result.diffPath ).length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'scores a total mismatch below 1 without throwing', () => {
+		const dir = mkdtempSync( join( tmpdir(), 'dla-evidence-' ) );
+		dirs.push( dir );
+		const result = writePixelEvidence(
+			dir,
+			png( 8, 8, [ 0, 0, 0, 255 ] ),
+			png( 8, 8, [ 255, 255, 255, 255 ] )
+		);
+		expect( 'score' in result && result.score ).toBeLessThan( 1 );
+	} );
+} );

--- a/src/lib/fidelity/evidence.ts
+++ b/src/lib/fidelity/evidence.ts
@@ -1,0 +1,50 @@
+// src/lib/fidelity/evidence.ts
+//
+// Optional PNG pair + diff for a human looking at a compare failure.
+// The pixel score is never a pass/fail input — that is how 0.98 blessed the freeze.
+//
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PNG } from 'pngjs';
+import pixelmatch from 'pixelmatch';
+
+export interface PixelEvidence {
+	score: number;
+	sourcePath: string;
+	liberatedPath: string;
+	diffPath: string;
+}
+
+export function writePixelEvidence(
+	directory: string,
+	sourcePng: Buffer,
+	liberatedPng: Buffer
+): PixelEvidence | { error: string } {
+	mkdirSync( directory, { recursive: true } );
+	const sourcePath = join( directory, 'source.png' );
+	const liberatedPath = join( directory, 'liberated.png' );
+	const diffPath = join( directory, 'diff.png' );
+	writeFileSync( sourcePath, sourcePng );
+	writeFileSync( liberatedPath, liberatedPng );
+
+	const source = PNG.sync.read( sourcePng );
+	const liberated = PNG.sync.read( liberatedPng );
+	if ( source.width !== liberated.width || source.height !== liberated.height ) {
+		return {
+			error: `screenshot size ${ liberated.width }x${ liberated.height } !== source ${ source.width }x${ source.height }`,
+		};
+	}
+
+	const diff = new PNG( { width: source.width, height: source.height } );
+	const diffPixels = pixelmatch(
+		source.data,
+		liberated.data,
+		diff.data,
+		source.width,
+		source.height,
+		{ threshold: 0.1 }
+	);
+	writeFileSync( diffPath, PNG.sync.write( diff ) );
+	const score = 1 - diffPixels / ( source.width * source.height );
+	return { score, sourcePath, liberatedPath, diffPath };
+}

--- a/src/lib/fidelity/score.test.ts
+++ b/src/lib/fidelity/score.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { scoreReport, scoreViewport, type LayoutObservation } from './score.js';
+
+const at = ( viewport: number, extra: Partial< LayoutObservation > = {} ): LayoutObservation => ( {
+	viewport,
+	title: 'Home',
+	textChars: 336,
+	widestImage: viewport,
+	docWidth: viewport,
+	overflow: false,
+	externalHosts: [],
+	...extra,
+} );
+
+describe( 'scoreViewport', () => {
+	it( 'passes when the copy matches the source at an unsampled width', () => {
+		const score = scoreViewport( at( 1600 ), at( 1600 ) );
+		expect( score.pass ).toBe( true );
+		expect( score.failures ).toEqual( [] );
+	} );
+
+	it( 'fails when the copy is frozen at the capture width', () => {
+		// The Roeeby freeze: source is 1600, copy stuck at 1440.
+		const score = scoreViewport( at( 1600 ), at( 1600, { widestImage: 1440 } ) );
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /widest image 1440px !== source 1600px/ );
+	} );
+
+	it( 'fails when the copy overflows and the source does not', () => {
+		const score = scoreViewport(
+			at( 900, { docWidth: 900 } ),
+			at( 900, { docWidth: 980, overflow: true } )
+		);
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /horizontal overflow/ );
+	} );
+
+	it( 'allows overflow only when the source also overflows', () => {
+		const score = scoreViewport(
+			at( 390, { docWidth: 980, overflow: true, widestImage: 980 } ),
+			at( 390, { docWidth: 980, overflow: true, widestImage: 980 } )
+		);
+		expect( score.pass ).toBe( true );
+	} );
+
+	it( 'fails when the copy still talks to the source CDN', () => {
+		const score = scoreViewport(
+			at( 1440 ),
+			at( 1440, { externalHosts: [ 'siteassets.parastorage.com' ] } )
+		);
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /parastorage/ );
+	} );
+
+	it( 'fails on text or title drift', () => {
+		expect( scoreViewport( at( 1440 ), at( 1440, { textChars: 300 } ) ).pass ).toBe( false );
+		expect( scoreViewport( at( 1440 ), at( 1440, { title: 'Other' } ) ).pass ).toBe( false );
+	} );
+
+	it( 'tolerates one pixel of image rounding', () => {
+		expect( scoreViewport( at( 1440, { widestImage: 1440 } ), at( 1440, { widestImage: 1441 } ) ).pass ).toBe(
+			true
+		);
+	} );
+
+	it( 'refuses to score mismatched viewports', () => {
+		expect( () => scoreViewport( at( 1440 ), at( 1600 ) ) ).toThrow( /mismatched viewports/ );
+	} );
+} );
+
+describe( 'scoreReport', () => {
+	it( 'passes only when every viewport passes', () => {
+		const ok = scoreViewport( at( 1600 ), at( 1600 ) );
+		const bad = scoreViewport( at( 1728 ), at( 1728, { widestImage: 1440 } ) );
+		expect( scoreReport( [ ok ] ) ).toEqual( { pass: true, failed: 0, passed: 1 } );
+		expect( scoreReport( [ ok, bad ] ) ).toEqual( { pass: false, failed: 1, passed: 1 } );
+	} );
+} );

--- a/src/lib/fidelity/score.ts
+++ b/src/lib/fidelity/score.ts
@@ -1,0 +1,96 @@
+// src/lib/fidelity/score.ts
+//
+// Score a source observation against the liberated copy at one viewport.
+//
+// The gate that would have caught the frozen-layout bug: measuring only at the
+// capture width certifies the exact failure mode. This compares at a width the
+// caller chose, and the check runner picks widths the sweep never sampled.
+//
+export interface LayoutObservation {
+	/** Viewport width the observation was taken at. */
+	viewport: number;
+	title: string;
+	/** Visible text length after collapsing whitespace. */
+	textChars: number;
+	/** Widest visible image, in CSS pixels. Null when none. */
+	widestImage: number | null;
+	/** documentElement.scrollWidth. */
+	docWidth: number;
+	/** True when the document is wider than the viewport. */
+	overflow: boolean;
+	/** Hosts the page requested that are not the local copy. */
+	externalHosts: string[];
+}
+
+export interface ViewportScore {
+	viewport: number;
+	pass: boolean;
+	failures: string[];
+	notes: string[];
+	source: LayoutObservation;
+	liberated: LayoutObservation;
+}
+
+/** Image width may drift by a pixel of rounding; more than this is a freeze. */
+export const IMAGE_TOLERANCE_PX = 2;
+
+export function scoreViewport(
+	source: LayoutObservation,
+	liberated: LayoutObservation
+): ViewportScore {
+	if ( source.viewport !== liberated.viewport ) {
+		throw new Error(
+			`Cannot score mismatched viewports: source ${ source.viewport } vs liberated ${ liberated.viewport }`
+		);
+	}
+
+	const failures: string[] = [];
+	const notes: string[] = [];
+
+	if ( source.title !== liberated.title ) {
+		failures.push( `title "${ liberated.title }" !== source "${ source.title }"` );
+	}
+	if ( source.textChars !== liberated.textChars ) {
+		failures.push( `text ${ liberated.textChars } chars !== source ${ source.textChars }` );
+	}
+
+	if ( source.widestImage === null && liberated.widestImage === null ) {
+		notes.push( 'no images' );
+	} else if ( source.widestImage === null || liberated.widestImage === null ) {
+		failures.push(
+			`widest image ${ liberated.widestImage ?? 'none' } !== source ${ source.widestImage ?? 'none' }`
+		);
+	} else if ( Math.abs( liberated.widestImage - source.widestImage ) > IMAGE_TOLERANCE_PX ) {
+		failures.push(
+			`widest image ${ liberated.widestImage }px !== source ${ source.widestImage }px (Δ${
+				liberated.widestImage - source.widestImage
+			})`
+		);
+	}
+
+	if ( liberated.overflow && ! source.overflow ) {
+		failures.push( `horizontal overflow at ${ liberated.docWidth }px in a ${ liberated.viewport }px viewport` );
+	}
+
+	if ( liberated.externalHosts.length > 0 ) {
+		failures.push(
+			`copy requested ${ liberated.externalHosts.length } external host(s): ${ liberated.externalHosts
+				.slice( 0, 3 )
+				.join( ', ' ) }`
+		);
+	}
+
+	return {
+		viewport: source.viewport,
+		pass: failures.length === 0,
+		failures,
+		notes,
+		source,
+		liberated,
+	};
+}
+
+export function scoreReport( scores: ViewportScore[] ): { pass: boolean; failed: number; passed: number } {
+	const failed = scores.filter( ( score ) => ! score.pass ).length;
+	return { pass: failed === 0, failed, passed: scores.length - failed };
+}

--- a/src/ui/check.ts
+++ b/src/ui/check.ts
@@ -1,0 +1,26 @@
+// src/ui/check.ts
+//
+// `data-liberation check <dir>`: prove the liberated copy matches the source
+// at widths capture never sampled.
+//
+import { checkFidelity, type FidelityReport } from '../lib/fidelity/check.js';
+
+export async function runCheck( directory: string ): Promise< FidelityReport > {
+	const report = await checkFidelity( {
+		directory,
+		log: ( message ) => process.stderr.write( `${ message }\n` ),
+	} );
+
+	for ( const score of report.scores ) {
+		const mark = score.pass ? 'ok' : 'FAIL';
+		process.stdout.write( `${ score.viewport }px ${ mark }` );
+		if ( ! score.pass ) process.stdout.write( `: ${ score.failures.join( '; ' ) }` );
+		process.stdout.write( '\n' );
+	}
+	process.stdout.write(
+		report.pass
+			? `Passed ${ report.passed } viewport(s) against ${ report.sourceUrl }\n`
+			: `Failed ${ report.failed }/${ report.passed + report.failed } viewport(s) against ${ report.sourceUrl }\n`
+	);
+	return report;
+}

--- a/src/ui/compare.ts
+++ b/src/ui/compare.ts
@@ -1,13 +1,18 @@
-// src/ui/check.ts
+// src/ui/compare.ts
 //
-// `data-liberation check <dir>`: prove the liberated copy matches the source
-// at widths capture never sampled.
+// `data-liberation compare <dir>`: browser-compare the liberated copy to its
+// source at widths capture never sampled. `--screenshots` writes PNG evidence
+// and never decides pass/fail.
 //
 import { checkFidelity, type FidelityReport } from '../lib/fidelity/check.js';
 
-export async function runCheck( directory: string ): Promise< FidelityReport > {
+export async function runCompare(
+	directory: string,
+	options: { screenshots?: boolean } = {}
+): Promise< FidelityReport > {
 	const report = await checkFidelity( {
 		directory,
+		screenshots: options.screenshots,
 		log: ( message ) => process.stderr.write( `${ message }\n` ),
 	} );
 
@@ -15,6 +20,7 @@ export async function runCheck( directory: string ): Promise< FidelityReport > {
 		const mark = score.pass ? 'ok' : 'FAIL';
 		process.stdout.write( `${ score.viewport }px ${ mark }` );
 		if ( ! score.pass ) process.stdout.write( `: ${ score.failures.join( '; ' ) }` );
+		if ( score.notes.length ) process.stdout.write( `  (${ score.notes.join( '; ' ) })` );
 		process.stdout.write( '\n' );
 	}
 	process.stdout.write(


### PR DESCRIPTION
## Summary

The 1440px freeze passed every check that measured at the capture width. This adds the gate that would have caught it.

```bash
data-liberation compare <dir>
data-liberation compare <dir> --screenshots
```

The browser is the instrument: load the live source and the local copy at **1600 and 1728** — widths the learning sweep never visits — and fail on image-width drift, unexpected overflow, text/title mismatch, or leftover external requests.

`--screenshots` writes `compare/<width>/{source,liberated,diff}.png`. The pixel score is evidence only and never decides pass/fail. That is how 0.98 blessed the freeze.

Two directory arguments still run the old screenshot-dir pixel compare, so existing callers do not break.

`check` remains an alias for the one-directory form.

## Live results

`example.com` (declarative): **passed** both viewports.

`roeeby.com` (after fluid learning): geometry matches at 1600 and 1728. The command **fails** because the copy still requests `siteassets.parastorage.com` — leftover Wix runtime, not a layout freeze.

A frozen copy of Roeeby failed this same check with `widest image 1440px !== source 1600px`.

## Verification

- `npx vitest run` (307 files passed, 1 skipped; 3,090 tests passed, 1 todo)
- `npm run test:package`
- A test feeds a total pixel mismatch and still passes the gate when layout matches.

## AI assistance

OpenAI GPT-5.6-Sol was used through OpenCode to implement the gate, reclaim the compare verb, keep pixel diffs as evidence-only, and prepare this pull request. Chris Huber directed the work.