### PR TITLE
Fail compare when in-page or internal nav does not resolve

### DIFF
--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -31,6 +31,8 @@ const obs = ( viewport: number, extra: Partial< LayoutObservation > = {} ): Layo
 	docWidth: viewport,
 	overflow: false,
 	externalHosts: [],
+	hashTargets: [],
+	internalMissing: [],
 	...extra,
 } );
 

--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -10,7 +10,15 @@ import { chromium, type Page } from 'playwright';
 import { startStaticServer } from '../replicate/local-site/static-server.js';
 import { DEFAULT_SWEEP_WIDTHS } from '../screenshot/fluid-capture.js';
 import { writePixelEvidence } from './evidence.js';
-import { scoreReport, scoreViewport, type LayoutObservation, type ViewportScore } from './score.js';
+import {
+	scoreReport,
+	scoreViewport,
+	type HashTarget,
+	type LayoutObservation,
+	type ViewportScore,
+} from './score.js';
+
+const MAX_ROUTE_CHECKS = 32;
 
 /**
  * Widths the learning sweep does not visit. 1600 and 1728 sit above the
@@ -107,10 +115,85 @@ async function observePage(
 	try {
 		await page.goto( url, { waitUntil: 'domcontentloaded', timeout: 60_000 } ).catch( () => {} );
 		await page.waitForTimeout( settleMs );
-		const measured = await page.evaluate( () => {
+		const measured = await page.evaluate( async ( clickUnresolved: boolean ) => {
 			const images = [ ...document.querySelectorAll( 'img' ) ]
 				.map( ( image ) => image.getBoundingClientRect() )
 				.filter( ( rect ) => rect.width > 50 && rect.height > 50 );
+			const hashTargets: { fragment: string; resolved: boolean }[] = [];
+			const internalPaths: string[] = [];
+			const seen = new Set< string >();
+			for ( const link of document.querySelectorAll< HTMLAnchorElement >( 'a[href]' ) ) {
+				const href = link.getAttribute( 'href' ) ?? '';
+				if ( ! href || href === '#' ) continue;
+				let target: URL;
+				try {
+					target = new URL( href, location.href );
+				} catch {
+					continue;
+				}
+				if ( target.origin !== location.origin ) continue;
+				if ( target.hash ) {
+					let fragment: string;
+					try {
+						fragment = decodeURIComponent( target.hash.slice( 1 ) );
+					} catch {
+						continue;
+					}
+					if ( ! fragment || seen.has( `#${ fragment }` ) ) continue;
+					seen.add( `#${ fragment }` );
+					const exists = !!(
+						document.getElementById( fragment ) ||
+						document.querySelector( `[name="${ CSS.escape( fragment ) }"]` )
+					);
+					hashTargets.push( { fragment, resolved: exists } );
+				}
+				if (
+					target.pathname &&
+					target.pathname !== location.pathname &&
+					! seen.has( target.pathname )
+				) {
+					seen.add( target.pathname );
+					internalPaths.push( target.pathname );
+				}
+			}
+
+			if ( clickUnresolved ) {
+				const original = { x: scrollX, y: scrollY };
+				let clicks = 0;
+				for ( const target of hashTargets ) {
+					if ( target.resolved || clicks >= 8 ) continue;
+					const trigger = [ ...document.querySelectorAll< HTMLAnchorElement >( 'a[href]' ) ].find(
+						( link ) => {
+							try {
+								return (
+									decodeURIComponent( new URL( link.href, location.href ).hash.slice( 1 ) ) ===
+									target.fragment
+								);
+							} catch {
+								return false;
+							}
+						}
+					);
+					if ( ! trigger || trigger.getClientRects().length === 0 ) continue;
+					clicks++;
+					trigger.click();
+					let previous = scrollY;
+					let stable = 0;
+					for ( let attempt = 0; attempt < 40 && stable < 4; attempt++ ) {
+						await new Promise( ( resolve ) => setTimeout( resolve, 50 ) );
+						if ( Math.abs( scrollY - previous ) < 1 ) stable++;
+						else stable = 0;
+						previous = scrollY;
+					}
+					if ( Math.abs( scrollY - original.y ) > 4 ) target.resolved = true;
+					const root = document.documentElement;
+					const behavior = root.style.scrollBehavior;
+					root.style.scrollBehavior = 'auto';
+					window.scrollTo( original.x, original.y );
+					root.style.scrollBehavior = behavior;
+				}
+			}
+
 			return {
 				title: document.title,
 				textChars: ( document.body?.innerText ?? '' ).replace( /\s+/g, ' ' ).trim().length,
@@ -119,9 +202,30 @@ async function observePage(
 					: null,
 				docWidth: document.documentElement.scrollWidth,
 				overflow: document.documentElement.scrollWidth > window.innerWidth,
+				hashTargets,
+				internalPaths,
 			};
-		} );
-		return { viewport, ...measured, externalHosts: [ ...external ].sort() };
+		}, ! localOrigin );
+
+		const internalMissing: string[] = [];
+		if ( localOrigin ) {
+			for ( const path of measured.internalPaths.slice( 0, MAX_ROUTE_CHECKS ) ) {
+				const response = await page.request.get( `${ localOrigin }${ path }`, { timeout: 10_000 } );
+				if ( ! response.ok() ) internalMissing.push( path );
+			}
+		}
+
+		return {
+			viewport,
+			title: measured.title,
+			textChars: measured.textChars,
+			widestImage: measured.widestImage,
+			docWidth: measured.docWidth,
+			overflow: measured.overflow,
+			externalHosts: [ ...external ].sort(),
+			hashTargets: measured.hashTargets as HashTarget[],
+			internalMissing,
+		};
 	} finally {
 		page.off( 'request', onRequest );
 	}

--- a/src/lib/fidelity/score.test.ts
+++ b/src/lib/fidelity/score.test.ts
@@ -9,6 +9,8 @@ const at = ( viewport: number, extra: Partial< LayoutObservation > = {} ): Layou
 	docWidth: viewport,
 	overflow: false,
 	externalHosts: [],
+	hashTargets: [],
+	internalMissing: [],
 	...extra,
 } );
 
@@ -41,6 +43,30 @@ describe( 'scoreViewport', () => {
 			at( 390, { docWidth: 980, overflow: true, widestImage: 980 } )
 		);
 		expect( score.pass ).toBe( true );
+	} );
+
+	it( 'fails when a same-page hash has no target in the copy', () => {
+		const score = scoreViewport(
+			at( 1440, { hashTargets: [ { fragment: 'team', resolved: true } ] } ),
+			at( 1440, { hashTargets: [ { fragment: 'team', resolved: false } ] } )
+		);
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /#team/ );
+	} );
+
+	it( 'fails when the source hash worked and the copy dropped it', () => {
+		const score = scoreViewport(
+			at( 1440, { hashTargets: [ { fragment: 'features', resolved: true } ] } ),
+			at( 1440 )
+		);
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /#features/ );
+	} );
+
+	it( 'fails when an internal path 404s in the copy', () => {
+		const score = scoreViewport( at( 1440 ), at( 1440, { internalMissing: [ '/about/' ] } ) );
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /\/about\// );
 	} );
 
 	it( 'fails when the copy still talks to the source CDN', () => {

--- a/src/lib/fidelity/score.ts
+++ b/src/lib/fidelity/score.ts
@@ -20,6 +20,15 @@ export interface LayoutObservation {
 	overflow: boolean;
 	/** Hosts the page requested that are not the local copy. */
 	externalHosts: string[];
