### PR TITLE
Open the comparison to contributed checks

### DIFF
--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -10,6 +10,7 @@ import { chromium, type Page } from 'playwright';
 import { startStaticServer } from '../replicate/local-site/static-server.js';
 import { DEFAULT_SWEEP_WIDTHS } from '../screenshot/fluid-capture.js';
 import { writePixelEvidence } from './evidence.js';
+import { runFidelityChecks } from './checks.js';
 import {
 	scoreReport,
 	scoreViewport,
@@ -393,9 +394,27 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 			for ( const width of widths ) {
 				log( `[compare] ${ route } @ ${ width }px` );
 				const pair = await observe( sourceHref, localHref, width );
-				const score = scoreViewport( pair.source, pair.liberated );
+				const evidenceDir = join( dirname( receiptPath ), 'compare', String( width ) );
+				// Every check, built-in and contributed, runs through the registry.
+				const checked = await runFidelityChecks( {
+					route,
+					viewport: width,
+					sourceUrl: sourceHref,
+					candidateUrl: localHref,
+					source: pair.source,
+					candidate: pair.liberated,
+					evidenceDir,
+				} );
+				const score: ViewportScore = {
+					viewport: width,
+					pass: checked.failures.length === 0,
+					failures: checked.failures,
+					notes: checked.notes,
+					source: pair.source,
+					liberated: pair.liberated,
+				};
+				for ( const artifact of checked.artifacts ) score.notes.push( `evidence → ${ artifact }` );
 				if ( pair.sourcePng && pair.liberatedPng ) {
-					const evidenceDir = join( dirname( receiptPath ), 'compare', String( width ) );
 					const evidence = writePixelEvidence( evidenceDir, pair.sourcePng, pair.liberatedPng );
 					if ( 'score' in evidence ) {
 						score.notes.push(
@@ -407,6 +426,11 @@ export async function checkFidelity( options: FidelityCheckOptions ): Promise< F
 				}
 				scores.push( score );
 			}
+			// The interactivity pass deliberately does not run the check registry.
+			// It blanks every field except dialogs so that one narrow question can
+			// be asked at a width the layout comparison does not cover, and handing
+			// a contributed check a synthetic observation would invite it to draw
+			// conclusions from values that were zeroed rather than measured.
 			if ( ! widths.includes( 390 ) ) {
 				log( `[compare] ${ route } @ 390px interactivity` );
 				const pair = await observe( sourceHref, localHref, 390 );

--- a/src/lib/fidelity/checks.test.ts
+++ b/src/lib/fidelity/checks.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	fidelityCheckNames,
+	findFidelityCheck,
+	registerFidelityCheck,
+	runFidelityChecks,
+	unregisterFidelityCheck,
+	type FidelityCheckContext,
+} from './checks.js';
+import type { LayoutObservation } from './score.js';
+
+const observation = ( extra: Partial< LayoutObservation > = {} ): LayoutObservation => ( {
+	viewport: 1600,
+	title: 'Home',
+	textChars: 10,
+	widestImage: 1600,
+	images: [],
+	docWidth: 1600,
+	overflow: false,
+	externalHosts: [],
+	hashTargets: [],
+	internalMissing: [],
+	dialogs: [],
+	...extra,
+} );
+
+const context = ( extra: Partial< FidelityCheckContext > = {} ): FidelityCheckContext => ( {
+	route: '/',
+	viewport: 1600,
+	sourceUrl: 'https://example.com/',
+	candidateUrl: 'http://127.0.0.1:1234/',
+	source: observation(),
+	candidate: observation(),
+	evidenceDir: '/tmp/evidence',
+	...extra,
+} );
+
+afterEach( () => {
+	for ( const name of fidelityCheckNames() ) {
+		if ( name !== 'core' ) unregisterFidelityCheck( name );
+	}
+} );
+
+describe( 'the check registry', () => {
+	it( 'ships the built-in comparison registered through the public API', () => {
+		expect( fidelityCheckNames() ).toContain( 'core' );
+		expect( findFidelityCheck( 'core' ) ).not.toBeNull();
+	} );
+
+	it( 'refuses a duplicate name unless replacement is explicit', () => {
+		registerFidelityCheck( { name: 'visual', run: () => ( {} ) } );
+		expect( () => registerFidelityCheck( { name: 'visual', run: () => ( {} ) } ) ).toThrow(
+			/already registered/
+		);
+		expect( () =>
+			registerFidelityCheck( { name: 'visual', run: () => ( {} ) }, { replace: true } )
+		).not.toThrow();
+	} );
+
+	it( 'needs a name', () => {
+		expect( () => registerFidelityCheck( { name: '   ', run: () => ( {} ) } ) ).toThrow(
+			/needs a name/
+		);
+	} );
+
+	it( 'lets a consumer replace the built-in comparison entirely', async () => {
+		const builtIn = findFidelityCheck( 'core' )!;
+		try {
+			registerFidelityCheck(
+				{ name: 'core', run: () => ( { failures: [ 'my own rules' ] } ) },
+				{ replace: true }
+			);
+			expect( ( await runFidelityChecks( context() ) ).failures ).toEqual( [ 'my own rules' ] );
+		} finally {
+			// The registry is process-wide state, so a test that swaps the
+			// built-in has to put it back or it leaks into every later run.
+			registerFidelityCheck( builtIn, { replace: true } );
+		}
+	} );
+} );
+
+describe( 'runFidelityChecks', () => {
+	it( 'merges failures, notes and artifacts across checks', async () => {
+		registerFidelityCheck( {
+			name: 'visual',
+			run: () => ( {
+				failures: [ 'hero moved 40px' ],
+				notes: [ 'mismatch 0.031' ],
+				artifacts: [ '/tmp/evidence/diff.png' ],
+			} ),
+		} );
+
+		const result = await runFidelityChecks( context() );
+		expect( result.failures ).toContain( 'hero moved 40px' );
+		expect( result.notes ).toContain( 'mismatch 0.031' );
+		expect( result.artifacts ).toEqual( [ '/tmp/evidence/diff.png' ] );
+	} );
+
+	it( 'awaits an async check, so a harness can shell out', async () => {
+		registerFidelityCheck( {
+			name: 'sandboxed',
+			run: async () => {
+				await new Promise( ( resolve ) => setTimeout( resolve, 5 ) );
+				return { notes: [ 'ran out of process' ] };
+			},
+		} );
+		expect( ( await runFidelityChecks( context() ) ).notes ).toContain( 'ran out of process' );
+	} );
+
+	it( 'gives a check the target pair, not only the observations', async () => {
+		let seen: FidelityCheckContext | null = null;
+		registerFidelityCheck( {
+			name: 'records-context',
+			run: ( ctx ) => {
+				seen = ctx;
+				return {};
+			},
+		} );
+
+		await runFidelityChecks( context() );
+		expect( seen! ).toMatchObject( {
+			route: '/',
+			viewport: 1600,
+			sourceUrl: 'https://example.com/',
+			candidateUrl: 'http://127.0.0.1:1234/',
+			evidenceDir: '/tmp/evidence',
+		} );
+	} );
+
+	it( 'reports a throwing check as a failure instead of losing the rest of the gate', async () => {
+		registerFidelityCheck( {
+			name: 'broken',
+			run: () => {
+				throw new Error( 'sandbox unavailable' );
+			},
+		} );
+		registerFidelityCheck( { name: 'still-runs', run: () => ( { notes: [ 'unaffected' ] } ) } );
+
+		const result = await runFidelityChecks( context() );
+		expect( result.failures.some( ( f ) => /"broken" failed to run: sandbox unavailable/.test( f ) ) ).toBe(
+			true
+		);
+		expect( result.notes ).toContain( 'unaffected' );
+	} );
+
+	it( 'runs the built-in against the observation pair', async () => {
+		const result = await runFidelityChecks(
+			context( { candidate: observation( { textChars: 400 } ) } )
+		);
+		expect( result.failures.some( ( f ) => /text 400 chars/.test( f ) ) ).toBe( true );
+	} );
+} );

--- a/src/lib/fidelity/checks.ts
+++ b/src/lib/fidelity/checks.ts
@@ -1,0 +1,137 @@
+// src/lib/fidelity/checks.ts
+//
+// The comparison extension point.
+//
+// A check inspects one route at one viewport and reports what diverged. The
+// built-in comparison registers through this same call rather than a
+// privileged branch, because a door only one caller can open is not a door.
+//
+// Checks may be async and may write their own evidence, because the useful
+// ones are not pure functions of an observation: a visual comparison shells
+// out to a browser harness, captures its own screenshots, and leaves artifacts
+// behind. Handing a check the target URLs as well as the observations lets it
+// do its own looking instead of being limited to what this module already
+// measured.
+//
+import { scoreViewport, type LayoutObservation } from './score.js';
+
+export interface FidelityCheckContext {
+	/** Route in the copy, e.g. `/` or `/about/`. */
+	route: string;
+	viewport: number;
+	/** Live source URL for this route. */
+	sourceUrl: string;
+	/** Local URL serving the liberated copy of this route. */
+	candidateUrl: string;
+	source: LayoutObservation;
+	candidate: LayoutObservation;
+	/** Directory a check may write evidence into. Created on demand by the check. */
+	evidenceDir: string;
+}
+
+export interface FidelityCheckResult {
+	/** Divergences that fail the run. */
+	failures?: string[];
+	/** Observations worth reporting that do not fail the run. */
+	notes?: string[];
+	/** Paths to evidence this check wrote, for the report to reference. */
+	artifacts?: string[];
+}
+
+export interface FidelityCheck {
+	/** Unique name. Also how a consumer replaces or removes this check. */
+	name: string;
+	run(
+		context: FidelityCheckContext
+	): FidelityCheckResult | Promise< FidelityCheckResult >;
+}
+
+export interface RegisterCheckOptions {
+	/** Replace an existing registration of the same name. */
+	replace?: boolean;
+}
+
+const checks = new Map< string, FidelityCheck >();
+
+/**
+ * Make a check part of `data-liberation compare`.
+ *
+ * Duplicate names throw rather than silently overwrite: two checks quietly
+ * claiming one name is the kind of thing that surfaces as a mystery when a
+ * gate passes something it should have caught.
+ */
+export function registerFidelityCheck(
+	check: FidelityCheck,
+	options: RegisterCheckOptions = {}
+): void {
+	const name = check.name.trim().toLowerCase();
+	if ( ! name ) throw new Error( 'A fidelity check needs a name.' );
+	if ( checks.has( name ) && ! options.replace ) {
+		throw new Error(
+			`Fidelity check "${ name }" is already registered. Pass { replace: true } to override it.`
+		);
+	}
+	checks.set( name, { ...check, name } );
+}
+
+/** Remove a registration. For tests, and for hosts swapping a check. */
+export function unregisterFidelityCheck( name: string ): boolean {
+	return checks.delete( name.trim().toLowerCase() );
+}
+
+export function findFidelityCheck( name: string ): FidelityCheck | null {
+	return checks.get( name.trim().toLowerCase() ) ?? null;
+}
+
+export function fidelityCheckNames(): string[] {
+	return [ ...checks.keys() ].sort();
+}
+
+/**
+ * Run every registered check against one route at one viewport.
+ *
+ * A check that throws is reported as a failure under its own name rather than
+ * aborting the run: one badly behaved consumer should not be able to silence
+ * the rest of the gate, and a check that cannot run is itself a finding.
+ */
+export async function runFidelityChecks(
+	context: FidelityCheckContext
+): Promise< Required< FidelityCheckResult > > {
+	const failures: string[] = [];
+	const notes: string[] = [];
+	const artifacts: string[] = [];
+
+	for ( const check of checks.values() ) {
+		try {
+			const result = await check.run( context );
+			failures.push( ...( result.failures ?? [] ) );
+			notes.push( ...( result.notes ?? [] ) );
+			artifacts.push( ...( result.artifacts ?? [] ) );
+		} catch ( error ) {
+			failures.push(
+				`check "${ check.name }" failed to run: ${
+					error instanceof Error ? error.message : String( error )
+				}`
+			);
+		}
+	}
+
+	return { failures, notes, artifacts };
+}
+
+/**
+ * The built-in comparison: everything `scoreViewport` measures from a pair of
+ * observations — title, text, geometry, rendered images, overflow, external
+ * hosts, same-page anchors, internal links, dialogs.
+ *
+ * Registered here rather than called directly so that the built-in and any
+ * contributed check enter through the same door. A consumer that wants
+ * different semantics can replace it by name.
+ */
+registerFidelityCheck( {
+	name: 'core',
+	run: ( { source, candidate } ) => {
+		const score = scoreViewport( source, candidate );
+		return { failures: score.failures, notes: score.notes };
+	},
+} );


### PR DESCRIPTION
## Summary

Source detection has adapters. Publishing has a target registry. Comparison had no way in — `scoreViewport` was a fixed sequence of conditions, so a consumer wanting different semantics had to fork it.

Checks now register the way publish targets do:

```ts
registerFidelityCheck( {
  name: 'visual',
  run: async ( { route, viewport, sourceUrl, candidateUrl, source, candidate, evidenceDir } ) => ( {
    failures: [ … ],
    notes: [ … ],
    artifacts: [ … ],
  } ),
} );
```

The built-in comparison registers through that same call under the name `core`, rather than a privileged branch — a door only one caller can open is not a door. A consumer can replace it by name.

## The shape came from a real contributor

WP Codebox's visual-compare primitive (Automattic/wp-codebox#732) is the concrete case, and three of its properties decided the interface:

| It does this | So a check must |
|---|---|
| Runs a browser harness in a Playground sandbox | be **async** |
| Captures its own screenshots from a URL pair | receive **`sourceUrl` and `candidateUrl`**, not only the observations we already computed |
| Emits `source.png`, `candidate.png`, `diff.png`, `visual-diff.json` | be able to report **artifacts** |

That last column is why this is a registry rather than a config option: it lets Codebox contribute without Data Liberation Agent depending on Codebox, which is the boundary #732 set for itself.

A check that throws is reported as a failure under its own name instead of aborting the run. One badly behaved consumer should not be able to silence the rest of the gate, and a check that cannot run is itself a finding.

## One deliberate exclusion

The 390px interactivity pass does not run the registry. It blanks every field except dialogs so one narrow question can be asked at a width the layout comparison does not cover, and a contributed check handed that observation would be reading zeroes as measurements. Commented in place so it reads as a decision rather than an oversight.

## Verification

A check registered from **outside the package**, against a live 4-route Wix liberation:

```
contributed check ran 2 times
artifacts referenced: 2
sample: visual-stub compared / @ 1600 | evidence → …/compare/1600/visual-diff.json
```

It received the real target pair:

```json
{
  "route": "/",
  "viewport": 1600,
  "sourceUrl": "https://rlj107.wixsite.com/createanchors",
  "candidateUrl": "http://127.0.0.1:60957/"
}
```

And a contributed failure fails the run, reported alongside the built-in's:

```
pass: false | failures: images 23 of 23 missing: …; design threshold not met
```

Suite: 3,135 passed. Existing fidelity tests are unchanged and still pass, because `core` produces identical results.

## Note

The image failures in that last output are the false positive fixed separately in #122, which targets `main`. They disappear once that lands.

## AI assistance

Claude via OpenCode inspected the WP Codebox visual-compare surface to derive the interface constraints, implemented the registry and its tests, and verified with an externally registered check against a live site. Chris Huber directed and reviewed the work.
