### PR TITLE
Make the gate measure the whole site, and let liberation exit

### DIFF
--- a/skills/liberate/SKILL.md
+++ b/skills/liberate/SKILL.md
@@ -45,15 +45,26 @@ The run directory is that path with `website` removed — pass it to `compare` a
 data-liberation compare <run-dir>
 ```
 
-Compares the live source against the copy at widths the capture never sampled, and checks that navigation resolves, that internal links land, and that the copy asks for nothing off its own origin.
+This runs two tiers, and the report says which found what.
+
+**Self-consistency, over every route, offline.** Does the copy work on its own terms — every same-page and cross-page anchor resolving to exactly one target, every internal link landing on a real file, no asset still pointing at the origin. This needs no browser and no network, so it covers the whole site in milliseconds.
+
+**Source fidelity, over a sample, in a browser.** Does the copy still match the original — text, geometry and reflow at widths the capture never sampled, and dialogs opening as the source opens them. Each check is a live round trip costing roughly 25 seconds, so it runs on the entrypoint plus a spread of other routes rather than all of them.
 
 **Exit 0 means accepted. Exit 1 means report it.** Each failure names what diverged:
 
 ```
-1600px FAIL: nav 5 same-page anchor(s) match more than one target: #introduction #methodology
+self-consistency FAIL anchor-ambiguous: 1 route(s) — / /index.html#introduction matches 2 targets
+/anchor/ 1600px FAIL: text 62 chars !== source 707
 ```
 
-Add `--screenshots` to write source, copy, and diff PNGs alongside the run. The pixel score is evidence for a human, and the pass or fail comes from the named checks.
+The closing line states the scope measured, and both tiers must pass:
+
+```
+Passed: 4 route(s) checked offline, 4 of 4 compared to source, against https://example.com/
+```
+
+When that line shows fewer routes compared than captured, source fidelity was sampled — say so when reporting, rather than describing the whole site as verified. Add `--screenshots` to write source, copy, and diff PNGs. The pixel score is evidence for a human; pass or fail comes from the named checks.
 
 ## Step 3 — Publish
 

--- a/skills/liberate/SKILL.md
+++ b/skills/liberate/SKILL.md
@@ -1,331 +1,130 @@
 ---
 name: liberate
-description: Front door for liberating a website. A URL becomes a complete, portable HTML site — detect, discover, liberate every route, then hand back a local copy that runs on its own. That portable site IS the deliverable; HTML is the contract. WordPress reconstruction (blocks+products or theme replication) is an OPTIONAL downstream step offered only when the operator asks for WordPress — never assumed, never required, never a precondition for liberating. A local directory of owned HTML/CSS/JS that the operator wants turned into a WordPress block theme dispatches liberate-local. Idempotent: re-running on an already-liberated site reuses what is on disk.
+description: Liberate a website into a complete, portable HTML site by driving the data-liberation CLI. A URL becomes a directory of HTML, CSS, assets, routes and navigation that runs on its own — that directory is the deliverable and HTML is the contract. Covers the whole job in three commands: liberate the site, verify the copy against its source, and publish it to a live URL.
 ---
 
 # Liberate a website
 
-The front door for liberation. **Liberating a website means producing a complete, portable HTML copy of it** — every retained route, its CSS, assets, navigation, responsive behavior, and the client-side behavior it needs — in a directory that runs on its own.
+**What you produce:** a directory that runs on its own — every retained route, its CSS, media, fonts, navigation, same-page anchors, and responsive behavior, with references rewritten to point inside the copy.
 
-**HTML is the contract.** The liberated site is the deliverable. It is not an intermediate representation on the way to some other platform, and it does not assume any destination.
+**HTML is the contract.** That directory is the deliverable, not an intermediate step toward a platform.
 
-**It routes on the input type:**
+The CLI does the work. Your job is to run it, read what it reports, verify the result, and tell the operator what they got.
 
-- **A URL** (a live site you don't control) → liberate it: detect → discover → liberate every route → serve the result locally. Stop there. That is a complete outcome.
-- **A local directory** (a folder of owned HTML/CSS/JS) → there is nothing to liberate; the operator already owns the source. This input only makes sense when they want it turned into a **WordPress block theme**, which is owned entirely by **`liberate-local`** (read & follow `skills/liberate-local/SKILL.md`).
+## The whole surface
 
-**WordPress is optional and downstream.** After a URL is liberated, the operator may want it reconstructed in WordPress. Offer that only when they ask for WordPress or have already said that WordPress is the destination. Two reconstruct paths exist:
+| Command | What it does |
+|---|---|
+| `data-liberation <url> --no-serve` | Detect the platform, discover routes, liberate every one, write the site |
+| `data-liberation compare <run-dir>` | Verify the copy against its live source. **This is the acceptance gate** |
+| `data-liberation publish <run-dir> --to <target>` | Put the copy on a live URL |
 
-- **`replicate-with-blocks`** — project the source onto editable WordPress core blocks + WooCommerce. Best launchpad for a redesign.
-- **`replicate-theme`** — carry the source markup near-verbatim + scope its own CSS into a high-fidelity, non-block-editable theme.
+## Step 1 — Liberate
 
-**Idempotent:** re-running `/liberate <url>` on an already-liberated site reuses what is on disk instead of re-hitting the network, so a later WordPress reconstruct costs nothing extra.
-
-**Headless (CI/batch):** `data-liberation <url>` performs the whole liberation and serves the result. `--no-serve` writes the site and exits. WordPress reconstruction is agent-only, via the sub-skills.
-
----
-
-## Pipeline overview
-
-```
-/liberate <input>   ── front door, shared context ──────────────────────────────
-│
-├─ ROUTE ON INPUT TYPE  ◀── do this FIRST, before anything else
-│     ├─ <input> resolves to an existing LOCAL DIRECTORY?
-│     │     └─ YES → the operator owns this source; the only sensible job is
-│     │              WordPress theme conversion → dispatch liberate-local INLINE → DONE
-│     └─ otherwise treat as a URL ▼
-│
-├─ idempotent check: already liberated on disk?  (website/ + capture-receipt.json / artifact.json)
-│     ├─ YES → reuse it ───────────────────────────────────────────────────┐
-│     └─ NO  → 1 detect → discover    platform · sitemap · features · archetype inventory (CHEAP)
-│                                                                           │
-│  ┌────────────────────────────────────────────────────────────────────────┘
-│  ▼
-├─ 2 LIBERATE  ── the deliverable ──────────────────────────────────────────────
-│     every retained route → hydrated HTML + CSS + assets, references rewritten
-│     local, navigation and anchors resolving locally
-│     ▼
-├─ 3 SERVE + REPORT   runnable local copy · routes liberated/reused/failed ·
-│     unresolved dependencies · anything the source withheld
-│     ▼
-│  ✅ DONE. The portable HTML site is a complete outcome. Stop here unless the
-│     operator wants another destination.
-│
-└─ OPTIONAL — WordPress destination, only when the operator asks for WordPress:
-      ask which reconstruct path (AskUserQuestion), then run the WordPress-path
-      steps (extract → media → products) and dispatch the chosen sub-skill INLINE:
-        blocks+products → replicate-with-blocks   (core blocks + WooCommerce + QA ladder → run-report.json)
-        theme           → replicate-theme         (carry-and-scope islands + scoped CSS → compare → run-report-carry.json)
+```bash
+data-liberation https://example.com/ --no-serve
 ```
 
-Liberation output is shared across every downstream destination, so trying a different destination later never re-hits the network.
+Reports two lines:
 
-Each reconstruct sub-skill owns its own reconstruct → install → QA → report, plus its own budget guard (`checkBudget` in `src/lib/replicate/budget-guard.ts`) and run-report (`buildRunReport` in `src/lib/replicate/run-report.ts`). This skill's deliverable is the liberated site; a chosen sub-skill produces the WordPress replica + its `run-report*.json`.
+```
+Liberated 12/12 routes (3 reused)
+Site: /Users/you/data-liberation/example.com/website
+```
 
----
+The run directory is that path with `website` removed — pass it to `compare` and `publish`.
 
-## Step-by-step workflow
+- `--output <dir>` chooses where the run lands. Default is `~/data-liberation/<host-slug>`.
+- `--resume` reuses what is already on disk and reports it as `reused`. Add it when re-running against a site you have already liberated; without it the run captures the source again.
+- `--screenshots` adds desktop and mobile PNGs when the operator wants visual evidence.
+- Leave fluid learning on. It is what keeps the copy reflowing like the source instead of freezing at one width.
 
-### Step R — Route on input type (run before everything)
+## Step 2 — Verify
 
-Before any detection, idempotent check, or extraction, decide which path the input takes:
+```bash
+data-liberation compare <run-dir>
+```
 
-- **Local directory** — if the input resolves to an **existing local directory** (an absolute or relative filesystem path to a folder of owned HTML/CSS/JS), there is nothing to liberate: the operator already has the source. The job is WordPress theme conversion, so dispatch `liberate-local` inline: **read & follow `skills/liberate-local/SKILL.md`** in this same shared context. That sub-skill owns the entire local pipeline (resolve inputs → optional data-model → `liberate_convert_local_site` → parity report). When it returns, you are done — **do not** run any of the URL steps below.
-- **URL** — anything else (a `http(s)://` URL, or a bare host like `example.com`) takes the **URL** path: continue to Step 0. If the input has no scheme and is not a directory, treat it as a URL and normalize it (prepend `https://`).
+Compares the live source against the copy at widths the capture never sampled, and checks that navigation resolves, that internal links land, and that the copy asks for nothing off its own origin.
 
-Disambiguation rule when it's genuinely unclear: a value that **exists on disk as a directory** is local; otherwise it's a URL. A path that doesn't exist as a directory and looks like a host/URL is a URL — don't error, treat it as remote.
+**Exit 0 means accepted. Exit 1 means report it.** Each failure names what diverged:
 
