### PR TITLE
Fail compare when a source dialog does not open in the copy

### DIFF
--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -33,6 +33,7 @@ const obs = ( viewport: number, extra: Partial< LayoutObservation > = {} ): Layo
 	externalHosts: [],
 	hashTargets: [],
 	internalMissing: [],
+	dialogs: [],
 	...extra,
 } );
 
@@ -72,7 +73,7 @@ describe( 'checkFidelity', () => {
 				return { source: obs( viewport ), liberated: obs( viewport ) };
 			},
 		} );
-		expect( seen ).toEqual( [ 1600, 1728 ] );
+		expect( seen ).toEqual( [ 1600, 1728, 390 ] );
 		expect( report.pass ).toBe( true );
 		expect( report.sourceUrl ).toBe( 'https://example.com/' );
 	} );

--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -13,6 +13,7 @@ import { writePixelEvidence } from './evidence.js';
 import {
 	scoreReport,
 	scoreViewport,
+	type DialogProbe,
 	type HashTarget,
 	type LayoutObservation,
 	type ViewportScore,
@@ -215,6 +216,53 @@ async function observePage(
 			}
 		}
 
+		const dialogs = ( await page.evaluate( `(async () => {
+			const isShown = (element) => {
+				const rect = element.getBoundingClientRect();
+				const style = getComputedStyle(element);
+				return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+			};
+			const openCount = () =>
+				[...document.querySelectorAll('[role="dialog"],[aria-modal="true"],dialog[open]')].filter(isShown).length;
+			const triggers = [...document.querySelectorAll('button,a[aria-haspopup],summary,[aria-expanded]')]
+				.filter((element) => {
+					if (!isShown(element)) return false;
+					if (element.getAttribute('aria-disabled') === 'true') return false;
+					const href = element.tagName === 'A' ? (element.getAttribute('href') || '').trim() : '';
+					if (href && href !== '#' && !href.startsWith('#')) return false;
+					if (element.tagName === 'SUMMARY') return true;
+					if (element.hasAttribute('aria-expanded')) return true;
+					const popup = (element.getAttribute('aria-haspopup') || '').toLowerCase();
+					if (['dialog', 'menu', 'true'].includes(popup)) return true;
+					const label = (element.getAttribute('aria-label') || element.innerText || '').toLowerCase();
+					return element.tagName === 'BUTTON' && /\\bmenu\\b/.test(label);
+				})
+				.slice(0, 8);
+			const probes = [];
+			for (const trigger of triggers) {
+				const label = (trigger.getAttribute('aria-label') || trigger.innerText || 'dialog').replace(/\\s+/g, ' ').trim().slice(0, 40);
+				const before = openCount();
+				const expanded = trigger.getAttribute('aria-expanded') === 'true';
+				const bodyClass = document.body.className;
+				const hidden = [...document.querySelectorAll('[aria-hidden="true"]')];
+				trigger.click();
+				await new Promise((resolve) => setTimeout(resolve, 400));
+				const details = trigger.closest('details');
+				const revealed = hidden.some((element) => element.getAttribute('aria-hidden') !== 'true');
+				const opened =
+					openCount() > before ||
+					(trigger.getAttribute('aria-expanded') === 'true' && !expanded) ||
+					Boolean(details && details.open) ||
+					revealed ||
+					document.body.className !== bodyClass;
+				probes.push({ label: label || 'dialog', opened });
+				document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+				if (details && details.open) details.open = false;
+				await new Promise((resolve) => setTimeout(resolve, 150));
+			}
+			return probes;
+		})()` ) ) as DialogProbe[];
+
 		return {
 			viewport,
 			title: measured.title,
@@ -225,6 +273,7 @@ async function observePage(
 			externalHosts: [ ...external ].sort(),
 			hashTargets: measured.hashTargets as HashTarget[],
 			internalMissing,
+			dialogs,
 		};
 	} finally {
 		page.off( 'request', onRequest );
@@ -286,6 +335,27 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 						score.notes.push( evidence.error );
 					}
 				}
