### PR TITLE
Make image identity survive our own localization

### DIFF
--- a/src/lib/fidelity/score.test.ts
+++ b/src/lib/fidelity/score.test.ts
@@ -207,13 +207,30 @@ describe( 'normalizeImageKey', () => {
 	} );
 
 	it( 'strips WordPress collision and generated-size suffixes', () => {
-		expect( normalizeImageKey( '/wp-content/uploads/2026/08/hero-2.jpg' ) ).toBe( 'hero.jpg' );
-		expect( normalizeImageKey( 'https://a.example.com/img/hero-1024x576.jpg' ) ).toBe( 'hero.jpg' );
-		expect( normalizeImageKey( 'https://a.example.com/img/HERO-scaled.jpg' ) ).toBe( 'hero.jpg' );
+		expect( normalizeImageKey( '/wp-content/uploads/2026/08/hero-2.jpg' ) ).toBe( 'hero' );
+		expect( normalizeImageKey( 'https://a.example.com/img/hero-1024x576.jpg' ) ).toBe( 'hero' );
+		expect( normalizeImageKey( 'https://a.example.com/img/HERO-scaled.jpg' ) ).toBe( 'hero' );
+	} );
+
+	it( 'survives a re-encoded, tilde-folded Wix media id', () => {
+		// Measured on a live liberation: the source serves `~mv2.png` from
+		// wixstatic and the copy serves `-mv2-2.avif` from its own media
+		// directory. Matching on the filename reported every image both
+		// missing and extra at once.
+		const source =
+			'https://static.wixstatic.com/media/84770f_036df751d6ad458abdb34ad1da5a52fb~mv2.png/v1/fill/w_919,h_131/84770f_036df751d6ad458abdb34ad1da5a52fb~mv2.png';
+		const copy = 'http://127.0.0.1:53001/media/84770f_036df751d6ad458abdb34ad1da5a52fb-mv2-2.avif';
+		expect( normalizeImageKey( copy ) ).toBe( normalizeImageKey( source ) );
+	} );
+
+	it( 'treats a re-encoded image as the same image', () => {
+		expect( normalizeImageKey( 'https://a.example.com/img/hero.png' ) ).toBe(
+			normalizeImageKey( 'http://127.0.0.1:53001/media/hero.avif' )
+		);
 	} );
 
 	it( 'leaves meaningful name parts alone', () => {
-		expect( normalizeImageKey( 'https://a.example.com/img/hero-card.jpg' ) ).toBe( 'hero-card.jpg' );
+		expect( normalizeImageKey( 'https://a.example.com/img/hero-card.jpg' ) ).toBe( 'hero-card' );
 	} );
 
 	it( 'collapses inline payloads to a stable token', () => {

--- a/src/lib/fidelity/score.ts
+++ b/src/lib/fidelity/score.ts
@@ -86,12 +86,23 @@ export const IMAGE_TOLERANCE_PX = 2;
 export const MISSING_IMAGE_TOLERANCE = 1;
 
 /**
- * Stable identity for one rendered image. The copy re-hosts media under its
- * own URLs and WordPress appends collision and generated-size suffixes, so
- * identity is the basename, lowercased, with query/hash and those suffixes
- * stripped: `hero-2.jpg`, `hero-1024x576.jpg`, and `hero-scaled.jpg` are all
- * `hero.jpg`. Inline and runtime-minted payloads collapse to a stable token
- * because their URLs are not a comparable identity.
+ * Stable identity for one rendered image, built to survive localization.
+ *
+ * The identity has to hold across three renamings, because the source URL and
+ * the copy's URL are never the same string:
+ *
+ * - **Directory.** The copy re-hosts media under its own path, so only the
+ *   basename can contribute.
+ * - **Extension.** Capture negotiates image formats, so a source `.png` is
+ *   commonly served from the copy as `.avif`. Format is not identity.
+ * - **Separators and suffixes.** Wix media ids carry a `~` that localization
+ *   rewrites to `-`, and both WordPress and our own collision handling append
+ *   numeric and generated-size suffixes.
+ *
+ * So `…~mv2.png` on wixstatic and `…-mv2-2.avif` in the copy are one image,
+ * as are `hero.jpg`, `hero-2.jpg`, `hero-1024x576.jpg` and `hero-scaled.jpg`.
+ * Inline and runtime-minted payloads collapse to a stable token because their
+ * URLs are not a comparable identity.
  */
 export function normalizeImageKey( src: string ): string {
 	if ( ! src ) return '';
@@ -100,8 +111,10 @@ export function normalizeImageKey( src: string ): string {
 	const path = src.split( /[?#]/ )[ 0 ] ?? '';
 	const slash = path.lastIndexOf( '/' );
 	const name = ( slash >= 0 ? path.slice( slash + 1 ) : path ).toLowerCase();
-	const stripped = name.replace( /-(?:\d+x\d+|scaled|\d+)(?=\.[a-z0-9]+$)/, '' );
-	return stripped || name;
+	const stem = name.replace( /\.[a-z0-9]+$/, '' );
+	const folded = stem.replace( /~/g, '-' );
+	const stripped = folded.replace( /-(?:\d+x\d+|scaled|\d+)$/, '' );
+	return stripped || folded || name;
 }
 
 /**


### PR DESCRIPTION
## Summary

The rendered-image check added in #121 fails **every image** on a live Wix liberation, reporting them missing and extra simultaneously:

```
/informative-video/ 1600px FAIL: images 8 of 8 missing: 84770f_df0e…~mv2.png 1600x122 at (0,408); …
                                (images 8 extra in copy (not a failure))
```

Equal counts on both sides is the tell — the images are present, under keys that cannot match. Measured on the pair:

```
source key: 84770f_036df751d6ad458abdb34ad1da5a52fb~mv2.png
copy   key: 84770f_036df751d6ad458abdb34ad1da5a52fb-mv2.avif
```

Two renamings the identity did not survive, and **both are ours rather than the platform's**:

1. **`~` → `-`** — localization rewrites the tilde in a Wix media id when it writes the file.
2. **`.png` → `.avif`** — capture negotiates image formats, so source and copy routinely differ in extension.

Identity now compares the extensionless stem with `~` folded to `-`. A re-encoded image is therefore correctly the same image.

Neither renaming is Wix-specific. Format negotiation is the default path, so this failed on **any source whose media is re-encoded**, which is most of them.

## Verification

Against the same live 4-route Wix site that exposed it, the 8-of-8 image failures are gone.

Unit coverage added for both renamings, using the real measured pair rather than a synthetic one:

- a `~mv2.png` wixstatic URL and a `-mv2-2.avif` copy URL resolve to one key
- `hero.png` and `hero.avif` resolve to one key

Existing expectations updated for the extensionless stem (`hero-2.jpg` → `hero`, previously `hero.jpg`); the collapsing behaviour is unchanged.

Suite: 3,128 passed.

## Unrelated finding

While verifying, the same site fails reproducibly with `text 686 chars !== source 665` at 1600px while passing at 1728px — the copy renders 21 more characters at one width only. Identical across repeated runs, and untouched by this change, which only affects image keys. Recording it here rather than folding it in.

## AI assistance

Claude via OpenCode diagnosed the false positive from a live gate run, identified the two renamings, implemented the fix and its tests, and verified against the original site. Chris Huber reviewed and orchestrated the work and remains responsible for the submitted changes.