-`liberate-local` is `user-invocable: false` (hidden from the user's autocomplete) and `disable-model-invocation: true`, so it only ever runs via this front door — the Skill tool will reject a direct `Skill({ skill: 'liberate-local' })` call. Dispatch = read its `SKILL.md` and execute its workflow inline.
+```
+1600px FAIL: nav 5 same-page anchor(s) match more than one target: #introduction #methodology
+```
 
-### Step 0 — Idempotent check (run first, URL path)
+Add `--screenshots` to write source, copy, and diff PNGs alongside the run. The pixel score is evidence for a human, and the pass or fail comes from the named checks.
 
-Call `liberate_paths({ url })` to resolve the output directory (`siteDir`). Do not hardcode `output/<site>/` relative to cwd — the default output base is `~/data-liberation/<host>`. If the site is already liberated — `website/` plus `capture-receipt.json` / `artifact.json` present in the resolved `siteDir` — **skip Steps 1 and 2**, report what is already on disk, and go straight to Step 3. For a partial run, prefer `resume: true` (see Resuming) so existing routes are reused instead of recaptured.
+## Step 3 — Publish
 
-### Step 1 — Detect & discover
+Run this when the operator asks for a live URL.
 
-1. Ask for the URL if not already provided.
-2. Call `liberate_detect` to identify the platform.
-3. Call `liberate_discover` to inventory the site. Show the counts and **platform features** to the operator.
-   - `platformFeatures` flags: stores, bookings, forms, members areas, scheduling, forums, events.
-   - Features marked `transferable: true` (e.g. stores) are handled during extraction.
-   - Features marked `transferable: false` include a `wpRecommendation` (suggested WP plugin).
-   - Narrate: "Detected Wix · 47 pages · 3 archetypes · 12 products · store (WooCommerce) · forms (WPForms recommended)."
+```bash
+data-liberation publish <run-dir> --to <target>
+```
 
-### Step 2 — Liberate the site
+Ask the operator where it should go. `spacefast` is the default when `--to` is omitted. To see what a build actually offers, name a target that does not exist — the error lists the registered ones:
 
-Call `liberate_capture` with the resolved `outputDir` (pass `resume: true` to reuse routes already on disk). Narrate per-route progress.
+```
+Unknown publish target "list". Available: spacefast.
+```
 
-This liberates every retained route into `<siteDir>/website/`: hydrated HTML, CSS, media, fonts, and required client runtime, with references rewritten to local paths so navigation and same-page anchors resolve inside the copy. It writes `capture-receipt.json` (routes, assets, layout geometry) and `diagnostics.json` (failures, unresolved dependencies) beside it.
+A publish reports the same shape whichever target serves it:
 
-**0 routes:** "Nothing could be liberated at `<url>`. The site may be behind auth or bot-protection — try CDP/admin access (`/diagnose`)." Stop.
+```
+Published 1 files to spacefast.
+Live: https://gzipped-nest.view.fast/
+Version: https://v1--gzipped-nest.view.fast/
+This space is private by default, so the live URL returns 403 until access is granted.
+Claim it to keep it: https://my.spacefast.com/claim#sfc_…
+Claim expires: 2026-08-28T06:58:13.658Z
+```
 
-Liberate **every** route in the retained set. A representative sample is not a liberated site; sampling is only acceptable when the operator explicitly asks for a scoped subset, and you must say plainly that the result is partial.
+Give the operator every line of that. **A claim link and its deadline matter most.** When a target publishes anonymously, the space belongs to nobody until it is claimed, and it can stay private meanwhile — the run above answers 403 to everyone until the operator acts on the link. Reporting the live URL alone would tell them the publish worked and leave them looking at an error.
 
-### Step 3 — Serve and report
+`--token`, or the target's token environment variable such as `SPACEFAST_TOKEN`, publishes into an account they already own.
 
-Serve the liberated site locally and give the operator the URL so they can click through it themselves.
+Publishing reads what is on disk, so a repaired copy or a different target can ship without touching the source site again.
 
-Report honestly, distinguishing outcomes that do not imply each other:
+## Showing the copy to a human
 
-- Routes liberated, reused, and failed, against routes discovered.
-- Unresolved dependencies and media from `diagnostics.json`.
-- Anything the source withheld (auth-gated, bot-blocked, or client-only behavior that did not survive).
+```bash
+data-liberation https://example.com/
+```
 
-Do not describe a site as complete or one-for-one on the strength of route counts alone. Route coverage is not visual fidelity, and neither proves that interactive behavior survived.
+Without `--no-serve` the command serves the copy and stays running until interrupted. Use it when someone wants to browse; use `--no-serve` whenever you need the command to return.
 
-**This is the end of liberation.** The portable HTML site is a complete deliverable. Do not offer, assume, or start a WordPress reconstruct unless the operator asks for WordPress.
+## What a run leaves behind
 
-### Optional — WordPress destination
+| Path | Contents |
+|---|---|
+| `website/` | The deliverable. Serve this directory anywhere |
+| `capture-receipt.json` | Source URL, route table mapping each page to the URL it came from, assets, profile |
+| `diagnostics.json` | Everything the source withheld or the capture could not resolve |
+| `source-profile.json` | Measured behavior: one document or per-device, declarative or runtime-written geometry, switch width |
 
-Run this **only** when the operator has asked for WordPress. Show the liberation inventory (pages · archetypes · products · platform features) plus a scope/cost/time estimate, then call **AskUserQuestion** to choose the reconstruct path. Recommend **Theme replication** by default; recommend **Blocks + products** when the site is clearly a store or you have a strong, specific reason. Use this copy verbatim, listing the recommended option first with ` (Recommended)` appended:
+## Reporting a run
 
-- question: `How should the site be reconstructed in WordPress?`
-- option label: `Blocks + products`
-  description: `WordPress-native blocks + navigation + WooCommerce product pages. Best launchpad for a redesign. (Reconstructs product pages.)`
-- option label: `Theme replication`
-  description: `Carry-and-scope: highest-fidelity replica of the source, raw-HTML-editable (not block-editable). (Imports product data; product pages fall back to default WooCommerce, not a carried replica.)`
+Give the operator:
 
-Never auto-select the path. A recommendation belongs inside the question; the operator's answer is the only thing that authorizes the reconstruct.
+1. Routes liberated, reused, and failed, from the CLI's own summary.
+2. The compare result per width, quoting any failure text verbatim.
+3. Any `diagnostics.json` key that came back non-empty, named and counted.
 
-Then run the WordPress-path steps against the already-liberated site:
+The keys worth surfacing are `failures`, `resourceFailures`, `unresolvedDependencies`, `unresolvedMedia`, `unresolvedAnchors`, `interactionFailures`, `excludedRoutes`, and `duplicateRoutes`.
 
-1. **Extract** — call `liberate_extract` with the same `outputDir` for pages/posts/products content and media refs, producing the WXR. Reuses the liberated HTML rather than re-hitting the network.
-2. **Media dedup + upload** — deduped and uploaded to the WP media library; the uploaded URLs are the canonical references downstream (specs, templates, `post_content`).
-3. **Products → CSV** — if products were extracted, compile `products.jsonl` → `products.csv` (WooCommerce import format). Report: "Also extracted N products → products.csv."
+## Reading a compare failure
 
-### Dispatch (inline)
+| Failure text | Where to look |
+|---|---|
+| `widest image … Δ` or `doc width` | Geometry froze at the capture width — confirm fluid learning ran, in `source-profile.json` under `geometry` and `learned` |
+| `nav … same-page anchor(s) missing` or `match more than one target` | `diagnostics.unresolvedAnchors` names the fragment and the reason |
+| `copy requested N external host(s)` | `diagnostics.unresolvedDependencies` and `resourceFailures` |
+| `internal link(s) 404` | `diagnostics.excludedRoutes` and `duplicateRoutes`, plus the route table in the receipt |
+| `title … !== source` or `text … chars` | Compare the receipt's route table against the URL the source actually serves |
 
-All three sub-skills this front door dispatches — the two reconstruct skills plus `liberate-local` (dispatched at Step R for the local-directory input) — are `disable-model-invocation: true` by design, so they only ever run from this front door, never spontaneously. That means **the Skill tool cannot invoke them**: a `Skill({ skill: 'replicate-theme' })` call is rejected with `cannot be used with Skill tool due to disable-model-invocation`. So **dispatch = Read the chosen sub-skill's `SKILL.md` and execute its workflow inline in this same shared context** (each sub-skill reads the resolved output directory from disk — use the `siteDir` returned by `liberate_paths` — and owns its own install → QA → report):
+Report the failure and the matching diagnostics together, so the operator sees both the symptom and the evidence.
 
-- blocks+products → read & follow `skills/replicate-with-blocks/SKILL.md`
-- theme replication → read & follow `skills/replicate-theme/SKILL.md`
+## Done
 
-The reconstruct phase (clustering, foundations, theme, build, validate, install, visual-QA for blocks; carry-and-scope + compare for theme) lives **entirely in the dispatched sub-skill** — this front door ends here.
-
-
----
-
-## Operator interaction states
-
-| Stage | State | Response |
-|---|---|---|
-| routing | input is a local directory | Dispatch `liberate-local` inline (read & follow its SKILL.md); skip all URL steps |
-| liberation | 0 routes | Stop + "Nothing could be liberated at `<url>`. Try CDP/admin access (`/diagnose`)." |
-| liberation | adapter fail | Log + pointer to `/diagnose` |
-| liberation | routes failed or dependencies unresolved | Report them plainly; do not claim a complete copy |
-| liberation | done | Serve the site, report coverage, and stop — WordPress is not implied |
-| WordPress (optional) | operator asked for WordPress and picked a path | Dispatch the chosen sub-skill (`replicate-with-blocks` / `replicate-theme`) inline |
-| reconstruct | gate fail · clusters failed · QA divergence · budget ceiling | Owned by the dispatched sub-skill — see its SKILL.md (`replicate-with-blocks`'s validate-artifacts + QA-ladder gates + budget guard; `replicate-theme`'s parity compare) |
-
-Progress is the agent's own narration — no Ink TUI in agent mode. The headless CLI keeps its existing Ink surfaces (`discover.tsx`, `screenshot.tsx`).
-
----
-
-## Run report (WordPress paths only)
-
-Liberation itself reports through `capture-receipt.json` + `diagnostics.json`. The reports below exist only when a WordPress reconstruct ran.
-
-Each reconstruct path emits its **own** report — `run-report.json` from `replicate-with-blocks`, `run-report-carry.json` from `replicate-theme` (each carries a `mode` field). The blocks-path `run-report.json` is verdict-first; read top-down to answer "is this good?":
-
-1. `verdict` — overall ✓ / ⚠ / ✗ + per-archetype.
-2. `summary` — clusters built/failed · pages composed/misfit · responsive pass/fail · sections divergent/accepted · pages unverified · provenance flags · fallback/low-confidence pages · est. cost/usage.
-3. `details[]` — per-cluster + per-page status, gate results, QA notes, operator-accepted divergences (with proof).
-
-The theme-path `run-report-carry.json` is parity-compare shaped — see `replicate-theme`.
-
----
-
-## Resuming
-
-If the user asks to resume (e.g. "resume", "continue", "it crashed"):
-
-1. Ask for the URL if not provided — `outputDir` is derived from it.
-2. Call `liberate_capture` with `resume: true`; routes already on disk are reused instead of recaptured, so only the missing ones cost network time.
-3. If the site is already fully liberated, say so, serve it, and stop. Offer a WordPress reconstruct only if the operator asks for WordPress.
-
-On the optional WordPress path, `liberate_extract`'s `resume` flag causes extraction to:
-- Skip platform detection/discovery if a completed WXR already exists
-- Skip URLs already successfully processed (tracked in `extraction-log.jsonl`)
-- Rebuild media dedup hashes from existing files
-- Append to the existing WXR rather than starting fresh
-
----
-
-## Output-quality contract (WordPress paths)
-
-These guarantees are enforced by the reconstruct sub-skills (mainly `replicate-with-blocks`'s validate-artifacts + QA gates; alt-text + copyright apply to both paths):
-
-- A source section matching **no** catalog interaction-model maps to a **faithful generic** (`columns`/`group`) and is **flagged** in the run-report — never silently forced into a wrong-specific template.
-- Capture-health fallback pages (hero+gallery) and misfit pages routed to `compose-page-blocks` are labeled **low-confidence / fallback** in the run-report.
-- **Alt text:** carry the source's alt verbatim. Images with missing/empty alt are **flagged in run-report** for human fill — never AI-generated (provenance rule).
-- **Contrast:** the brightness rule guarantees legibility. The validate-artifacts gate **warns** on sub-WCAG-AA (4.5:1) text in the run-report. It does not hard-fail or auto-adjust — the source itself may fail AA, and faithfulness wins.
-- **Copyright:** third-party sites get the `style.css` "Benchmark reference only — not for publication." header.
-
----
-
-## Discoveries
-
-If you encounter something notable while liberating — a new API endpoint, a platform quirk, a workaround for blocked content, a better acquisition technique — add an entry to `DISCOVERIES.md` at the top of the repo.
-
----
-
-## Verification
-
-After liberation, always read `diagnostics.json` and report failed routes, unresolved dependencies, and unresolved media. Click-through of the served copy is the operator's own check.
-
-On the optional WordPress path, also run `liberate_verify` on the output directory once extraction completes. This checks:
-- Stale CDN URLs still embedded in content (Shopify, Squarespace, Webflow, Wix CDN domains)
-- Failed page extractions and failed media downloads
-- Quality score breakdown (high/medium/low)
-- Media files on disk vs media attachments in the WXR
-- Redirect map completeness
-
-Report the verification results and flag anything that needs attention before importing.
-
----
-
-## Platform-specific notes
-
-### Squarespace
-
-Squarespace sites benefit significantly from **admin extraction via CDP**. Without it, you only get public content — no drafts, no unlisted pages, and Squarespace 7.1 fluid engine sites often return empty content from the `?format=json` API.
-
-**Guide the user through admin setup:**
-
-1. Ask the user to launch Chrome with remote debugging:
-   ```
-   google-chrome --remote-debugging-port=9222
-   ```
-   (On macOS: `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222`)
-2. In that Chrome window, navigate to their Squarespace site and **log in to admin**.
-3. Once logged in, run extraction with `--cdp-port 9222` (CLI) or `cdpPort: 9222` (MCP).
-
-The admin session gives the adapter access to:
-- Squarespace's admin API responses (richer metadata, structured content)
-- Draft and unlisted pages not visible publicly
-- `__NEXT_DATA__` hydration payloads on 7.1 sites
-- Automatic fallback to DOM extraction if JSON data is sparse
-
-**Always offer CDP-based extraction for Squarespace.** Public-only extraction works but produces lower quality results.
-
-### Wix
-
-Extraction uses Playwright (headless browser) to intercept Wix's internal API calls and extract window globals. This is slower but captures content that isn't available via HTTP alone. Large sites may take several minutes.
-
-### Webflow
-
-Webflow requires a Webflow API token. Ask the user for their token and pass it via `--token` (CLI) or the `token` parameter (MCP).
-
-### Shopify
-
-Shopify has **two extraction tiers**. Always offer the richer one first and fall back only if the user can't produce an Admin API token.
-
-**Tier 1 — Public JSON API (no credentials)**
-
-Works for any public Shopify storefront. Pulls pages, blog posts, and products via the public `/pages.json`, `/blogs.json`, and `/products.json` endpoints plus HTML fallback for theme-rendered content. No token needed. Product data is limited to what the public API exposes — you lose compareAtPrice sale semantics, real stock policy, cost of goods, variant images, and collections.
-
-**Tier 2 — Admin GraphQL (richer product data)**
-
-When the user has admin access to their store, offer to use Shopify's Admin GraphQL API. This yields:
-- `compareAtPrice` → proper sale/regular price mapping on simple + variable products
-- `inventoryPolicy` + `inventoryItem.tracked` → real stock status (oversell-aware)
-- `inventoryItem.unitCost` → cost of goods written to `meta:_wc_cog_cost`
-- `inventoryItem.measurement.weight` → unit-normalized weight (kg)
-- Variant-level images
-- Collections → WooCommerce categories
-- SEO metafields (`meta:_yoast_wpseo_title` / `_yoast_wpseo_metadesc`)
-- Cursor-based pagination with mid-run resume
-
-**Guide the user through admin setup:**
-
-1. Direct them to Shopify Admin → **Settings → Apps and sales channels → Develop apps**.
-2. Create a new custom app (name it "Data Liberation" or similar).
-3. Under **Configuration → Admin API access scopes**, enable at minimum:
-   - `read_products` (required)
-   - `read_inventory` (for cost-of-goods + stock)
-   - `read_online_store_pages` / `read_online_store_navigation` (for pages)
-   - `read_content` (for blog articles)
-4. Click **Install app** to generate the Admin API access token — copy it immediately, Shopify only shows it once.
-5. Pass the token as `adminToken` (MCP) or via the adapter opts. **You do not need to ask the user for the shop domain** — `liberate_discover` auto-detects the `*.myshopify.com` hostname from the storefront HTML (`Shopify.shop` JS global) and stores it as `inventory.shopDomain`, even for sites served on custom domains.
-
-**When to use which tier:**
-- User has a Shopify login and some admin comfort → **prompt for Tier 2** and walk them through the custom app flow above
-- User just wants "get my stuff out" and doesn't want to touch admin → **Tier 1 is fine** but tell them upfront what they'll lose (sale pricing, cost of goods, richer categories)
-- User has a custom storefront domain (e.g. `shop.brand.com`) → Tier 2 still works because of auto-detection; do NOT ask them for the myshopify.com subdomain manually unless the detector failed
-
-**If `liberate_discover` did not populate `inventory.shopDomain`** (rare — the site may be behind Cloudflare or heavy bot protection that blocks HTML fetch), ask the user directly:
-"I couldn't auto-detect the myshopify.com subdomain. Can you paste the URL you see when you log into your Shopify admin? It looks like `https://admin.shopify.com/store/<name>` — the `<name>` is what I need."
-
-Pass the admin-resolved value as `shopDomain` alongside `adminToken`.
-
-**GraphQL failures fall back to Tier 1 automatically** — if the token is wrong or the scopes are insufficient, the adapter logs a warning and continues with the public JSON path, so the user's extraction still produces output.
-
-### GoDaddy Websites & Marketing
-
-Public-crawl adapter for GoDaddy's **legacy** Websites & Marketing platform (also called "Go Daddy Website Builder" in page sources). Not to be confused with the newer Airo AI Builder.
-
-GoDaddy offers **no data export** from W+M — this adapter rescues content by crawling the public site. Detection looks for the `Go Daddy Website Builder` generator meta tag, the `img1.wsimg.com/isteam/` CDN pattern, and the `X-SiteId` header.
-
-Discovery fetches the three standard W+M sub-sitemaps individually so blog posts can be tagged precisely (W+M's `/news,-updates/f/<slug>` URL shape doesn't match the generic classifier):
-- `sitemap.website.xml` — pages
-- `sitemap.blog.xml` — blog posts
-- `sitemap.ols.xml` — products (**v1.1**, not yet implemented)
-
-**Blog post bodies are hydrated client-side from a `window._BLOG_DATA` JSON blob.** The adapter parses this blob and converts the Draft.js ContentState (`post.fullContent`) into HTML — preserving paragraphs, headings, lists, blockquotes, code blocks, links, and images. Title, publish date, categories, and featured image are also pulled from `_BLOG_DATA` rather than HTML meta tags (higher fidelity).
-
-Pages use DOM-based extraction: strip `HEADER_SECTION`, `FOOTER_*`, cookie banners, and the first-section title/image widgets (`*_SECTION_TITLE_RENDERED`, `*_IMAGE_RENDERED0`) which would otherwise duplicate the `<wp:post_title>` and media attachment.
-
-**v1 limitations:** No GoDaddy Online Store (OLS) product extraction yet — sites with a store are flagged, but products need a real store URL for testing before v1.1 ships.
-
----
-
-## General notes
-
-- Liberation produces `website/` (the portable HTML site), `capture-receipt.json`, `diagnostics.json`, and `artifact.json` under the resolved `siteDir`. That directory is self-contained and needs no WordPress to open, serve, or inspect.
-- The notes below apply only to the optional WordPress path.
-- Extraction produces a WXR file (WordPress import format) + a media directory + a redirect map.
-- If the site has products, a `products.csv` (WooCommerce format) and `products.jsonl` are also produced.
-- All content is imported as **drafts by default** — the user reviews and publishes manually (the WXR a user imports into their production WordPress). This is `liberate_extract`'s `contentStatus` default (`'draft'`). **When building a replica/preview** (the design phase — a Studio replica whose nav must resolve), pass `contentStatus: 'publish'` to `liberate_extract`/`liberate_extract_one` so imported pages/posts are live instead of 404ing. Attachments always use WP's `inherit` regardless.
-- The WordPress import step supports `importAuthors: true` to create WP user accounts per author, or `importAuthors: false` (default) to assign all content to the authenticated user. Ask before importing.
-- If no environment import skill is available, validate the WordPress connection with `liberate_setup` first, then call `liberate_import` with REST API credentials. If the environment provides an import skill (e.g. `import-liberated-data`), use `delegate: true` with both `liberate_setup` and `liberate_import`.
+A liberation is complete when `compare` exits 0 and the operator has the run directory, the route counts, and any unresolved entries. A live URL is complete when `publish` has reported it, along with the claim link when the publish was anonymous.

--- a/skills/liberate/SKILL.md
+++ b/skills/liberate/SKILL.md
@@ -15,17 +15,17 @@ The CLI does the work. Your job is to run it, read what it reports, verify the r
 
 | Command | What it does |
 |---|---|
-| `data-liberation <url> --no-serve` | Detect the platform, discover routes, liberate every one, write the site |
+| `data-liberation <url>` | Detect the platform, discover routes, liberate every one, write the site |
 | `data-liberation compare <run-dir>` | Verify the copy against its live source. **This is the acceptance gate** |
 | `data-liberation publish <run-dir> --to <target>` | Put the copy on a live URL |
 
 ## Step 1 — Liberate
 
 ```bash
-data-liberation https://example.com/ --no-serve
+data-liberation https://example.com/
 ```
 
-Reports two lines:
+Writes the site and exits, reporting two lines:
 
 ```
 Liberated 12/12 routes (3 reused)
@@ -89,10 +89,12 @@ Publishing reads what is on disk, so a repaired copy or a different target can s
 ## Showing the copy to a human
 
 ```bash
-data-liberation https://example.com/
+data-liberation https://example.com/ --resume --serve
 ```
 
-Without `--no-serve` the command serves the copy and stays running until interrupted. Use it when someone wants to browse; use `--no-serve` whenever you need the command to return.
+`--serve` keeps a local server running on the copy until it is interrupted, so offer it when someone wants to browse the result. With `--resume` alongside it, the site is already on disk and the server comes up immediately. Every run that does not serve prints this same command on stderr.
+
+Run it only when a human is waiting for it, since the command holds until interrupted.
 
 ## What a run leaves behind
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,9 @@ if (args[0] === 'mcp') {
     --output <dir>       Output base directory (default: ~/data-liberation; override with --output or DLA_OUTPUT_DIR)
     --resume             Reuse artifacts already on disk instead of recapturing
     --screenshots        Also capture full-page + scrolled PNG screenshots
-    --no-serve           Write the site and exit without serving it locally
+    --serve              Keep a local server running on the liberated site until
+                         interrupted, for browsing it. Liberation writes the site
+                         and exits without this.
     --no-learn-fluid     Skip the width sweep and freeze the layout at one width.
                          Learning is on by default: it keeps the copy reflowing
                          like the source instead of pinning it to the capture width.
@@ -418,7 +420,7 @@ if (args[0] === 'mcp') {
     resume: args.includes('--resume'),
     screenshots: args.includes('--screenshots'),
     learnFluid: !args.includes('--no-learn-fluid'),
-    serve: !args.includes('--no-serve'),
+    serve: args.includes('--serve'),
     log: (message) => process.stderr.write(`${message}\n`),
   });
 
@@ -441,5 +443,8 @@ if (args[0] === 'mcp') {
     };
     process.once('SIGINT', stop);
     process.once('SIGTERM', stop);
+  } else {
+    // Guidance goes to stderr so stdout stays the machine-readable result.
+    process.stderr.write(`Browse it: data-liberation ${url} --resume --serve\n`);
   }
 }

--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -146,6 +146,83 @@ describe( 'checkFidelity', () => {
 		expect( [ ...new Set( requested ) ] ).toEqual( [ 'https://example.com/handbook/intro' ] );
 	} );
 
+	it( 'checks every retained route, entrypoint first, not just the homepage', async () => {
+		const dir = mkdtempSync( join( tmpdir(), 'dla-check-' ) );
+		dirs.push( dir );
+		for ( const sub of [ 'website', 'website/about', 'website/pricing' ] )
+			mkdirSync( join( dir, sub ), { recursive: true } );
+		for ( const page of [ 'index.html', 'about/index.html', 'pricing/index.html' ] )
+			writeFileSync( join( dir, 'website', page ), '<h1>Page</h1>' );
+		writeFileSync(
+			join( dir, 'capture-receipt.json' ),
+			JSON.stringify( {
+				source: { url: 'https://example.com/' },
+				websiteRoot: 'website',
+				routes: [
+					{ url: 'https://example.com/pricing', path: 'website/pricing/index.html' },
+					{ url: 'https://example.com/', path: 'website/index.html' },
+					{ url: 'https://example.com/about', path: 'website/about/index.html' },
+				],
+			} )
+		);
+
+		const seen: string[] = [];
+		const report = await checkFidelity( {
+			directory: dir,
+			widths: [ 1600 ],
+			observe: async ( sourceHref, _local, viewport ) => {
+				seen.push( sourceHref );
+				return { source: obs( viewport ), liberated: obs( viewport ) };
+			},
+		} );
+
+		expect( report.routes ).toEqual( [ '/', '/about/', '/pricing/' ] );
+		expect( report.routesAvailable ).toBe( 3 );
+		expect( seen[ 0 ] ).toBe( 'https://example.com/' );
+		expect( new Set( seen ) ).toEqual(
+			new Set( [
+				'https://example.com/',
+				'https://example.com/about',
+				'https://example.com/pricing',
+			] )
+		);
+		expect( new Set( report.scores.map( ( score ) => score.route ) ) ).toEqual(
+			new Set( [ '/', '/about/', '/pricing/' ] )
+		);
+	} );
+
+	it( 'reports the scope it actually measured when the route cap bites', async () => {
+		const dir = mkdtempSync( join( tmpdir(), 'dla-check-' ) );
+		dirs.push( dir );
+		mkdirSync( join( dir, 'website' ), { recursive: true } );
+		writeFileSync( join( dir, 'website', 'index.html' ), '<h1>Home</h1>' );
+		const routes = Array.from( { length: 40 }, ( _value, index ) => ( {
+			url: `https://example.com/p${ index }`,
+			path: `website/p${ index }/index.html`,
+		} ) );
+		writeFileSync(
+			join( dir, 'capture-receipt.json' ),
+			JSON.stringify( {
+				source: { url: 'https://example.com/' },
+				websiteRoot: 'website',
+				routes,
+			} )
+		);
+
+		const report = await checkFidelity( {
+			directory: dir,
+			widths: [ 1600 ],
+			observe: async ( _source, _local, viewport ) => ( {
+				source: obs( viewport ),
+				liberated: obs( viewport ),
+			} ),
+		} );
+
+		// 40 captured routes plus the synthesised entrypoint, capped at 32.
+		expect( report.routesAvailable ).toBe( 41 );
+		expect( report.routes ).toHaveLength( 32 );
+	} );
+
 	it( 'refuses to compare a route the capture never took', async () => {
 		await expect(
 			checkFidelity( {

--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -146,22 +146,36 @@ describe( 'checkFidelity', () => {
 		expect( [ ...new Set( requested ) ] ).toEqual( [ 'https://example.com/handbook/intro' ] );
 	} );
 
-	it( 'checks every retained route, entrypoint first, not just the homepage', async () => {
+	it( 'compares a small sample to the source while checking every route offline', async () => {
 		const dir = mkdtempSync( join( tmpdir(), 'dla-check-' ) );
 		dirs.push( dir );
-		for ( const sub of [ 'website', 'website/about', 'website/pricing' ] )
+		for ( const sub of [ 'website', 'website/about', 'website/blog/a', 'website/blog/b' ] )
 			mkdirSync( join( dir, sub ), { recursive: true } );
-		for ( const page of [ 'index.html', 'about/index.html', 'pricing/index.html' ] )
-			writeFileSync( join( dir, 'website', page ), '<h1>Page</h1>' );
+		const post = ( title: string, paragraphs: number ) =>
+			`<html><body><main><article><h1>${ title }</h1>${ '<p>copy</p>'.repeat(
+				paragraphs
+			) }</article></main></body></html>`;
+		writeFileSync(
+			join( dir, 'website', 'index.html' ),
+			'<html><body><header><nav></nav></header><main><section><h1>Home</h1></section></main></body></html>'
+		);
+		writeFileSync(
+			join( dir, 'website', 'about', 'index.html' ),
+			'<html><body><main><aside><p>About</p></aside><ul><li>x</li></ul></main></body></html>'
+		);
+		// Two posts on one template, differing only in how much copy they carry.
+		writeFileSync( join( dir, 'website', 'blog', 'a', 'index.html' ), post( 'A', 3 ) );
+		writeFileSync( join( dir, 'website', 'blog', 'b', 'index.html' ), post( 'B', 17 ) );
 		writeFileSync(
 			join( dir, 'capture-receipt.json' ),
 			JSON.stringify( {
 				source: { url: 'https://example.com/' },
 				websiteRoot: 'website',
 				routes: [
-					{ url: 'https://example.com/pricing', path: 'website/pricing/index.html' },
+					{ url: 'https://example.com/blog/b', path: 'website/blog/b/index.html' },
 					{ url: 'https://example.com/', path: 'website/index.html' },
 					{ url: 'https://example.com/about', path: 'website/about/index.html' },
+					{ url: 'https://example.com/blog/a', path: 'website/blog/a/index.html' },
 				],
 			} )
 		);
@@ -176,37 +190,43 @@ describe( 'checkFidelity', () => {
 			},
 		} );
 
-		expect( report.routes ).toEqual( [ '/', '/about/', '/pricing/' ] );
-		expect( report.routesAvailable ).toBe( 3 );
+		// Small site: every route fits inside the sample.
+		expect( report.routesAvailable ).toBe( 4 );
+		expect( report.routes ).toEqual( [ '/', '/about/', '/blog/a/', '/blog/b/' ] );
 		expect( seen[ 0 ] ).toBe( 'https://example.com/' );
-		expect( new Set( seen ) ).toEqual(
-			new Set( [
-				'https://example.com/',
-				'https://example.com/about',
-				'https://example.com/pricing',
-			] )
-		);
-		expect( new Set( report.scores.map( ( score ) => score.route ) ) ).toEqual(
-			new Set( [ '/', '/about/', '/pricing/' ] )
-		);
+		// Offline tier covers all of them regardless.
+		expect( report.selfConsistency.routes ).toBe( 4 );
 	} );
 
-	it( 'reports the scope it actually measured when the route cap bites', async () => {
+	it( 'spreads the source sample so a large blog does not crowd out other pages', async () => {
 		const dir = mkdtempSync( join( tmpdir(), 'dla-check-' ) );
 		dirs.push( dir );
-		mkdirSync( join( dir, 'website' ), { recursive: true } );
-		writeFileSync( join( dir, 'website', 'index.html' ), '<h1>Home</h1>' );
-		const routes = Array.from( { length: 40 }, ( _value, index ) => ( {
-			url: `https://example.com/p${ index }`,
-			path: `website/p${ index }/index.html`,
-		} ) );
+		mkdirSync( join( dir, 'website', 'shop' ), { recursive: true } );
+		writeFileSync(
+			join( dir, 'website', 'index.html' ),
+			'<html><body><header><nav></nav></header><main><h1>Home</h1></main></body></html>'
+		);
+		// Sixty posts sort ahead of /shop/, so route-order selection never reached it.
+		const routes = [ { url: 'https://example.com/', path: 'website/index.html' } ];
+		for ( let index = 0; index < 60; index++ ) {
+			const slug = `blog/post-${ String( index ).padStart( 3, '0' ) }`;
+			mkdirSync( join( dir, 'website', slug ), { recursive: true } );
+			writeFileSync(
+				join( dir, 'website', slug, 'index.html' ),
+				`<html><body><main><article><h1>Post ${ index }</h1>${ '<p>copy</p>'.repeat(
+					index + 1
+				) }</article></main></body></html>`
+			);
+			routes.push( { url: `https://example.com/${ slug }`, path: `website/${ slug }/index.html` } );
+		}
+		writeFileSync(
+			join( dir, 'website', 'shop', 'index.html' ),
+			'<html><body><main><section><h2>Shop</h2><ul><li>item</li></ul></section><aside><form></form></aside></main></body></html>'
+		);
+		routes.push( { url: 'https://example.com/shop', path: 'website/shop/index.html' } );
 		writeFileSync(
 			join( dir, 'capture-receipt.json' ),
-			JSON.stringify( {
-				source: { url: 'https://example.com/' },
-				websiteRoot: 'website',
-				routes,
-			} )
+			JSON.stringify( { source: { url: 'https://example.com/' }, websiteRoot: 'website', routes } )
 		);
 
 		const report = await checkFidelity( {
@@ -218,9 +238,13 @@ describe( 'checkFidelity', () => {
 			} ),
 		} );
 
-		// 40 captured routes plus the synthesised entrypoint, capped at 32.
-		expect( report.routesAvailable ).toBe( 41 );
-		expect( report.routes ).toHaveLength( 32 );
+		// Ordered selection spent every check inside /blog/; an even spread reaches /shop/.
+		expect( report.routesAvailable ).toBe( 62 );
+		expect( report.routes[ 0 ] ).toBe( '/' );
+		expect( report.routes ).toContain( '/shop/' );
+		expect( report.routes ).toHaveLength( 4 );
+		// And every one of the 62 routes was checked offline.
+		expect( report.selfConsistency.routes ).toBe( 62 );
 	} );
 
 	it( 'refuses to compare a route the capture never took', async () => {

--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -139,10 +139,11 @@ describe( 'checkFidelity', () => {
 			},
 		} );
 
-		expect( requested ).toEqual( [
-			'https://example.com/handbook/intro',
-			'https://example.com/handbook/intro',
-		] );
+		// Every pass asks for the captured page, however many passes there are.
+		// Pinning the exact call count is what broke when an interactivity pass
+		// was added; the intent is that no pass reaches for the origin root.
+		expect( requested.length ).toBeGreaterThan( 0 );
+		expect( [ ...new Set( requested ) ] ).toEqual( [ 'https://example.com/handbook/intro' ] );
 	} );
 
 	it( 'refuses to compare a route the capture never took', async () => {

--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -55,12 +55,18 @@ export interface FidelityCheckOptions {
 	observe?: ObservePair;
 }
 
+/** A score, told which route produced it. */
+export type RouteScore = ViewportScore & { route: string };
+
 export interface FidelityReport {
 	sourceUrl: string;
 	websiteDir: string;
 	widths: number[];
+	/** Routes actually measured. */
 	routes: string[];
-	scores: ViewportScore[];
+	/** Routes the capture retained. Larger than `routes` only when the cap bit. */
+	routesAvailable: number;
+	scores: RouteScore[];
 	pass: boolean;
 	failed: number;
 	passed: number;
@@ -77,6 +83,12 @@ interface CaptureReceipt {
  * `/about/index.html` are the same place. Extensions other than a directory
  * index are left alone, because `/feed.xml` is a file rather than a directory.
  */
+/** Filesystem-safe stem for a route, so per-route evidence cannot collide. */
+export function evidenceSlug( route: string ): string {
+	const slug = route.replace( /[^a-z0-9]+/gi, '-' ).replace( /^-+|-+$/g, '' );
+	return slug || 'index';
+}
+
 export function canonicalRoutePath( route: string ): string {
 	const path = route.replace( /\\/g, '/' ).replace( /^\/*/, '/' ).split( /[?#]/ )[ 0 ] ?? '/';
 	if ( path === '/index.html' ) return '/';
@@ -352,15 +364,30 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 	if ( ! sourceUrl ) throw new Error( `capture-receipt.json has no source.url: ${ receiptPath }` );
 
 	const widths = options.widths ?? checkWidthsFor();
-	const routes = ( options.routes ?? [ '/' ] ).map( canonicalRoutePath );
 	const settleMs = options.settleMs ?? 4000;
 
 	const sources = routeSourceMap( receipt );
 	if ( ! sources.has( '/' ) ) sources.set( '/', sourceUrl );
-	for ( const route of routes ) {
+
+	// Every retained route, not just the homepage. A copy is claimed to preserve
+	// the whole site, so checking one page and reporting a pass describes the
+	// homepage while implying the site. The entrypoint leads so the most
+	// important failure surfaces first.
+	const captured = [ ...sources.keys() ].sort( ( left, right ) =>
+		left === '/' ? -1 : right === '/' ? 1 : left.localeCompare( right )
+	);
+	const requested = options.routes?.map( canonicalRoutePath );
+	for ( const route of requested ?? [] ) {
 		if ( sources.has( route ) ) continue;
 		throw new Error(
-			`Route ${ route } was not captured. Captured routes: ${ [ ...sources.keys() ].join( ', ' ) }`
+			`Route ${ route } was not captured. Captured routes: ${ captured.join( ', ' ) }`
+		);
+	}
+	const selected = requested ?? captured;
+	const routes = selected.slice( 0, MAX_ROUTE_CHECKS );
+	if ( selected.length > routes.length ) {
+		log(
+			`[compare] checking ${ routes.length } of ${ selected.length } routes (cap ${ MAX_ROUTE_CHECKS })`
 		);
 	}
 
@@ -386,7 +413,7 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 		};
 	}
 
-	const scores: ViewportScore[] = [];
+	const scores: RouteScore[] = [];
 	try {
 		for ( const route of routes ) {
 			const sourceHref = sources.get( route )!;
@@ -394,7 +421,12 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 			for ( const width of widths ) {
 				log( `[compare] ${ route } @ ${ width }px` );
 				const pair = await observe( sourceHref, localHref, width );
-				const evidenceDir = join( dirname( receiptPath ), 'compare', String( width ) );
+				const evidenceDir = join(
+					dirname( receiptPath ),
+					'compare',
+					evidenceSlug( route ),
+					String( width )
+				);
 				// Every check, built-in and contributed, runs through the registry.
 				const checked = await runFidelityChecks( {
 					route,
@@ -405,7 +437,8 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 					candidate: pair.liberated,
 					evidenceDir,
 				} );
-				const score: ViewportScore = {
+				const score: RouteScore = {
+					route,
 					viewport: width,
 					pass: checked.failures.length === 0,
 					failures: checked.failures,
@@ -446,10 +479,10 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 					hashTargets: [],
 					internalMissing: [],
 				} );
-				const score = scoreViewport(
-					dialogOnly( pair.source ),
-					dialogOnly( pair.liberated )
-				);
+				const score = {
+					...scoreViewport( dialogOnly( pair.source ), dialogOnly( pair.liberated ) ),
+					route,
+				};
 				score.notes.push( 'interactivity' );
 				scores.push( score );
 			}
@@ -460,5 +493,13 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 	}
 
 	const summary = scoreReport( scores );
-	return { sourceUrl, websiteDir, widths, routes, scores, ...summary };
+	return {
+		sourceUrl,
+		websiteDir,
+		widths,
+		routes,
+		routesAvailable: selected.length,
+		scores,
+		...summary,
+	};
 }

--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -9,8 +9,9 @@ import { dirname, join, resolve } from 'node:path';
 import { chromium, type Page } from 'playwright';
 import { startStaticServer } from '../replicate/local-site/static-server.js';
 import { DEFAULT_SWEEP_WIDTHS } from '../screenshot/fluid-capture.js';
-import { writePixelEvidence } from './evidence.js';
 import { runFidelityChecks } from './checks.js';
+import { writePixelEvidence } from './evidence.js';
+import { checkSelfConsistency, type SelfConsistencyReport } from './self-consistency.js';
 import {
 	scoreReport,
 	scoreViewport,
@@ -22,6 +23,9 @@ import {
 } from './score.js';
 
 const MAX_ROUTE_CHECKS = 32;
+
+/** Routes compared against the live source by default. Each costs a browser round trip. */
+const BROWSER_ROUTE_SAMPLE = 4;
 
 /**
  * Widths the learning sweep does not visit. 1600 and 1728 sit above the
@@ -49,6 +53,8 @@ export interface FidelityCheckOptions {
 	/** Pathnames to check, e.g. `/` and `/about/`. Default: homepage only. */
 	routes?: string[];
 	settleMs?: number;
+	/** How many routes to compare against the live source. */
+	sampleSize?: number;
 	/** Write source/liberated/diff PNGs. Never used as pass/fail. */
 	screenshots?: boolean;
 	log?: ( ( message: string ) => void ) | undefined;
@@ -64,8 +70,10 @@ export interface FidelityReport {
 	widths: number[];
 	/** Routes actually measured. */
 	routes: string[];
-	/** Routes the capture retained. Larger than `routes` only when the cap bit. */
+	/** Routes the capture retained. */
 	routesAvailable: number;
+	/** Offline checks over every route. */
+	selfConsistency: SelfConsistencyReport;
 	scores: RouteScore[];
 	pass: boolean;
 	failed: number;
@@ -83,6 +91,45 @@ interface CaptureReceipt {
  * `/about/index.html` are the same place. Extensions other than a directory
  * index are left alone, because `/feed.xml` is a file rather than a directory.
  */
+/** Route in the copy → its file, relative to the website directory. */
+export function routeFiles( receipt: CaptureReceipt ): Map< string, string > {
+	const websiteRoot = ( receipt.websiteRoot ?? 'website' ).replace( /\\/g, '/' ).replace( /\/*$/, '' );
+	const files = new Map< string, string >();
+	for ( const route of receipt.routes ?? [] ) {
+		if ( ! route?.url || ! route?.path ) continue;
+		const path = route.path.replace( /\\/g, '/' );
+		const relative =
+			websiteRoot && path.startsWith( `${ websiteRoot }/` )
+				? path.slice( websiteRoot.length + 1 )
+				: path;
+		files.set( canonicalRoutePath( `/${ relative.replace( /^\/*/, '' ) }` ), relative );
+	}
+	return files;
+}
+
+/**
+ * Pick `limit` routes spread evenly across the list, entrypoint first.
+ *
+ * Even spacing is the point. Taking the first N of an alphabetical list on a
+ * site with sixty posts and a shop page spends every check inside /blog/ and
+ * never reaches /shop/.
+ */
+export function spreadSample( routes: string[], limit: number ): string[] {
+	if ( limit <= 0 ) return [];
+	if ( routes.length <= limit ) return [ ...routes ];
+	const [ first, ...rest ] = routes as [ string, ...string[] ];
+	const picks = [ first ];
+	const take = limit - 1;
+	// Span both ends of the remainder. Stopping short leaves whatever sorts last
+	// — often the very sections a blog was burying — permanently unmeasured.
+	for ( let index = 0; index < take; index++ ) {
+		const position = take === 1 ? rest.length - 1 : Math.round( ( index * ( rest.length - 1 ) ) / ( take - 1 ) );
+		const candidate = rest[ position ];
+		if ( candidate && ! picks.includes( candidate ) ) picks.push( candidate );
+	}
+	return picks;
+}
+
 /** Filesystem-safe stem for a route, so per-route evidence cannot collide. */
 export function evidenceSlug( route: string ): string {
 	const slug = route.replace( /[^a-z0-9]+/gi, '-' ).replace( /^-+|-+$/g, '' );
@@ -369,10 +416,6 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 	const sources = routeSourceMap( receipt );
 	if ( ! sources.has( '/' ) ) sources.set( '/', sourceUrl );
 
-	// Every retained route, not just the homepage. A copy is claimed to preserve
-	// the whole site, so checking one page and reporting a pass describes the
-	// homepage while implying the site. The entrypoint leads so the most
-	// important failure surfaces first.
 	const captured = [ ...sources.keys() ].sort( ( left, right ) =>
 		left === '/' ? -1 : right === '/' ? 1 : left.localeCompare( right )
 	);
@@ -383,12 +426,22 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 			`Route ${ route } was not captured. Captured routes: ${ captured.join( ', ' ) }`
 		);
 	}
-	const selected = requested ?? captured;
-	const routes = selected.slice( 0, MAX_ROUTE_CHECKS );
-	if ( selected.length > routes.length ) {
-		log(
-			`[compare] checking ${ routes.length } of ${ selected.length } routes (cap ${ MAX_ROUTE_CHECKS })`
-		);
+
+	// Tier one: every route, offline. Anchors, internal links and stray remote
+	// assets are pure functions of what is on disk, so there is no reason to
+	// sample them.
+	const selfConsistency = checkSelfConsistency( websiteDir, routeFiles( receipt ) );
+	log(
+		`[compare] self-consistency: ${ selfConsistency.routes } route(s), ${ selfConsistency.findings.length } finding(s)`
+	);
+
+	// Tier two: the live source, which costs a browser round trip per check, so
+	// it runs on a bounded sample. The entrypoint always leads; the rest are
+	// spread across the route list rather than taken in order, since ordered
+	// selection on a blog spends the whole budget inside /blog/.
+	const routes = requested ?? spreadSample( captured, options.sampleSize ?? BROWSER_ROUTE_SAMPLE );
+	if ( ! requested && routes.length < captured.length ) {
+		log( `[compare] source fidelity: sampling ${ routes.length } of ${ captured.length } route(s)` );
 	}
 
 	let observe = options.observe;
@@ -493,12 +546,14 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 	}
 
 	const summary = scoreReport( scores );
+	summary.pass = summary.pass && selfConsistency.pass;
 	return {
 		sourceUrl,
 		websiteDir,
 		widths,
 		routes,
-		routesAvailable: selected.length,
+		routesAvailable: captured.length,
+		selfConsistency,
 		scores,
 		...summary,
 	};

--- a/src/lib/fidelity/self-consistency.test.ts
+++ b/src/lib/fidelity/self-consistency.test.ts
@@ -1,0 +1,141 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { checkSelfConsistency, summariseFindings } from './self-consistency.js';
+
+const dirs: string[] = [];
+afterEach( () => {
+	for ( const dir of dirs.splice( 0 ) ) rmSync( dir, { recursive: true, force: true } );
+} );
+
+function site( pages: Record< string, string > ): string {
+	const dir = mkdtempSync( join( tmpdir(), 'dla-selfcheck-' ) );
+	dirs.push( dir );
+	for ( const [ path, html ] of Object.entries( pages ) ) {
+		mkdirSync( join( dir, path, '..' ), { recursive: true } );
+		writeFileSync( join( dir, path ), html );
+	}
+	return dir;
+}
+
+const files = ( ...routes: Array< [ string, string ] > ) => new Map( routes );
+
+describe( 'checkSelfConsistency', () => {
+	it( 'accepts a copy whose links, anchors and assets all resolve locally', () => {
+		const dir = site( {
+			'index.html':
+				'<a href="/index.html#team">Team</a><a href="/about/">About</a><img src="/media/a.png"><h2 id="team">Team</h2>',
+			'about/index.html': '<a href="/">Home</a>',
+			'media/a.png': 'x',
+		} );
+		const report = checkSelfConsistency(
+			dir,
+			files( [ '/', 'index.html' ], [ '/about/', 'about/index.html' ] )
+		);
+		expect( report.findings ).toEqual( [] );
+		expect( report.pass ).toBe( true );
+		expect( report.routes ).toBe( 2 );
+	} );
+
+	it( 'catches a same-page anchor with no target', () => {
+		const dir = site( { 'index.html': '<a href="/index.html#missing">Jump</a>' } );
+		const report = checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) );
+		expect( report.findings ).toEqual( [
+			{ route: '/', kind: 'anchor-missing', detail: '/index.html#missing' },
+		] );
+	} );
+
+	it( 'catches an anchor that matches more than one target', () => {
+		// The desktop/mobile collision: the browser picks the first silently.
+		const dir = site( {
+			'index.html': '<a href="/index.html#team">Team</a><div id="team"></div><div id="team"></div>',
+		} );
+		const report = checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) );
+		expect( report.findings[ 0 ] ).toMatchObject( { kind: 'anchor-ambiguous' } );
+		expect( report.findings[ 0 ]?.detail ).toContain( '2 targets' );
+	} );
+
+	it( 'catches an internal link with no page behind it', () => {
+		const dir = site( { 'index.html': '<a href="/pricing/">Pricing</a>' } );
+		const report = checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) );
+		expect( report.findings ).toEqual( [
+			{ route: '/', kind: 'link-dangling', detail: '/pricing/' },
+		] );
+	} );
+
+	it( 'leaves links to other sites alone', () => {
+		const dir = site( { 'index.html': '<a href="https://wordpress.org/">WP</a><a href="mailto:a@b.c">Mail</a>' } );
+		expect( checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) ).pass ).toBe( true );
+	} );
+
+	it( 'leaves a canonical link alone, since nothing fetches it', () => {
+		const dir = site( {
+			'index.html':
+				'<link rel="canonical" href="https://rlj107.wixsite.com/createanchors"><h1>Home</h1>',
+		} );
+		expect( checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) ).pass ).toBe( true );
+	} );
+
+	it( 'catches a stylesheet that still points at the origin', () => {
+		const dir = site( { 'index.html': '<link rel="stylesheet" href="https://static.example.com/a.css">' } );
+		const report = checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) );
+		expect( report.findings ).toEqual( [
+			{ route: '/', kind: 'remote-asset', detail: 'static.example.com' },
+		] );
+	} );
+
+	it( 'catches an asset still pointing at the origin', () => {
+		const dir = site( { 'index.html': '<img src="https://static.wixstatic.com/media/a.png">' } );
+		const report = checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) );
+		expect( report.findings ).toEqual( [
+			{ route: '/', kind: 'remote-asset', detail: 'static.wixstatic.com' },
+		] );
+	} );
+
+	it( 'reports a route whose file was never written', () => {
+		const dir = site( { 'index.html': '<h1>Home</h1>' } );
+		const report = checkSelfConsistency(
+			dir,
+			files( [ '/', 'index.html' ], [ '/gone/', 'gone/index.html' ] )
+		);
+		expect( report.findings[ 0 ] ).toMatchObject( { route: '/gone/', kind: 'link-dangling' } );
+	} );
+} );
+
+describe( 'summariseFindings', () => {
+	it( 'groups one broken template instead of printing it per route', () => {
+		const findings = Array.from( { length: 60 }, ( _value, index ) => ( {
+			route: `/blog/post-${ index }/`,
+			kind: 'anchor-missing' as const,
+			detail: '#top',
+		} ) );
+		const [ group ] = summariseFindings( findings );
+		expect( group ).toMatchObject( { kind: 'anchor-missing', routes: 60 } );
+		expect( group?.examples ).toHaveLength( 3 );
+	} );
+} );
+
+describe( 'anchor link shapes the exporter actually emits', () => {
+	it( 'checks a bare fragment and a rewritten same-page link alike', () => {
+		for ( const href of [ '#team', '/index.html#team', 'index.html#team' ] ) {
+			const dir = site( { 'index.html': `<a href="${ href }">Team</a><div id="team"></div><div id="team"></div>` } );
+			const report = checkSelfConsistency( dir, files( [ '/', 'index.html' ] ) );
+			expect( report.findings[ 0 ], href ).toMatchObject( { kind: 'anchor-ambiguous' } );
+		}
+	} );
+
+	it( 'follows a cross-page anchor to the page that must contain it', () => {
+		const dir = site( {
+			'index.html': '<a href="/about/#team">Team</a>',
+			'about/index.html': '<h1>About</h1>',
+		} );
+		const report = checkSelfConsistency(
+			dir,
+			files( [ '/', 'index.html' ], [ '/about/', 'about/index.html' ] )
+		);
+		expect( report.findings ).toEqual( [
+			{ route: '/', kind: 'anchor-missing', detail: '/about/#team' },
+		] );
+	} );
+} );

--- a/src/lib/fidelity/self-consistency.ts
+++ b/src/lib/fidelity/self-consistency.ts
@@ -1,0 +1,181 @@
+// src/lib/fidelity/self-consistency.ts
+//
+// Does the copy work on its own terms?
+//
+// Most of what a liberated site can get wrong is answerable without the live
+// source and without a browser: an anchor with no target, a link to a page that
+// was never written, an asset still pointing at the origin CDN. Those are the
+// failures a reader actually hits, they are pure functions of what is on disk,
+// and checking them costs milliseconds — so every route gets checked, not a
+// sample.
+//
+// Comparing against the live source is a different and far more expensive
+// question, and it lives in check.ts.
+//
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as cheerio from 'cheerio';
+import { ASSET_LINK_REL, isRemoteAssetUrl } from '../self-contain.js';
+import { resolveRequestPath } from '../replicate/local-site/static-server.js';
+
+export type FindingKind = 'anchor-missing' | 'anchor-ambiguous' | 'link-dangling' | 'remote-asset';
+
+export interface Finding {
+	route: string;
+	kind: FindingKind;
+	detail: string;
+}
+
+export interface SelfConsistencyReport {
+	/** Routes examined. Always all of them. */
+	routes: number;
+	findings: Finding[];
+	pass: boolean;
+}
+
+/** Asset references that must resolve inside the copy for it to stand alone. */
+const ASSET_REFS: Array< [ string, string ] > = [
+	[ 'img[src]', 'src' ],
+	[ 'source[src]', 'src' ],
+	[ 'video[src]', 'src' ],
+	[ 'audio[src]', 'src' ],
+	[ 'script[src]', 'src' ],
+	[ 'link[href]', 'href' ],
+];
+
+/**
+ * Count elements a fragment would resolve to in a document.
+ *
+ * Cached by file, because a shared nav means the same target page is asked
+ * about once per route otherwise.
+ */
+function fragmentTargets(
+	cache: Map< string, cheerio.CheerioAPI | null >,
+	file: string,
+	fragment: string
+): number | null {
+	let $ = cache.get( file );
+	if ( $ === undefined ) {
+		try {
+			$ = cheerio.load( readFileSync( file, 'utf8' ) );
+		} catch {
+			$ = null;
+		}
+		cache.set( file, $ );
+	}
+	if ( ! $ ) return null;
+	return $( '[id],a[name]' ).filter(
+		( _index, target ) =>
+			$!( target ).attr( 'id' ) === fragment || $!( target ).attr( 'name' ) === fragment
+	).length;
+}
+
+/**
+ * Check every route in the copy for defects visible without the source.
+ *
+ * `resolveRequestPath` is the same resolver the local preview server uses, so a
+ * link this reports as dangling is one that would genuinely 404 when someone
+ * clicked it.
+ */
+export function checkSelfConsistency(
+	websiteDir: string,
+	routeFiles: Map< string, string >
+): SelfConsistencyReport {
+	const findings: Finding[] = [];
+	const documents = new Map< string, cheerio.CheerioAPI | null >();
+
+	for ( const [ route, relative ] of routeFiles ) {
+		let html: string;
+		try {
+			html = readFileSync( join( websiteDir, relative ), 'utf8' );
+		} catch {
+			findings.push( { route, kind: 'link-dangling', detail: `route file missing: ${ relative }` } );
+			continue;
+		}
+		const $ = cheerio.load( html );
+
+		const seen = new Set< string >();
+		$( 'a[href]' ).each( ( _index, element ) => {
+			const href = ( $( element ).attr( 'href' ) ?? '' ).trim();
+			if ( ! href || href === '#' ) return;
+			if ( /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test( href ) ) return; // external or non-http scheme
+			if ( seen.has( href ) ) return;
+			seen.add( href );
+
+			const [ rawPath = '', rawFragment = '' ] = href.split( '#' );
+			// The export rewrites same-page links to `/index.html#fragment`, so a
+			// link is same-document by where it resolves, not by how it is spelled.
+			const target = rawPath
+				? resolveRequestPath( websiteDir, rawPath.startsWith( '/' ) ? rawPath : `/${ join( relative, '..', rawPath ) }` )
+				: join( websiteDir, relative );
+			if ( ! target ) {
+				findings.push( { route, kind: 'link-dangling', detail: href } );
+				return;
+			}
+			if ( ! rawFragment ) return;
+
+			let fragment: string;
+			try {
+				fragment = decodeURIComponent( rawFragment );
+			} catch {
+				return;
+			}
+			if ( ! fragment ) return;
+
+			const targets = fragmentTargets( documents, target, fragment );
+			if ( targets === null ) return;
+			if ( targets === 0 ) {
+				findings.push( { route, kind: 'anchor-missing', detail: href } );
+			} else if ( targets > 1 ) {
+				// Two targets and the browser silently picks the first, which is how
+				// a mobile anchor ends up scrolling to a hidden desktop section.
+				findings.push( {
+					route,
+					kind: 'anchor-ambiguous',
+					detail: `${ href } matches ${ targets } targets`,
+				} );
+			}
+		} );
+
+		const seenRemote = new Set< string >();
+		for ( const [ selector, attribute ] of ASSET_REFS ) {
+			$( selector ).each( ( _index, element ) => {
+				const node = $( element );
+				// A <link> only counts when its rel actually fetches something.
+				if ( selector.startsWith( 'link' ) ) {
+					const relations = ( node.attr( 'rel' ) ?? '' ).toLowerCase().split( /\s+/ );
+					if ( ! relations.some( ( relation ) => ASSET_LINK_REL.test( relation ) ) ) return;
+				}
+				const value = ( node.attr( attribute ) ?? '' ).trim();
+				if ( ! value || ! isRemoteAssetUrl( value ) ) return;
+				let host: string;
+				try {
+					host = new URL( value.startsWith( '//' ) ? `https:${ value }` : value ).hostname;
+				} catch {
+					return;
+				}
+				if ( seenRemote.has( host ) ) return;
+				seenRemote.add( host );
+				findings.push( { route, kind: 'remote-asset', detail: host } );
+			} );
+		}
+	}
+
+	return { routes: routeFiles.size, findings, pass: findings.length === 0 };
+}
+
+/** Group findings for reporting, so one broken template does not print 60 times. */
+export function summariseFindings( findings: Finding[] ): Array< { kind: FindingKind; routes: number; examples: string[] } > {
+	const byKind = new Map< FindingKind, { routes: Set< string >; examples: string[] } >();
+	for ( const finding of findings ) {
+		const entry = byKind.get( finding.kind ) ?? { routes: new Set< string >(), examples: [] };
+		entry.routes.add( finding.route );
+		if ( entry.examples.length < 3 ) entry.examples.push( `${ finding.route } ${ finding.detail }` );
+		byKind.set( finding.kind, entry );
+	}
+	return [ ...byKind ].map( ( [ kind, entry ] ) => ( {
+		kind,
+		routes: entry.routes.size,
+		examples: entry.examples,
+	} ) );
+}

--- a/src/lib/self-contain.ts
+++ b/src/lib/self-contain.ts
@@ -5,7 +5,12 @@ import * as cheerio from 'cheerio';
 const EMPTY_CSS_URL = 'data:application/octet-stream;base64,';
 const TRANSPARENT_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=';
 
-const ASSET_LINK_REL = /^(?:stylesheet|preload|prefetch|preconnect|dns-prefetch|prerender|modulepreload|manifest)$|(?:^|-)icon$/;
+/**
+ * `rel` values that make a `<link>` fetch something. `canonical` and
+ * `alternate` are metadata: they name a URL without requesting it, so a copy
+ * that still points at its origin there is not reaching out to the network.
+ */
+export const ASSET_LINK_REL = /^(?:stylesheet|preload|prefetch|preconnect|dns-prefetch|prerender|modulepreload|manifest)$|(?:^|-)icon$/;
 
 export function isRemoteAssetUrl( value: string ): boolean {
 	const url = value.trim().replace( /&amp;/g, '&' );

--- a/src/ui/compare.ts
+++ b/src/ui/compare.ts
@@ -5,6 +5,7 @@
 // and never decides pass/fail.
 //
 import { checkFidelity, type FidelityReport } from '../lib/fidelity/check.js';
+import { summariseFindings } from '../lib/fidelity/self-consistency.js';
 
 export async function runCompare(
 	directory: string,
@@ -16,6 +17,21 @@ export async function runCompare(
 		log: ( message ) => process.stderr.write( `${ message }\n` ),
 	} );
 
+	// Tier one, over every route.
+	const consistency = report.selfConsistency;
+	if ( consistency.pass ) {
+		process.stdout.write( `self-consistency ok across ${ consistency.routes } route(s)\n` );
+	} else {
+		for ( const group of summariseFindings( consistency.findings ) ) {
+			process.stdout.write(
+				`self-consistency FAIL ${ group.kind }: ${ group.routes } route(s) — ${ group.examples.join(
+					'; '
+				) }\n`
+			);
+		}
+	}
+
+	// Tier two, over the sampled routes.
 	for ( const score of report.scores ) {
 		const mark = score.pass ? 'ok' : 'FAIL';
 		process.stdout.write( `${ score.route } ${ score.viewport }px ${ mark }` );
@@ -25,15 +41,12 @@ export async function runCompare(
 	}
 
 	// Say what was measured, not just how it went. "Passed" over an unstated
-	// scope is how a homepage-only check gets read as a whole-site result.
-	const checked =
-		report.routes.length === report.routesAvailable
-			? `${ report.routes.length } route(s)`
-			: `${ report.routes.length } of ${ report.routesAvailable } route(s)`;
+	// scope is how a sampled check gets read as a whole-site result.
+	const scope = `${ consistency.routes } route(s) checked offline, ${ report.routes.length } of ${ report.routesAvailable } compared to source`;
 	process.stdout.write(
 		report.pass
-			? `Passed ${ report.passed } check(s) across ${ checked } against ${ report.sourceUrl }\n`
-			: `Failed ${ report.failed }/${ report.passed + report.failed } check(s) across ${ checked } against ${ report.sourceUrl }\n`
+			? `Passed: ${ scope }, against ${ report.sourceUrl }\n`
+			: `Failed ${ report.failed } source check(s) and ${ consistency.findings.length } offline finding(s): ${ scope }, against ${ report.sourceUrl }\n`
 	);
 	return report;
 }

--- a/src/ui/compare.ts
+++ b/src/ui/compare.ts
@@ -18,15 +18,22 @@ export async function runCompare(
 
 	for ( const score of report.scores ) {
 		const mark = score.pass ? 'ok' : 'FAIL';
-		process.stdout.write( `${ score.viewport }px ${ mark }` );
+		process.stdout.write( `${ score.route } ${ score.viewport }px ${ mark }` );
 		if ( ! score.pass ) process.stdout.write( `: ${ score.failures.join( '; ' ) }` );
 		if ( score.notes.length ) process.stdout.write( `  (${ score.notes.join( '; ' ) })` );
 		process.stdout.write( '\n' );
 	}
+
+	// Say what was measured, not just how it went. "Passed" over an unstated
+	// scope is how a homepage-only check gets read as a whole-site result.
+	const checked =
+		report.routes.length === report.routesAvailable
+			? `${ report.routes.length } route(s)`
+			: `${ report.routes.length } of ${ report.routesAvailable } route(s)`;
 	process.stdout.write(
 		report.pass
-			? `Passed ${ report.passed } viewport(s) against ${ report.sourceUrl }\n`
-			: `Failed ${ report.failed }/${ report.passed + report.failed } viewport(s) against ${ report.sourceUrl }\n`
+			? `Passed ${ report.passed } check(s) across ${ checked } against ${ report.sourceUrl }\n`
+			: `Failed ${ report.failed }/${ report.passed + report.failed } check(s) across ${ checked } against ${ report.sourceUrl }\n`
 	);
 	return report;
 }


### PR DESCRIPTION
## Summary

Four changes, all in service of proving the HTML contract with evidence instead of assertion.

### 1. The gate measured one page and reported a pass

`compare` defaulted to `['/']` and `ui/compare.ts` passed no routes, so a 4-route liberation printed `Passed 3 viewport(s)`. The product claims to preserve *every retained route*; that summary described the homepage while implying the site.

The receipt already carries the route table — compare now walks it, entrypoint first, bounded by the `MAX_ROUTE_CHECKS` constant that was already defined and previously only bounded internal-link checks. When the cap bites, the run says so, and the report carries `routesAvailable` beside the routes actually measured, so a narrowed scope is stated rather than implied.

**Measured against a live 4-route Wix site, with body content stripped from one non-homepage route:**

```
old scope (homepage only)
  / 1600px ok
  / 1728px ok
  / 390px ok
  Passed 3 viewport(s)                                        exit 0

new scope (route table)
  / 1600px ok
  /anchor/ 1600px FAIL: text 62 chars !== source 707;
                        nav 6 same-page anchor(s) missing: #seaturtle #narwal #crab
  /example/ 1600px ok
  /informative-video/ 1600px ok
  Failed 2/12 check(s) across 4 route(s)                      exit 1
```

The old gate was **green on a broken copy**.

Cost is ~25s per route, so a full liberation takes minutes rather than seconds. That is the correct trade: a gate that read one page in three seconds was not measuring the thing being claimed.

### 2. Liberation exits

`data-liberation <url>` started a local server and held the process open until interrupted, so every programmatic caller had to pass `--no-serve` — the skill, a Studio wrapper, CI, and any agent running it in a shell, where it reads as a hang rather than a preview. The documented bare command was the one that never returned.

```
without --no-serve: exit=124 elapsed=30s   (killed; never exits)
with    --no-serve: exit=0   elapsed=1s
```

Liberation now writes the site and exits. `--serve` opts into the server, and every non-serving run prints that command on stderr so stdout stays the machine-readable result. Existing `--no-serve` invocations keep working, since unrecognised flags are ignored and not serving is now the default.

### 3. One skill, driving the CLI

The front door described a pipeline instead of the product. Searching the whole agent surface — skills, commands, prompts, docs, README, AGENTS.md, CLAUDE.md — for the words the contract is made of:

| Term | Hits before this PR |
|---|---|
| `spacefast` | 0 |
| `data-liberation publish` | 0 |
| `data-liberation compare` | 0 |

The publish registry, the Spacefast target, and the fidelity gate were invisible to every agent entry point. The skill is now the three verbs the CLI exposes: 331 lines of routing become 128 lines of operating the tool.

### 4. Repairs `main`

`main` is currently red — CI fails at `58de3823`. #113 added a 390px interactivity pass; #112 added a test asserting one observation per width. They were written in parallel and merged **nine seconds apart**, so neither branch ever ran the other's code and #112's run was cancelled by #113's merge. Nothing was wrong with either change. The assertion now states its real intent — every pass asks for the captured page rather than the origin root — which holds however many passes compare grows.

## Verified while writing

Every command, flag, and quoted output in the skill was run against a live site rather than copied from existing docs. Two claims did not survive that:

- **Reuse is not automatic.** A plain re-run recaptures; `--resume` is what reports `(1 reused)`. The previous skill's idempotence claim was not true of the CLI's behavior, and the first draft of this one repeated it.
- **An anonymous publish is private.** The real output ends with `This space is private by default, so the live URL returns 403 until access is granted`, plus a claim link and deadline. An agent reporting only the live URL hands the operator a 403.

## Scope

The WordPress reconstruction skills and MCP tools are untouched, and are now orphaned rather than load-bearing — nothing on the product path reaches them. Removing them is a separate change, and this gate is what will prove the product still works as it comes out.

## Verification

- Full suite: **3,112 passed**, 1 skipped, 1 todo.
- `npm run test:package` passes.
- Live 4-route Wix liberation gated clean, then failed correctly with one route damaged.
- Full liberate → compare → publish chain run end to end against `https://example.com/`.

## AI assistance

Claude via OpenCode was used to inventory the skill and MCP surface, verify the CLI contract against live runs, diagnose the red `main`, find the homepage-only gate scope, and construct the damaged-route counterfactual. Chris Huber reviewed and orchestrated the work and remains responsible for the submitted changes.