### PR TITLE
Fail compare when the copy loses images the source renders

### DIFF
--- a/src/lib/fidelity/check.test.ts
+++ b/src/lib/fidelity/check.test.ts
@@ -34,6 +34,7 @@ const obs = ( viewport: number, extra: Partial< LayoutObservation > = {} ): Layo
 	title: 'Home',
 	textChars: 10,
 	widestImage: viewport,
+	images: [],
 	docWidth: viewport,
 	overflow: false,
 	externalHosts: [],
@@ -169,6 +170,23 @@ describe( 'checkFidelity', () => {
 		} );
 		expect( report.pass ).toBe( false );
 		expect( report.failed ).toBe( 1 );
+	} );
+
+	it( 'fails the report when the copy renders fewer images than the source', async () => {
+		const slides = ( viewport: number ) => [
+			{ key: 'slide-a.jpg', x: 0, y: 96, width: viewport, height: 600 },
+			{ key: 'slide-b.jpg', x: 0, y: 96, width: viewport, height: 600 },
+		];
+		const report = await checkFidelity( {
+			directory: liberatedRun(),
+			widths: [ 1600 ],
+			observe: async ( _source, _local, viewport ) => ( {
+				source: obs( viewport, { images: slides( viewport ) } ),
+				liberated: obs( viewport, { images: [] } ),
+			} ),
+		} );
+		expect( report.pass ).toBe( false );
+		expect( report.scores[ 0 ]?.failures[ 0 ] ).toMatch( /^images 2 of 2 missing: slide-a\.jpg/ );
 	} );
 
 	it( 'records a pixel score as evidence without letting it fail the gate', async () => {

--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -13,6 +13,7 @@ import { writePixelEvidence } from './evidence.js';
 import {
 	scoreReport,
 	scoreViewport,
+	normalizeImageKey,
 	type DialogProbe,
 	type HashTarget,
 	type LayoutObservation,
@@ -156,9 +157,27 @@ async function observePage(
 		await page.goto( url, { waitUntil: 'domcontentloaded', timeout: 60_000 } ).catch( () => {} );
 		await page.waitForTimeout( settleMs );
 		const measured = await page.evaluate( async ( clickUnresolved: boolean ) => {
-			const images = [ ...document.querySelectorAll( 'img' ) ]
-				.map( ( image ) => image.getBoundingClientRect() )
-				.filter( ( rect ) => rect.width > 50 && rect.height > 50 );
+			// Images that occupy real layout space at this viewport: wider and
+			// taller than 50px (the same floor as widestImage) and not
+			// visibility:hidden, so tracking pixels and hidden decorations add
+			// no noise. opacity:0 is deliberately kept — a carousel's parked
+			// slides are transparent yet still hold the slideshow's layout
+			// box, and a copy that drops them all is exactly the regression
+			// the image-count gate exists to catch.
+			const images = [ ...document.querySelectorAll< HTMLImageElement >( 'img' ) ]
+				.map( ( image ) => ( {
+					rect: image.getBoundingClientRect(),
+					src: image.currentSrc || image.getAttribute( 'src' ) || '',
+					hidden: getComputedStyle( image ).visibility === 'hidden',
+				} ) )
+				.filter( ( { rect, hidden } ) => ! hidden && rect.width > 50 && rect.height > 50 )
+				.map( ( { rect, src } ) => ( {
+					key: src,
+					x: Math.round( rect.x ),
+					y: Math.round( rect.y ),
+					width: Math.round( rect.width ),
+					height: Math.round( rect.height ),
+				} ) );
 			const hashTargets: { fragment: string; resolved: boolean; targets: number }[] = [];
 			const internalPaths: string[] = [];
 			const seen = new Set< string >();
@@ -238,8 +257,9 @@ async function observePage(
 				title: document.title,
 				textChars: ( document.body?.innerText ?? '' ).replace( /\s+/g, ' ' ).trim().length,
 				widestImage: images.length
-					? Math.round( Math.max( ...images.map( ( rect ) => rect.width ) ) )
+					? Math.max( ...images.map( ( image ) => image.width ) )
 					: null,
+				images,
 				docWidth: document.documentElement.scrollWidth,
 				overflow: document.documentElement.scrollWidth > window.innerWidth,
 				hashTargets,
@@ -307,6 +327,10 @@ async function observePage(
 			title: measured.title,
 			textChars: measured.textChars,
 			widestImage: measured.widestImage,
+			images: measured.images.map( ( image ) => ( {
+				...image,
+				key: normalizeImageKey( image.key ),
+			} ) ),
 			docWidth: measured.docWidth,
 			overflow: measured.overflow,
 			externalHosts: [ ...external ].sort(),
@@ -391,6 +415,7 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 					title: 'x',
 					textChars: 0,
 					widestImage: null,
+					images: [],
 					overflow: false,
 					docWidth: 390,
 					externalHosts: [],

--- a/src/lib/fidelity/score.test.ts
+++ b/src/lib/fidelity/score.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { scoreReport, scoreViewport, type LayoutObservation } from './score.js';
+import {
+	normalizeImageKey,
+	scoreReport,
+	scoreViewport,
+	type LayoutObservation,
+	type RenderedImage,
+} from './score.js';
 
 const at = ( viewport: number, extra: Partial< LayoutObservation > = {} ): LayoutObservation => ( {
 	viewport,
 	title: 'Home',
 	textChars: 336,
 	widestImage: viewport,
+	images: [],
 	docWidth: viewport,
 	overflow: false,
 	externalHosts: [],
@@ -13,6 +20,14 @@ const at = ( viewport: number, extra: Partial< LayoutObservation > = {} ): Layou
 	internalMissing: [],
 	dialogs: [],
 	...extra,
+} );
+
+const img = ( key: string, x: number, y: number, width: number, height: number ): RenderedImage => ( {
+	key,
+	x,
+	y,
+	width,
+	height,
 } );
 
 describe( 'scoreViewport', () => {
@@ -124,8 +139,92 @@ describe( 'scoreViewport', () => {
 		);
 	} );
 
+	it( 'passes when the copy renders the same images as the source', () => {
+		const images = [ img( 'hero.jpg', 0, 96, 1600, 600 ), img( 'team.jpg', 32, 900, 400, 300 ) ];
+		const score = scoreViewport( at( 1600, { images } ), at( 1600, { images } ) );
+		expect( score.pass ).toBe( true );
+		expect( score.failures ).toEqual( [] );
+	} );
+
+	it( 'fails when the copy ships an empty slideshow, naming how many slides and where they sit', () => {
+		// The Ummels regression: the copy kept the header banner (so the
+		// widest-image check passed) but rendered the homepage slideshow with
+		// zero slides, and compare passed at 1600/1728/390 because nothing
+		// counted rendered images.
+		const header = img( 'header.jpg', 0, 0, 1600, 96 );
+		const slides = [
+			img( 'dakkapel-slide.jpg', 0, 96, 1600, 600 ),
+			img( 'goot-slide.jpg', 0, 96, 1600, 600 ),
+			img( 'bedrijfsbus-slide.jpg', 0, 96, 1600, 600 ),
+		];
+		const score = scoreViewport(
+			at( 1600, { images: [ header, ...slides ] } ),
+			at( 1600, { images: [ header ] } )
+		);
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /^images 3 of 4 missing/ );
+		expect( score.failures[ 0 ] ).toContain( 'dakkapel-slide.jpg 1600x600 at (0,96)' );
+	} );
+
+	it( 'does not fail when the copy renders extra images', () => {
+		const source = [ img( 'hero.jpg', 0, 0, 1600, 600 ) ];
+		const copy = [
+			img( 'hero.jpg', 0, 0, 1600, 600 ),
+			img( 'wordpress-badge.png', 700, 2400, 200, 80 ),
+		];
+		const score = scoreViewport( at( 1600, { images: source } ), at( 1600, { images: copy } ) );
+		expect( score.pass ).toBe( true );
+		expect( score.notes ).toContain( 'images 1 extra in copy (not a failure)' );
+	} );
+
+	it( 'tolerates one missing image for lazy-load or carousel drift', () => {
+		const source = [ img( 'hero.jpg', 0, 0, 1600, 600 ), img( 'footer-badge.png', 640, 2400, 320, 120 ) ];
+		const score = scoreViewport(
+			at( 1600, { images: source } ),
+			at( 1600, { images: source.slice( 0, 1 ) } )
+		);
+		expect( score.pass ).toBe( true );
+		expect( score.notes ).toContain( 'images 1 missing within tolerance' );
+	} );
+
+	it( 'matches same-named images by count, not presence', () => {
+		const gallery = [ img( 'divider.jpg', 0, 800, 1600, 60 ), img( 'divider.jpg', 0, 1600, 1600, 60 ), img( 'divider.jpg', 0, 2400, 1600, 60 ) ];
+		const score = scoreViewport( at( 1600, { images: gallery } ), at( 1600, { images: gallery.slice( 0, 1 ) } ) );
+		expect( score.pass ).toBe( false );
+		expect( score.failures[ 0 ] ).toMatch( /^images 2 of 3 missing/ );
+	} );
+
 	it( 'refuses to score mismatched viewports', () => {
 		expect( () => scoreViewport( at( 1440 ), at( 1600 ) ) ).toThrow( /mismatched viewports/ );
+	} );
+} );
+
+describe( 'normalizeImageKey', () => {
+	it( 'keeps identity across re-localized URLs', () => {
+		expect( normalizeImageKey( 'https://cdn.example.com/img/hero.jpg?v=3' ) ).toBe(
+			normalizeImageKey( 'http://localhost:8871/wp-content/uploads/2026/08/hero.jpg' )
+		);
+	} );
+
+	it( 'strips WordPress collision and generated-size suffixes', () => {
+		expect( normalizeImageKey( '/wp-content/uploads/2026/08/hero-2.jpg' ) ).toBe( 'hero.jpg' );
+		expect( normalizeImageKey( 'https://a.example.com/img/hero-1024x576.jpg' ) ).toBe( 'hero.jpg' );
+		expect( normalizeImageKey( 'https://a.example.com/img/HERO-scaled.jpg' ) ).toBe( 'hero.jpg' );
+	} );
+
+	it( 'leaves meaningful name parts alone', () => {
+		expect( normalizeImageKey( 'https://a.example.com/img/hero-card.jpg' ) ).toBe( 'hero-card.jpg' );
+	} );
+
+	it( 'collapses inline payloads to a stable token', () => {
+		expect( normalizeImageKey( 'data:image/png;base64,AAAA' ) ).toBe( 'data:image/png' );
+		expect( normalizeImageKey( 'data:image/png;base64,BBBB' ) ).toBe( 'data:image/png' );
+	} );
+
+	it( 'collapses runtime-minted blob URLs to a stable token', () => {
+		expect( normalizeImageKey( 'blob:https://example.com/8b1a-uuid' ) ).toBe(
+			normalizeImageKey( 'blob:http://localhost:8871/different-uuid' )
+		);
 	} );
 } );
 

--- a/src/lib/fidelity/score.ts
+++ b/src/lib/fidelity/score.ts
@@ -6,6 +6,22 @@
 // capture width certifies the exact failure mode. This compares at a width the
 // caller chose, and the check runner picks widths the sweep never sampled.
 //
+/**
+ * One image the page actually renders at this viewport: where it sits (the
+ * rounded box, in CSS pixels) plus a normalized source identity. The pair is
+ * the stable key — the copy hosts media under its own URLs, so the basename
+ * is the only identity that survives localization, and the box is what makes
+ * a loss nameable ("the slideshow at the top is gone", not "an image went
+ * missing somewhere").
+ */
+export interface RenderedImage {
+	key: string;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
 export interface LayoutObservation {
 	/** Viewport width the observation was taken at. */
 	viewport: number;
@@ -14,6 +30,9 @@ export interface LayoutObservation {
 	textChars: number;
 	/** Widest visible image, in CSS pixels. Null when none. */
 	widestImage: number | null;
+	/** Images rendering with real layout space at this viewport. Tracking
+	 *  pixels and hidden decorations are excluded by the observer. */
+	images: RenderedImage[];
 	/** documentElement.scrollWidth. */
 	docWidth: number;
 	/** True when the document is wider than the viewport. */
@@ -54,6 +73,56 @@ export interface ViewportScore {
 /** Image width may drift by a pixel of rounding; more than this is a freeze. */
 export const IMAGE_TOLERANCE_PX = 2;
 
+/**
+ * The copy may render this many fewer images than the source at a single
+ * viewport without failing. One is the largest drift still explained by
+ * known-benign causes: a carousel parked on a different slide between the two
+ * observations, or a single below-the-fold image only the live source
+ * hydrated with an intrinsic size inside the settle window. Real losses
+ * arrive in sets — the empty-slideshow regression dropped every slide (three
+ * or more) at once at every width — so more than one missing image at the
+ * same viewport is treated as content loss, not noise.
+ */
+export const MISSING_IMAGE_TOLERANCE = 1;
+
+/**
+ * Stable identity for one rendered image. The copy re-hosts media under its
+ * own URLs and WordPress appends collision and generated-size suffixes, so
+ * identity is the basename, lowercased, with query/hash and those suffixes
+ * stripped: `hero-2.jpg`, `hero-1024x576.jpg`, and `hero-scaled.jpg` are all
+ * `hero.jpg`. Inline and runtime-minted payloads collapse to a stable token
+ * because their URLs are not a comparable identity.
+ */
+export function normalizeImageKey( src: string ): string {
+	if ( ! src ) return '';
+	if ( src.startsWith( 'data:' ) ) return `data:${ src.slice( 5 ).split( ';' )[ 0 ] ?? '' }`;
+	if ( src.startsWith( 'blob:' ) ) return 'blob:';
+	const path = src.split( /[?#]/ )[ 0 ] ?? '';
+	const slash = path.lastIndexOf( '/' );
+	const name = ( slash >= 0 ? path.slice( slash + 1 ) : path ).toLowerCase();
+	const stripped = name.replace( /-(?:\d+x\d+|scaled|\d+)(?=\.[a-z0-9]+$)/, '' );
+	return stripped || name;
+}
+
+/**
+ * Source images with no copy counterpart, matched key-by-key as a multiset so
+ * a page using the same file twice must render it twice. Extra copy images
+ * are not the caller's problem: additions do not fail this gate.
+ */
+function missingRenderedImages( source: RenderedImage[], copy: RenderedImage[] ): RenderedImage[] {
+	const available = new Map< string, number >();
+	for ( const image of copy ) {
+		available.set( image.key, ( available.get( image.key ) ?? 0 ) + 1 );
+	}
+	const missing: RenderedImage[] = [];
+	for ( const image of source ) {
+		const left = available.get( image.key ) ?? 0;
+		if ( left > 0 ) available.set( image.key, left - 1 );
+		else missing.push( image );
+	}
+	return missing;
+}
+
 export function scoreViewport(
 	source: LayoutObservation,
 	liberated: LayoutObservation
@@ -86,6 +155,28 @@ export function scoreViewport(
 				liberated.widestImage - source.widestImage
 			})`
 		);
+	}
+
+	// The empty-slideshow gate: the widest image can survive (a header banner
+	// covers it) while an entire slideshow below it renders nothing. Counting
+	// what each side actually renders is the only way that regression fails.
+	const missingImages = missingRenderedImages( source.images, liberated.images );
+	if ( missingImages.length > MISSING_IMAGE_TOLERANCE ) {
+		failures.push(
+			`images ${ missingImages.length } of ${ source.images.length } missing: ${ missingImages
+				.slice( 0, 3 )
+				.map(
+					( image ) =>
+						`${ image.key } ${ image.width }x${ image.height } at (${ image.x },${ image.y })`
+				)
+				.join( '; ' ) }`
+		);
+	} else if ( missingImages.length > 0 ) {
+		notes.push( `images ${ missingImages.length } missing within tolerance` );
+	}
+	const matchedImages = source.images.length - missingImages.length;
+	if ( liberated.images.length > matchedImages ) {
+		notes.push( `images ${ liberated.images.length - matchedImages } extra in copy (not a failure)` );
 	}
 
 	if ( liberated.overflow && ! source.overflow ) {


### PR DESCRIPTION
## Summary

`compare` measured layout, navigation, and interactivity, but never counted rendered images. dakdekkersbedrijf-ummels.nl proved the cost: its homepage slideshow captured as an empty TPA iframe, the copy shipped zero slides, and the gate was green at 1600, 1728, and 390.

The paired observation now records the images each side actually renders at that viewport — rounded box plus a localization-stable identity — and a viewport fails when the copy is missing more than `MISSING_IMAGE_TOLERANCE` of them. The failure names how many were lost and where they sat.

Identity is the basename with query, hash, and WordPress collision/size suffixes stripped, because the copy re-hosts media under its own URLs. Matching is a multiset, so a page using one file twice must render it twice. Extra images in the copy do not fail the gate.

Fixes #120

## Verification

`npx vitest run src/lib/fidelity` — 41 passed

## AI assistance

OpenCode (Z.ai GLM-5.3) implemented the rendered-image comparison and its tests from the issue specification, through a Homeboy cook that ran the gate and opened this pull request. Chris Huber directed the work.