### PR TITLE
Gate image geometry, typography, and motion parity

### DIFF
--- a/src/lib/fidelity/check.ts
+++ b/src/lib/fidelity/check.ts
@@ -238,6 +238,106 @@ async function observePage(
 					width: Math.round( rect.width ),
 					height: Math.round( rect.height ),
 				} ) );
+
+			const typography: Array< {
+				key: string;
+				fontFamily: string;
+				fontWeight: string;
+				fontSize: number;
+				lineHeight: number;
+				letterSpacing: number;
+				advance: number;
+				loaded: boolean;
+			} > = [];
+			const canvas = document.createElement( 'canvas' );
+			const context = canvas.getContext( '2d' );
+			const walker = document.createTreeWalker( document.body, NodeFilter.SHOW_TEXT );
+			let textNode: Node | null;
+			while ( typography.length < 120 && ( textNode = walker.nextNode() ) ) {
+				const parent = textNode.parentElement;
+				const text = ( textNode.textContent ?? '' ).replace( /\s+/g, ' ' ).trim();
+				if ( ! parent || ! text || parent.closest( 'script,style,noscript,template' ) ) continue;
+				const range = document.createRange();
+				range.selectNodeContents( textNode );
+				const rect = range.getBoundingClientRect();
+				const style = getComputedStyle( parent );
+				if (
+					rect.width <= 0 ||
+					rect.height <= 0 ||
+					style.display === 'none' ||
+					style.visibility === 'hidden'
+				) {
+					continue;
+				}
+				const fontSize = Number.parseFloat( style.fontSize ) || 0;
+				const font = `${ style.fontStyle } ${ style.fontWeight } ${ style.fontSize } ${ style.fontFamily }`;
+				if ( context ) context.font = font;
+				typography.push( {
+					key: text.slice( 0, 120 ),
+					fontFamily: style.fontFamily,
+					fontWeight: style.fontWeight,
+					fontSize,
+					lineHeight: Number.parseFloat( style.lineHeight ) || fontSize * 1.2,
+					letterSpacing: Number.parseFloat( style.letterSpacing ) || 0,
+					advance: Math.round( ( context?.measureText( text ).width ?? rect.width ) * 100 ) / 100,
+					loaded: document.fonts.check( font, text ),
+				} );
+			}
+
+			const occurrencesBefore = new Map< string, number >();
+			const animationsBefore = document
+				.getAnimations()
+				.filter( ( animation ) => animation.effect?.getComputedTiming().iterations !== Infinity )
+				.map( ( animation ) => {
+					const name = ( animation as Animation & { animationName?: string } ).animationName;
+					if ( ! name || name === 'none' ) return null;
+					const occurrence = occurrencesBefore.get( name ) ?? 0;
+					occurrencesBefore.set( name, occurrence + 1 );
+					return {
+						key: `${ name }:${ occurrence }`,
+						name,
+						time: animation.currentTime?.toString() ?? 'null',
+						state: animation.playState,
+					};
+				} )
+				.filter( ( animation ): animation is NonNullable< typeof animation > => animation !== null );
+			const animationStateBefore = new Map(
+				animationsBefore.map( ( animation ) => [ animation.key, animation ] )
+			);
+			const originalScroll = { x: scrollX, y: scrollY };
+			const root = document.documentElement;
+			const scrollBehavior = root.style.scrollBehavior;
+			root.style.scrollBehavior = 'auto';
+			window.scrollTo( 0, Math.min( document.documentElement.scrollHeight - innerHeight, innerHeight * 1.5 ) );
+			await new Promise( ( resolve ) => requestAnimationFrame( () => requestAnimationFrame( resolve ) ) );
+			await new Promise( ( resolve ) => setTimeout( resolve, 250 ) );
+			const occurrencesAfter = new Map< string, number >();
+			const animationsAfter = document
+				.getAnimations()
+				.filter( ( animation ) => animation.effect?.getComputedTiming().iterations !== Infinity )
+				.map( ( animation ) => {
+					const name = ( animation as Animation & { animationName?: string } ).animationName;
+					if ( ! name || name === 'none' ) return null;
+					const occurrence = occurrencesAfter.get( name ) ?? 0;
+					occurrencesAfter.set( name, occurrence + 1 );
+					return {
+						key: `${ name }:${ occurrence }`,
+						name,
+						time: animation.currentTime?.toString() ?? 'null',
+						state: animation.playState,
+					};
+				} )
+				.filter( ( animation ): animation is NonNullable< typeof animation > => animation !== null );
+			const responsiveAnimations = animationsAfter
+				.filter( ( animation ) => {
+					const before = animationStateBefore.get( animation.key );
+					return ! before || before.time !== animation.time || before.state !== animation.state;
+				} )
+				.map( ( animation ) => animation.name )
+				.sort();
+			window.scrollTo( originalScroll.x, originalScroll.y );
+			root.style.scrollBehavior = scrollBehavior;
+			const animations = animationsBefore.map( ( animation ) => animation.name ).sort();
 			const hashTargets: { fragment: string; resolved: boolean; targets: number }[] = [];
 			const internalPaths: string[] = [];
 			const seen = new Set< string >();