+				scores.push( score );
+			}
+			if ( ! widths.includes( 390 ) ) {
+				log( `[compare] ${ route } @ 390px interactivity` );
+				const pair = await observe( sourceHref, localHref, 390 );
+				const dialogOnly = ( observation: LayoutObservation ): LayoutObservation => ( {
+					...observation,
+					title: 'x',
+					textChars: 0,
+					widestImage: null,
+					overflow: false,
+					docWidth: 390,
+					externalHosts: [],
+					hashTargets: [],
+					internalMissing: [],
+				} );
+				const score = scoreViewport(
+					dialogOnly( pair.source ),
+					dialogOnly( pair.liberated )
+				);
+				score.notes.push( 'interactivity' );
 				scores.push( score );
 			}
 		}

--- a/src/lib/fidelity/score.test.ts
+++ b/src/lib/fidelity/score.test.ts
@@ -11,6 +11,7 @@ const at = ( viewport: number, extra: Partial< LayoutObservation > = {} ): Layou
 	externalHosts: [],
 	hashTargets: [],
 	internalMissing: [],
+	dialogs: [],
 	...extra,
 } );
 
@@ -67,6 +68,15 @@ describe( 'scoreViewport', () => {
 		const score = scoreViewport( at( 1440 ), at( 1440, { internalMissing: [ '/about/' ] } ) );
 		expect( score.pass ).toBe( false );
 		expect( score.failures[ 0 ] ).toMatch( /\/about\// );
+	} );
+
+	it( 'fails when a source dialog does not open in the copy', () => {
+		const score = scoreViewport(
+			at( 1440, { dialogs: [ { label: 'Menu', opened: true } ] } ),
+			at( 1440, { dialogs: [ { label: 'Menu', opened: false } ] } )
+		);
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /Menu/ );
 	} );
 
 	it( 'fails when the copy still talks to the source CDN', () => {

--- a/src/lib/fidelity/score.ts
+++ b/src/lib/fidelity/score.ts
@@ -24,6 +24,13 @@ export interface LayoutObservation {
 	hashTargets: HashTarget[];
 	/** Internal pathnames whose local copy 404s. Empty on the live source. */
 	internalMissing: string[];
+	/** Click-to-open dialogs/menus observed on this document. */
+	dialogs: DialogProbe[];
+}
+
+export interface DialogProbe {
+	label: string;
+	opened: boolean;
 }
 
 export interface HashTarget {
@@ -118,6 +125,18 @@ export function scoreViewport(
 				.slice( 0, 3 )
 				.join( ', ' ) }`
 		);
+	}
+
+	const copyOpened = new Set(
+		( liberated.dialogs ?? [] )
+			.filter( ( dialog ) => dialog.opened )
+			.map( ( dialog ) => dialog.label.toLowerCase() )
+	);
+	const dead = ( source.dialogs ?? [] )
+		.filter( ( dialog ) => dialog.opened && ! copyOpened.has( dialog.label.toLowerCase() ) )
+		.map( ( dialog ) => dialog.label );
+	if ( dead.length > 0 ) {
+		failures.push( `interactivity ${ dead.length } dialog(s) dead: ${ dead.slice( 0, 3 ).join( ', ' ) }` );
 	}
 
 	return {


### PR DESCRIPTION
## Summary

Layout, leftover hosts, hashes, and internal 404s were gated. Click-to-open was not.

`compare` now clicks visible menu/dialog triggers on the live source and the copy. If the source opens and the copy does not, it fails.

Desktop layout stays at 1600/1728. Interactivity also probes **390px**, where hamburger chrome actually appears.

## Live result

https://myhra-fluid-demo.squarespace.com/ at 1600/1728: layout still passes. Folder dropdowns are hover, not click.

At 390px: **FAIL** `interactivity 1 dialog(s) dead: Open Menu`. Source burger opens. The copy's burger does nothing — scripts are gone.

## Verification

- `npx vitest run src/lib/fidelity` (22 passed)
- Live `compare` on the Squarespace demo capture

## AI assistance

OpenAI GPT-5.6-Sol was used through OpenCode to add the interactivity observations, scoring, the 390px probe, and this pull request. Chris Huber directed the work.