+	/** Same-page hash targets found on this document. */
+	hashTargets: HashTarget[];
+	/** Internal pathnames whose local copy 404s. Empty on the live source. */
+	internalMissing: string[];
+}
+
+export interface HashTarget {
+	fragment: string;
+	resolved: boolean;
 }
 
 export interface ViewportScore {
@@ -75,6 +84,37 @@ export function scoreViewport(
 	if ( liberated.externalHosts.length > 0 ) {
 		failures.push(
 			`copy requested ${ liberated.externalHosts.length } external host(s): ${ liberated.externalHosts
+				.slice( 0, 3 )
+				.join( ', ' ) }`
+		);
+	}
+
+	const copyUnresolved = liberated.hashTargets
+		.filter( ( target ) => ! target.resolved )
+		.map( ( target ) => target.fragment );
+	if ( copyUnresolved.length > 0 ) {
+		failures.push(
+			`nav ${ copyUnresolved.length } same-page anchor(s) missing: #${ copyUnresolved
+				.slice( 0, 3 )
+				.join( ' #' ) }`
+		);
+	} else {
+		const copyResolved = new Set(
+			liberated.hashTargets.filter( ( target ) => target.resolved ).map( ( target ) => target.fragment )
+		);
+		const lost = source.hashTargets
+			.filter( ( target ) => target.resolved && ! copyResolved.has( target.fragment ) )
+			.map( ( target ) => target.fragment );
+		if ( lost.length > 0 ) {
+			failures.push(
+				`nav ${ lost.length } same-page anchor(s) missing: #${ lost.slice( 0, 3 ).join( ' #' ) }`
+			);
+		}
+	}
+
+	if ( liberated.internalMissing.length > 0 ) {
+		failures.push(
+			`nav ${ liberated.internalMissing.length } internal link(s) 404: ${ liberated.internalMissing
 				.slice( 0, 3 )
 				.join( ', ' ) }`
 		);


### PR DESCRIPTION
## Summary

Matt's first functional observation was that navigation did not work. `compare` did not check it.

The browser is still the instrument:

- Same-page hashes must have a target in the copy (`id` or `name`). If the live source only resolves them by scrolling, that still counts as a working source hash — the copy has no runtime, so a missing target is a fail.
- Internal path links on the copy must not 404.

Editorial external links are ignored. Empty-href widgets (Roeeby's Contact dialog) are not navigation.

## Live result

`data-liberation compare` on the current Roeeby copy still **passes** at 1600 and 1728. That site has no same-page hash links; its `About` / project hrefs already rewrite to local files. The Wix adapter from Studio `dbd9e2ba5` stays unported until this gate fails a site that actually uses runtime hashes.

## Verification

- `npx vitest run src/lib/fidelity` (21 passed)
- Live `compare` on `/Users/chubes/data-liberation/www.roeeby.com`

## AI assistance

OpenAI GPT-5.6-Sol was used through OpenCode to add the nav observations, scoring, tests, and this pull request. Chris Huber directed the work.