@@ -320,6 +420,9 @@ async function observePage(
 					? Math.max( ...images.map( ( image ) => image.width ) )
 					: null,
 				images,
+				typography,
+				animations,
+				responsiveAnimations,
 				docWidth: document.documentElement.scrollWidth,
 				overflow: document.documentElement.scrollWidth > window.innerWidth,
 				hashTargets,
@@ -391,6 +494,9 @@ async function observePage(
 				...image,
 				key: normalizeImageKey( image.key ),
 			} ) ),
+			typography: measured.typography,
+			animations: measured.animations,
+			responsiveAnimations: measured.responsiveAnimations,
 			docWidth: measured.docWidth,
 			overflow: measured.overflow,
 			externalHosts: [ ...external ].sort(),

--- a/src/lib/fidelity/checks.test.ts
+++ b/src/lib/fidelity/checks.test.ts
@@ -37,13 +37,15 @@ const context = ( extra: Partial< FidelityCheckContext > = {} ): FidelityCheckCo
 
 afterEach( () => {
 	for ( const name of fidelityCheckNames() ) {
-		if ( name !== 'core' ) unregisterFidelityCheck( name );
+		if ( ! [ 'core', 'image-geometry', 'motion', 'typography' ].includes( name ) ) {
+			unregisterFidelityCheck( name );
+		}
 	}
 } );
 
 describe( 'the check registry', () => {
 	it( 'ships the built-in comparison registered through the public API', () => {
-		expect( fidelityCheckNames() ).toContain( 'core' );
+		expect( fidelityCheckNames() ).toEqual( [ 'core', 'image-geometry', 'motion', 'typography' ] );
 		expect( findFidelityCheck( 'core' ) ).not.toBeNull();
 	} );
 

--- a/src/lib/fidelity/checks.ts
+++ b/src/lib/fidelity/checks.ts
@@ -14,6 +14,11 @@
 // measured.
 //
 import { scoreViewport, type LayoutObservation } from './score.js';
+import {
+	checkImageGeometry,
+	checkMotion,
+	checkTypography,
+} from './rendered-contract-checks.js';
 
 export interface FidelityCheckContext {
 	/** Route in the copy, e.g. `/` or `/about/`. */
@@ -134,4 +139,19 @@ registerFidelityCheck( {
 		const score = scoreViewport( source, candidate );
 		return { failures: score.failures, notes: score.notes };
 	},
+} );
+
+registerFidelityCheck( {
+	name: 'image-geometry',
+	run: ( { source, candidate } ) => checkImageGeometry( source, candidate ),
+} );
+
+registerFidelityCheck( {
+	name: 'typography',
+	run: ( { source, candidate } ) => checkTypography( source, candidate ),
+} );
+
+registerFidelityCheck( {
+	name: 'motion',
+	run: ( { source, candidate } ) => checkMotion( source, candidate ),
 } );

--- a/src/lib/fidelity/rendered-contract-checks.test.ts
+++ b/src/lib/fidelity/rendered-contract-checks.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+	checkImageGeometry,
+	checkMotion,
+	checkTypography,
+} from './rendered-contract-checks.js';
+import type { LayoutObservation, RenderedImage, RenderedTextStyle } from './score.js';
+
+const observation = ( extra: Partial< LayoutObservation > = {} ): LayoutObservation => ( {
+	viewport: 1600,
+	title: 'Home',
+	textChars: 10,
+	widestImage: 1600,
+	images: [],
+	docWidth: 1600,
+	overflow: false,
+	externalHosts: [],
+	hashTargets: [],
+	internalMissing: [],
+	dialogs: [],
+	...extra,
+} );
+
+const image = ( key: string, x: number, y: number, width = 400, height = 300 ): RenderedImage => ( {
+	key,
+	x,
+	y,
+	width,
+	height,
+} );
+
+const text = ( extra: Partial< RenderedTextStyle > = {} ): RenderedTextStyle => ( {
+	key: 'Nimbus Commute',
+	fontFamily: 'aether, sans-serif',
+	fontWeight: '400',
+	fontSize: 64,
+	lineHeight: 70,
+	letterSpacing: 0,
+	advance: 480,
+	loaded: true,
+	...extra,
+} );
+
+describe( 'checkImageGeometry', () => {
+	it( 'fails when a matched image moves outside tolerance', () => {
+		const result = checkImageGeometry(
+			observation( { images: [ image( 'hero', 0, 96, 1600, 600 ) ] } ),
+			observation( { images: [ image( 'hero', 32, 140, 1600, 600 ) ] } )
+		);
+		expect( result.failures?.[ 0 ] ).toContain( 'hero source 1600x600 at (0,96)' );
+		expect( result.failures?.[ 0 ] ).toContain( 'copy 1600x600 at (32,140)' );
+	} );
+
+	it( 'matches repeated images to their nearest geometry', () => {
+		const source = [ image( 'tile', 0, 100 ), image( 'tile', 0, 900 ) ];
+		const candidate = [ image( 'tile', 2, 902 ), image( 'tile', 2, 102 ) ];
+		expect(
+			checkImageGeometry( observation( { images: source } ), observation( { images: candidate } ) )
+		).toEqual( {} );
+	} );
+
+	it( 'allows small browser rounding drift', () => {
+		expect(
+			checkImageGeometry(
+				observation( { images: [ image( 'hero', 0, 100, 400, 300 ) ] } ),
+				observation( { images: [ image( 'hero', 8, 108, 404, 296 ) ] } )
+			)
+		).toEqual( {} );
+	} );
+} );
+
+describe( 'checkTypography', () => {
+	it( 'fails on computed family, weight, and metric drift', () => {
+		const result = checkTypography(
+			observation( { typography: [ text() ] } ),
+			observation( {
+				typography: [
+					text( {
+						fontFamily: 'Arial, sans-serif',
+						fontWeight: '700',
+						fontSize: 60,
+						advance: 430,
+					} ),
+				],
+			} )
+		);
+		expect( result.failures?.[ 0 ] ).toContain( 'family Arial, sans-serif !== aether, sans-serif' );
+		expect( result.failures?.[ 0 ] ).toContain( 'weight 700 !== 400' );
+		expect( result.failures?.[ 0 ] ).toContain( 'advance 430px !== 480px' );
+	} );
+
+	it( 'detects a named face that failed to load through its rendered advance', () => {
+		const result = checkTypography(
+			observation( { typography: [ text() ] } ),
+			observation( { typography: [ text( { advance: 455, loaded: false } ) ] } )
+		);
+		expect( result.failures?.[ 0 ] ).toContain( 'font face is not loaded' );
+		expect( result.failures?.[ 0 ] ).toContain( 'advance 455px !== 480px' );
+	} );
+
+	it( 'matches duplicate text runs by nearest style', () => {
+		const source = [ text(), text( { fontSize: 24, lineHeight: 30, advance: 180 } ) ];
+		const candidate = [ source[ 1 ], source[ 0 ] ];
+		expect(
+			checkTypography(
+				observation( { typography: source } ),
+				observation( { typography: candidate } )
+			)
+		).toEqual( {} );
+	} );
+
+	it( 'fails when too few source text runs can be matched', () => {
+		const source = Array.from( { length: 10 }, ( _, index ) => text( { key: `run-${ index }` } ) );
+		const result = checkTypography(
+			observation( { typography: source } ),
+			observation( { typography: source.slice( 0, 3 ) } )
+		);
+		expect( result.failures?.[ 0 ] ).toContain( 'typography coverage 3 of 10 (30%)' );
+	} );
+} );
+
+describe( 'checkMotion', () => {
+	it( 'fails when the copy loses most finite CSS animations', () => {
+		const source = Array.from( { length: 20 }, ( _, index ) => `reveal-${ index }` );
+		const result = checkMotion(
+			observation( { animations: source } ),
+			observation( { animations: source.slice( 0, 2 ) } )
+		);
+		expect( result.failures?.[ 0 ] ).toContain( 'animation coverage 2 of 20 (10%)' );
+	} );
+
+	it( 'passes when the copy preserves at least eighty percent by name', () => {
+		const source = Array.from( { length: 10 }, ( _, index ) => `reveal-${ index }` );
+		expect(
+			checkMotion(
+				observation( { animations: source } ),
+				observation( { animations: source.slice( 0, 8 ) } )
+			)
+		).toEqual( {} );
+	} );
+
+	it( 'fails when preserved animations do not respond to controlled scroll', () => {
+		const animations = Array.from( { length: 10 }, ( _, index ) => `reveal-${ index }` );
+		const result = checkMotion(
+			observation( { animations, responsiveAnimations: animations } ),
+			observation( { animations, responsiveAnimations: animations.slice( 0, 2 ) } )
+		);
+		expect( result.failures?.[ 0 ] ).toContain( 'responsive animation coverage 2 of 10 (20%)' );
+	} );
+
+	it( 'does not require motion from a source that has none', () => {
+		expect(
+			checkMotion( observation( { animations: [] } ), observation( { animations: [] } ) )
+		).toEqual( {} );
+	} );
+} );

--- a/src/lib/fidelity/rendered-contract-checks.ts
+++ b/src/lib/fidelity/rendered-contract-checks.ts
@@ -1,0 +1,221 @@
+import type { FidelityCheckResult } from './checks.js';
+import type { LayoutObservation, RenderedImage, RenderedTextStyle } from './score.js';
+
+export const IMAGE_POSITION_TOLERANCE_PX = 8;
+export const IMAGE_SIZE_TOLERANCE_PX = 4;
+export const TYPOGRAPHY_METRIC_TOLERANCE_PX = 1;
+export const TYPOGRAPHY_COVERAGE_FLOOR = 0.8;
+export const MOTION_COVERAGE_FLOOR = 0.8;
+
+interface ImagePair {
+	source: RenderedImage;
+	candidate: RenderedImage;
+}
+
+function imageDistance( source: RenderedImage, candidate: RenderedImage ): number {
+	return (
+		Math.abs( source.x - candidate.x ) +
+		Math.abs( source.y - candidate.y ) +
+		Math.abs( source.width - candidate.width ) +
+		Math.abs( source.height - candidate.height )
+	);
+}
+
+/** Match repeated images by identity and nearest geometry rather than array order. */
+function matchedImages( source: RenderedImage[], candidate: RenderedImage[] ): ImagePair[] {
+	const available = new Map< string, RenderedImage[] >();
+	for ( const image of candidate ) {
+		const group = available.get( image.key ) ?? [];
+		group.push( image );
+		available.set( image.key, group );
+	}
+
+	const pairs: ImagePair[] = [];
+	for ( const image of source ) {
+		const group = available.get( image.key );
+		if ( ! group?.length ) continue;
+		let nearest = 0;
+		for ( let index = 1; index < group.length; index++ ) {
+			if ( imageDistance( image, group[ index ] ) < imageDistance( image, group[ nearest ] ) ) {
+				nearest = index;
+			}
+		}
+		pairs.push( { source: image, candidate: group.splice( nearest, 1 )[ 0 ] } );
+	}
+	return pairs;
+}
+
+export function checkImageGeometry(
+	source: LayoutObservation,
+	candidate: LayoutObservation
+): FidelityCheckResult {
+	const moved = matchedImages( source.images, candidate.images ).filter( ( pair ) => {
+		const { source: left, candidate: right } = pair;
+		return (
+			Math.abs( left.x - right.x ) > IMAGE_POSITION_TOLERANCE_PX ||
+			Math.abs( left.y - right.y ) > IMAGE_POSITION_TOLERANCE_PX ||
+			Math.abs( left.width - right.width ) > IMAGE_SIZE_TOLERANCE_PX ||
+			Math.abs( left.height - right.height ) > IMAGE_SIZE_TOLERANCE_PX
+		);
+	} );
+	if ( moved.length === 0 ) return {};
+
+	return {
+		failures: [
+			`image geometry differs for ${ moved.length } matched image(s): ${ moved
+				.slice( 0, 3 )
+				.map( ( { source: left, candidate: right } ) =>
+					`${ left.key } source ${ left.width }x${ left.height } at (${ left.x },${ left.y }), copy ${ right.width }x${ right.height } at (${ right.x },${ right.y })`
+				)
+				.join( '; ' ) }`,
+		],
+	};
+}
+
+function normalizedFamily( family: string ): string {
+	return family.toLowerCase().replace( /["']/g, '' ).replace( /\s+/g, ' ' ).trim();
+}
+
+function styleDistance( source: RenderedTextStyle, candidate: RenderedTextStyle ): number {
+	return (
+		( normalizedFamily( source.fontFamily ) === normalizedFamily( candidate.fontFamily ) ? 0 : 1000 ) +
+		( source.fontWeight === candidate.fontWeight ? 0 : 100 ) +
+		Math.abs( source.fontSize - candidate.fontSize ) +
+		Math.abs( source.lineHeight - candidate.lineHeight ) +
+		Math.abs( source.letterSpacing - candidate.letterSpacing ) +
+		Math.abs( source.advance - candidate.advance )
+	);
+}
+
+interface TextPair {
+	source: RenderedTextStyle;
+	candidate: RenderedTextStyle;
+}
+
+function matchedTextStyles(
+	source: RenderedTextStyle[],
+	candidate: RenderedTextStyle[]
+): TextPair[] {
+	const available = new Map< string, RenderedTextStyle[] >();
+	for ( const style of candidate ) {
+		const group = available.get( style.key ) ?? [];
+		group.push( style );
+		available.set( style.key, group );
+	}
+	const pairs: TextPair[] = [];
+	for ( const style of source ) {
+		const group = available.get( style.key );
+		if ( ! group?.length ) continue;
+		let nearest = 0;
+		for ( let index = 1; index < group.length; index++ ) {
+			if ( styleDistance( style, group[ index ] ) < styleDistance( style, group[ nearest ] ) ) {
+				nearest = index;
+			}
+		}
+		pairs.push( { source: style, candidate: group.splice( nearest, 1 )[ 0 ] } );
+	}
+	return pairs;
+}
+
+function typographyDifferences( source: RenderedTextStyle, candidate: RenderedTextStyle ): string[] {
+	const differences: string[] = [];
+	if ( normalizedFamily( source.fontFamily ) !== normalizedFamily( candidate.fontFamily ) ) {
+		differences.push( `family ${ candidate.fontFamily } !== ${ source.fontFamily }` );
+	}
+	if ( source.fontWeight !== candidate.fontWeight ) {
+		differences.push( `weight ${ candidate.fontWeight } !== ${ source.fontWeight }` );
+	}
+	for ( const [ label, left, right ] of [
+		[ 'size', source.fontSize, candidate.fontSize ],
+		[ 'line-height', source.lineHeight, candidate.lineHeight ],
+		[ 'letter-spacing', source.letterSpacing, candidate.letterSpacing ],
+		[ 'advance', source.advance, candidate.advance ],
+	] as const ) {
+		if ( Math.abs( left - right ) > TYPOGRAPHY_METRIC_TOLERANCE_PX ) {
+			differences.push( `${ label } ${ right }px !== ${ left }px` );
+		}
+	}
+	if ( source.loaded && ! candidate.loaded ) differences.push( 'font face is not loaded' );
+	return differences;
+}
+
+export function checkTypography(
+	source: LayoutObservation,
+	candidate: LayoutObservation
+): FidelityCheckResult {
+	const sourceStyles = source.typography ?? [];
+	const candidateStyles = candidate.typography ?? [];
+	if ( sourceStyles.length === 0 ) return {};
+	if ( candidateStyles.length === 0 ) {
+		return { failures: [ `typography missing for ${ sourceStyles.length } source text run(s)` ] };
+	}
+
+	const matchedStyles = matchedTextStyles( sourceStyles, candidateStyles );
+	const coverage = matchedStyles.length / sourceStyles.length;
+	if ( coverage < TYPOGRAPHY_COVERAGE_FLOOR ) {
+		return {
+			failures: [
+				`typography coverage ${ matchedStyles.length } of ${ sourceStyles.length } (${ Math.round(
+					coverage * 100
+				) }%) is below ${ Math.round( TYPOGRAPHY_COVERAGE_FLOOR * 100 ) }%`,
+			],
+		};
+	}
+
+	const mismatches = matchedStyles
+		.map( ( pair ) => ( { ...pair, differences: typographyDifferences( pair.source, pair.candidate ) } ) )
+		.filter( ( pair ) => pair.differences.length > 0 );
+	if ( mismatches.length === 0 ) return {};
+
+	return {
+		failures: [
+			`typography differs for ${ mismatches.length } matched text run(s): ${ mismatches
+				.slice( 0, 3 )
+				.map( ( mismatch ) => `"${ mismatch.source.key.slice( 0, 40 ) }" ${ mismatch.differences.join( ', ' ) }` )
+				.join( '; ' ) }`,
+		],
+	};
+}
+
+function matchedAnimationCount( source: string[], candidate: string[] ): number {
+	const available = new Map< string, number >();
+	for ( const name of candidate ) available.set( name, ( available.get( name ) ?? 0 ) + 1 );
+	let matched = 0;
+	for ( const name of source ) {
+		const left = available.get( name ) ?? 0;
+		if ( left === 0 ) continue;
+		matched++;
+		available.set( name, left - 1 );
+	}
+	return matched;
+}
+
+export function checkMotion(
+	source: LayoutObservation,
+	candidate: LayoutObservation
+): FidelityCheckResult {
+	const sourceAnimations = source.animations ?? [];
+	const candidateAnimations = candidate.animations ?? [];
+	if ( sourceAnimations.length === 0 ) return {};
+	const matched = matchedAnimationCount( sourceAnimations, candidateAnimations );
+	const coverage = matched / sourceAnimations.length;
+	const sourceResponsive = source.responsiveAnimations ?? [];
+	const candidateResponsive = candidate.responsiveAnimations ?? [];
+	const responsiveMatched = matchedAnimationCount( sourceResponsive, candidateResponsive );
+	const responsiveCoverage = sourceResponsive.length
+		? responsiveMatched / sourceResponsive.length
+		: 1;
+	if ( coverage >= MOTION_COVERAGE_FLOOR && responsiveCoverage >= MOTION_COVERAGE_FLOOR ) return {};
+
+	return {
+		failures: [
+			coverage < MOTION_COVERAGE_FLOOR
+				? `animation coverage ${ matched } of ${ sourceAnimations.length } (${ Math.round(
+					coverage * 100
+				) }%) is below ${ Math.round( MOTION_COVERAGE_FLOOR * 100 ) }%; copy registered ${ candidateAnimations.length } finite CSS animation(s)`
+				: `responsive animation coverage ${ responsiveMatched } of ${ sourceResponsive.length } (${ Math.round(
+					responsiveCoverage * 100
+				) }%) is below ${ Math.round( MOTION_COVERAGE_FLOOR * 100 ) }% after controlled scroll`,
+		],
+	};
+}

--- a/src/lib/fidelity/score.ts
+++ b/src/lib/fidelity/score.ts
@@ -22,6 +22,21 @@ export interface RenderedImage {
 	height: number;
 }
 
+/** Computed typography for one visible text run. The text key survives DOM
+ * wrapper changes while the measured values describe what the browser drew. */
+export interface RenderedTextStyle {
+	key: string;
+	fontFamily: string;
+	fontWeight: string;
+	fontSize: number;
+	lineHeight: number;
+	letterSpacing: number;
+	/** Canvas advance in CSS pixels using the computed font. Detects fallback
+	 * rendering when CSS still names a face that did not load. */
+	advance: number;
+	loaded: boolean;
+}
+
 export interface LayoutObservation {
 	/** Viewport width the observation was taken at. */
 	viewport: number;
@@ -33,6 +48,13 @@ export interface LayoutObservation {
 	/** Images rendering with real layout space at this viewport. Tracking
 	 *  pixels and hidden decorations are excluded by the observer. */
 	images: RenderedImage[];
+	/** Representative visible text runs and their computed rendering. */
+	typography?: RenderedTextStyle[];
+	/** Finite CSS animation names currently attached to rendered elements. */
+	animations?: string[];
+	/** Finite CSS animations that appeared, advanced, or changed play state
+	 * during a controlled scroll probe. */
+	responsiveAnimations?: string[];
 	/** documentElement.scrollWidth. */
 	docWidth: number;
 	/** True when the document is wider than the viewport. */


### PR DESCRIPTION
## Problem

`data-liberation compare` could fail when images disappeared, but not when retained images moved or resized. It did not measure typography or motion at all. Three materially broken artifacts could therefore pass those parts of the HTML contract:

- the right image in the wrong box;
- CSS naming the right font while the browser renders a fallback or different metrics;
- preserved keyframes with no finite animation attached or responding to scroll.

## Change

The browser observation now records three additional generic HTML rendering surfaces:

- visible text runs with computed family, weight, size, line-height, letter-spacing, font-load state, and canvas advance;
- finite CSS animation names at rest;
- finite CSS animations that appear, advance, or change play state during a controlled scroll probe.

The existing rendered-image observation already carries normalized identity and geometry. Three built-in checks now enter through the public fidelity-check registry introduced in #123:

- `image-geometry` nearest-matches repeated image identities and gates position beyond 8px or size beyond 4px;
- `typography` nearest-matches repeated text runs, requires 80% coverage, and gates computed or rendered metric drift beyond 1px;
- `motion` requires 80% finite-animation coverage by name both at rest and among animations responding to controlled scroll.

These are HTML-to-HTML checks. They have no WordPress, block, theme, or publishing dependency, and each can be replaced independently through `registerFidelityCheck()`.

## Live evidence

Measured against the Nimbus Commute Wix source and two liberated artifacts:

### Motion

Before the scroll-timeline repair in #124:

```text
animation coverage 0 of 29 (0%) is below 80%; copy registered 0 finite CSS animation(s)
source: 29 finite, 7 responsive to scroll
copy:    0 finite, 0 responsive to scroll
```

With #124's self-contained HTML motion:

```text
source: 29 finite, 7 responsive to scroll
copy:   29 finite, 29 responsive to scroll
result: pass
```

### Image geometry

The gate independently names the two retained but incorrectly sized images:

```text
pexels-shvets-production source 464x335 at (77,1304), copy 418x302 at (77,1304)
c837a6_... source 161x406 at (1084,1212), copy 144x365 at (1084,1212)
```

### Typography

The artifact produced 58 matched visible text runs with equal computed and rendered metrics, so typography correctly did not add a failure for that build. Synthetic coverage verifies family, weight, font loading, size, line-height, letter-spacing, canvas-advance, and insufficient-run failures.

## Verification

- Full suite: 312 files passed, 3162 tests passed, 1 skipped, 1 todo.
- `npm run build` passes.
- `npm run test:package` passes.
- Live source/artifact comparison proves the old motion artifact fails, #124 passes, and the known image geometry drift is named.

## AI assistance

OpenAI gpt-5.6-sol via OpenCode implemented the browser observations and fidelity checks, constructed the unit coverage, and ran full-package and live source/artifact verification. Chris Huber directed the comparison-contract architecture and owns the submitted change.
