### PR TITLE
Add WordPress.com publish target

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ if (args[0] === 'mcp') {
 
   Usage:
     data-liberation <url>              Liberate a website into a portable HTML site
-    data-liberation publish <dir>      Publish a liberated site (--to spacefast)
+    data-liberation publish <dir>      Publish a liberated site (--to spacefast or wpcom)
     data-liberation compare <dir>      Compare a liberated copy to its source at unsampled widths
     data-liberation extract <url>      Extract content into a WXR file (WordPress path)
     data-liberation inspect <url>      Inspect a site before extraction
@@ -49,8 +49,10 @@ if (args[0] === 'mcp') {
                          like the source instead of pinning it to the capture width.
 
   Publish options:
-    --to <target>        Where to publish. Targets: spacefast (default)
-    --token <token>      Publish into your own account (or SPACEFAST_TOKEN).
+    --to <target>        Where to publish. Targets: spacefast (default), wpcom
+    --site <site>        Destination WordPress.com site ID or domain for wpcom
+    --yes                Approve the exact WordPress.com import plan
+    --token <token>      Publish into your own account (or SPACEFAST_TOKEN/WPCOM_TOKEN).
                          Without it the publish is anonymous and returns a claim link.
 
   Compare options:
@@ -306,10 +308,13 @@ if (args[0] === 'mcp') {
   const { publishSite } = await import('./ui/publish.js');
   const { PublishError } = await import('./lib/publish/index.js');
   try {
+    const target = getArg('--to') ?? 'spacefast';
     const result = await publishSite({
       directory,
-      target: getArg('--to') ?? 'spacefast',
-      token: getArg('--token') ?? process.env.SPACEFAST_TOKEN ?? undefined,
+      target,
+      token: getArg('--token') ?? (target === 'wpcom' ? process.env.WPCOM_TOKEN : process.env.SPACEFAST_TOKEN) ?? undefined,
+      destination: getArg('--site') ?? undefined,
+      approve: args.includes('--yes'),
       log: (message) => process.stderr.write(`${message}\n`),
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,7 @@ if (args[0] === 'mcp') {
   Publish options:
     --to <target>        Where to publish. Targets: spacefast (default), wpcom
     --site <site>        Destination WordPress.com site ID or domain for wpcom
+    --session <id>       Resume an existing WordPress.com import session
     --yes                Approve the exact WordPress.com import plan
     --token <token>      Publish into your own account (or SPACEFAST_TOKEN/WPCOM_TOKEN).
                          Without it the publish is anonymous and returns a claim link.
@@ -315,6 +316,7 @@ if (args[0] === 'mcp') {
       token: getArg('--token') ?? (target === 'wpcom' ? process.env.WPCOM_TOKEN : process.env.SPACEFAST_TOKEN) ?? undefined,
       destination: getArg('--site') ?? undefined,
       approve: args.includes('--yes'),
+      session: getArg('--session') ?? undefined,
       log: (message) => process.stderr.write(`${message}\n`),
     });
 

--- a/src/lib/publish/index.test.ts
+++ b/src/lib/publish/index.test.ts
@@ -25,8 +25,9 @@ afterEach( () => unregisterPublishTarget( 'acme' ) );
 describe( 'publish target registry', () => {
 	it( 'registers the built-in through the public API', () => {
 		// The built-in must not be privileged: it appears because it registered.
-		expect( publishTargetNames() ).toContain( 'spacefast' );
+		expect( publishTargetNames() ).toEqual( [ 'spacefast', 'wpcom' ] );
 		expect( findPublishTarget( 'spacefast' )?.name ).toBe( 'spacefast' );
+		expect( findPublishTarget( 'wpcom' )?.name ).toBe( 'wpcom' );
 	} );
 
 	it( 'accepts a target from outside this package', async () => {

--- a/src/lib/publish/index.ts
+++ b/src/lib/publish/index.ts
@@ -9,6 +9,7 @@
 //
 import { spacefastTarget } from './spacefast.js';
 import type { PublishTarget } from './types.js';
+import { wpcomTarget } from './wpcom.js';
 
 const targets = new Map< string, PublishTarget >();
 
@@ -50,6 +51,7 @@ export function publishTargetNames(): string[] {
 
 // Built-ins go through the public API, exactly as an external target would.
 registerPublishTarget( spacefastTarget );
+registerPublishTarget( wpcomTarget );
 
 export { PublishError } from './types.js';
 export type { PublishOptions, PublishResult, PublishTarget } from './types.js';

--- a/src/lib/publish/spacefast.test.ts
+++ b/src/lib/publish/spacefast.test.ts
@@ -3,8 +3,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { collectDirectoryEntries, spacefastTarget } from './spacefast.js';
+import { spacefastTarget } from './spacefast.js';
 import { PublishError } from './types.js';
+import { collectDirectoryEntries } from './zip.js';
 
 const dirs: string[] = [];
 

--- a/src/lib/publish/spacefast.ts
+++ b/src/lib/publish/spacefast.ts
@@ -9,9 +9,7 @@
 // direct API path is complete, and the CLI is a 36 MB install that a single
 // publish does not justify.
 //
-import { readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
-import { createZipArchive, type ZipEntry } from './zip.js';
+import { collectDirectoryEntries, createZipArchive } from './zip.js';
 import { PublishError, type PublishOptions, type PublishResult, type PublishTarget } from './types.js';
 
 const PUBLISH_ENDPOINT = 'https://api.spacefast.com/v1/publish';
@@ -41,30 +39,6 @@ interface SpacefastProblem {
 	title?: string;
 	detail?: string;
 	requestId?: string;
-}
-
-/** Collect every file under root as archive entries with POSIX-relative paths. */
-export function collectDirectoryEntries( root: string ): ZipEntry[] {
-	const entries: ZipEntry[] = [];
-	const walk = ( directory: string ): void => {
-		for ( const item of readdirSync( directory, { withFileTypes: true } ).sort( ( a, b ) =>
-			a.name.localeCompare( b.name )
-		) ) {
-			const absolute = join( directory, item.name );
-			// Resolve through symlinks so a linked asset publishes its bytes.
-			if ( item.isDirectory() || ( item.isSymbolicLink() && statSync( absolute ).isDirectory() ) ) {
-				walk( absolute );
-				continue;
-			}
-			if ( ! item.isFile() && ! item.isSymbolicLink() ) continue;
-			entries.push( {
-				path: relative( root, absolute ).split( sep ).join( '/' ),
-				contents: readFileSync( absolute ),
-			} );
-		}
-	};
-	walk( root );
-	return entries;
 }
 
 function problemFrom( status: number, body: string ): PublishError {

--- a/src/lib/publish/types.ts
+++ b/src/lib/publish/types.ts
@@ -13,6 +13,8 @@ export interface PublishOptions {
 	destination?: string | undefined;
 	/** Approve a target's reviewed deployment plan when one is required. */
 	approve?: boolean | undefined;
+	/** Resume a target-specific publish session instead of creating another. */
+	session?: string | undefined;
 	log?: ( ( message: string ) => void ) | undefined;
 }
 

--- a/src/lib/publish/types.ts
+++ b/src/lib/publish/types.ts
@@ -9,6 +9,10 @@ export interface PublishOptions {
 	directory: string;
 	/** Credential for an owned publish. Anonymous when omitted. */
 	token?: string | undefined;
+	/** Provider-specific destination identifier, such as a WordPress.com site. */
+	destination?: string | undefined;
+	/** Approve a target's reviewed deployment plan when one is required. */
+	approve?: boolean | undefined;
 	log?: ( ( message: string ) => void ) | undefined;
 }
 

--- a/src/lib/publish/wpcom.test.ts
+++ b/src/lib/publish/wpcom.test.ts
@@ -1,0 +1,120 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { wpcomTarget } from './wpcom.js';
+
+const dirs: string[] = [];
+
+function site(): string {
+	const directory = mkdtempSync( join( tmpdir(), 'dla-wpcom-' ) );
+	dirs.push( directory );
+	writeFileSync( join( directory, 'index.html' ), '<h1>Home</h1>' );
+	mkdirSync( join( directory, 'assets' ) );
+	writeFileSync( join( directory, 'assets', 'site.css' ), 'body{}' );
+	return directory;
+}
+
+function json( body: unknown, status = 200 ): Response {
+	return new Response( JSON.stringify( body ), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	} );
+}
+
+afterEach( () => {
+	vi.unstubAllGlobals();
+	for ( const directory of dirs.splice( 0 ) ) rmSync( directory, { recursive: true, force: true } );
+} );
+
+describe( 'wpcomTarget', () => {
+	it( 'uploads, approves the exact plan, and returns the live site receipt', async () => {
+		const fetchMock = vi.fn( async ( input: string | URL | Request, init?: RequestInit ) => {
+			const url = String( input );
+			if ( url === 'https://uploads.example/upload' ) return json( { success: true } );
+			if ( url.endsWith( '/upload-complete' ) ) return json( { session_id: 'abc123', state: 'artifact_queued' } );
+			if ( url.endsWith( '/approve' ) ) return json( { session_id: 'abc123', state: 'queued' } );
+			if ( url.endsWith( '/abc123' ) ) {
+				const statusCalls = fetchMock.mock.calls.filter( ( call ) => String( call[ 0 ] ).endsWith( '/abc123' ) );
+				return statusCalls.length === 1
+					? json( { session_id: 'abc123', state: 'preview_ready', plan_hash: 'plan-sha' } )
+					: json( {
+						session_id: 'abc123',
+						state: 'finished',
+						site_url: 'https://example.wordpress.com/',
+						receipt: { success: true, pages: 1 },
+					} );
+			}
+			if ( url.endsWith( '/static-site-import-session' ) ) {
+				return json( {
+					session_id: 'abc123',
+					state: 'awaiting_upload',
+					upload: { url: 'https://uploads.example/upload', token: 'upload-token', filename: 'site.zip' },
+				} );
+			}
+			throw new Error( `Unexpected request: ${ url } ${ init?.method ?? 'GET' }` );
+		} );
+		vi.stubGlobal( 'fetch', fetchMock );
+
+		const result = await wpcomTarget.publish( {
+			directory: site(),
+			token: 'oauth-token',
+			destination: 'example.wordpress.com',
+			approve: true,
+		} );
+
+		expect( result ).toMatchObject( {
+			target: 'wpcom',
+			liveUrl: 'https://example.wordpress.com/',
+			files: 2,
+		} );
+		const createCall = fetchMock.mock.calls.find( ( call ) => String( call[ 0 ] ).endsWith( '/static-site-import-session' ) )!;
+		const createBody = JSON.parse( String( createCall[ 1 ]?.body ) );
+		expect( createBody.source ).toMatchObject( {
+			type: 'artifact_upload',
+			files: 2,
+			entrypoint: 'index.html',
+		} );
+		expect( createBody.source.sha256 ).toMatch( /^[a-f0-9]{64}$/ );
+		expect( createBody.source.bytes ).toBeGreaterThan( 0 );
+
+		const uploadCall = fetchMock.mock.calls.find( ( call ) => String( call[ 0 ] ) === 'https://uploads.example/upload' )!;
+		expect( new Headers( uploadCall[ 1 ]?.headers ).get( 'authorization' ) ).toBe( 'Bearer upload-token' );
+		expect( new Headers( uploadCall[ 1 ]?.headers ).get( 'authorization' ) ).not.toContain( 'oauth-token' );
+		expect( ( ( uploadCall[ 1 ]?.body as FormData ).get( 'file' ) as Blob ).size ).toBe( createBody.source.bytes );
+
+		const approveCall = fetchMock.mock.calls.find( ( call ) => String( call[ 0 ] ).endsWith( '/approve' ) )!;
+		expect( JSON.parse( String( approveCall[ 1 ]?.body ) ) ).toEqual( { plan_hash: 'plan-sha' } );
+	} );
+
+	it( 'requires explicit approval after planning', async () => {
+		vi.stubGlobal( 'fetch', vi.fn( async ( input: string | URL | Request ) => {
+			const url = String( input );
+			if ( url === 'https://uploads.example/upload' ) return json( {} );
+			if ( url.endsWith( '/upload-complete' ) ) return json( { state: 'artifact_queued' } );
+			if ( url.endsWith( '/abc123' ) ) {
+				return json( { session_id: 'abc123', state: 'preview_ready', plan_hash: 'review-me' } );
+			}
+			return json( {
+				session_id: 'abc123',
+				state: 'awaiting_upload',
+				upload: { url: 'https://uploads.example/upload', token: 'upload-token', filename: 'site.zip' },
+			} );
+		} ) );
+
+		await expect( wpcomTarget.publish( {
+			directory: site(),
+			token: 'oauth-token',
+			destination: 'example.wordpress.com',
+		} ) ).rejects.toMatchObject( { code: 'approval_required' } );
+	} );
+
+	it( 'requires a token and destination before reading the site', async () => {
+		await expect( wpcomTarget.publish( { directory: '/missing' } ) ).rejects.toMatchObject( {
+			code: 'token_required',
+		} );
+		await expect( wpcomTarget.publish( { directory: '/missing', token: 'token' } ) ).rejects.toMatchObject( {
+			code: 'site_required',
+		} );
+	} );
+} );

--- a/src/lib/publish/wpcom.test.ts
+++ b/src/lib/publish/wpcom.test.ts
@@ -109,6 +109,57 @@ describe( 'wpcomTarget', () => {
 		} ) ).rejects.toMatchObject( { code: 'approval_required' } );
 	} );
 
+	it( 'resumes a preview without creating or uploading another session', async () => {
+		const fetchMock = vi.fn( async ( input: string | URL | Request ) => {
+			const url = String( input );
+			if ( url.endsWith( '/abc123/approve' ) ) {
+				return json( { session_id: 'abc123', state: 'queued' } );
+			}
+			if ( url.endsWith( '/abc123' ) ) {
+				const statusCalls = fetchMock.mock.calls.filter( ( call ) => String( call[ 0 ] ).endsWith( '/abc123' ) );
+				return statusCalls.length === 1
+					? json( { session_id: 'abc123', state: 'preview_ready', plan_hash: 'plan-sha' } )
+					: json( {
+						session_id: 'abc123',
+						state: 'finished',
+						site_url: 'https://example.wordpress.com/',
+						receipt: { success: true },
+					} );
+			}
+			throw new Error( `Unexpected request: ${ url }` );
+		} );
+		vi.stubGlobal( 'fetch', fetchMock );
+
+		const result = await wpcomTarget.publish( {
+			directory: site(),
+			token: 'oauth-token',
+			destination: 'example.wordpress.com',
+			session: 'abc123',
+			approve: true,
+		} );
+
+		expect( result.liveUrl ).toBe( 'https://example.wordpress.com/' );
+		expect( fetchMock.mock.calls.some( ( call ) => String( call[ 0 ] ) === 'https://uploads.example/upload' ) ).toBe( false );
+		expect( fetchMock.mock.calls.some( ( call ) => String( call[ 0 ] ).endsWith( '/static-site-import-session' ) ) ).toBe( false );
+	} );
+
+	it( 'rejects resuming a session bound to another archive', async () => {
+		vi.stubGlobal( 'fetch', vi.fn( async () => json( {
+			session_id: 'abc123',
+			state: 'preview_ready',
+			source_digest: '0'.repeat( 64 ),
+			plan_hash: 'plan-sha',
+		} ) ) );
+
+		await expect( wpcomTarget.publish( {
+			directory: site(),
+			token: 'oauth-token',
+			destination: 'example.wordpress.com',
+			session: 'abc123',
+			approve: true,
+		} ) ).rejects.toMatchObject( { code: 'session_source_mismatch' } );
+	} );
+
 	it( 'requires a token and destination before reading the site', async () => {
 		await expect( wpcomTarget.publish( { directory: '/missing' } ) ).rejects.toMatchObject( {
 			code: 'token_required',

--- a/src/lib/publish/wpcom.ts
+++ b/src/lib/publish/wpcom.ts
@@ -9,6 +9,7 @@ const MAX_POLLS = 300;
 interface Session {
 	session_id: string;
 	state: string;
+	source_digest?: string;
 	plan_hash?: string;
 	site_url?: string;
 	receipt?: { success?: boolean; code?: string; [ key: string ]: unknown };
@@ -97,57 +98,102 @@ async function publishToWpcom( options: PublishOptions ): Promise< PublishResult
 	}
 	const archive = createZipArchive( entries );
 	const digest = createHash( 'sha256' ).update( archive ).digest( 'hex' );
-	options.log?.( `Creating WordPress.com import session for ${ options.destination }...` );
-	const session = await request< Session >( endpoint( options.destination ), options.token, {
-		method: 'POST',
-		body: JSON.stringify( {
-			source: {
-				type: 'artifact_upload',
-				sha256: digest,
-				bytes: archive.length,
-				files: entries.length,
-				entrypoint: 'index.html',
-			},
-		} ),
-	} );
-	if ( ! session.session_id || ! session.upload ) {
-		throw new PublishError( {
-			code: 'upload_grant_missing',
-			message: 'WordPress.com did not return an upload grant.',
+	let session: Session;
+	if ( options.session ) {
+		options.log?.( `Resuming WordPress.com import session ${ options.session }...` );
+		session = await request< Session >(
+			endpoint( options.destination, `/${ encodeURIComponent( options.session ) }` ),
+			options.token
+		);
+		if ( session.source_digest && session.source_digest !== digest ) {
+			throw new PublishError( {
+				code: 'session_source_mismatch',
+				message: `WordPress.com session ${ session.session_id } belongs to a different site archive.`,
+			} );
+		}
+	} else {
+		options.log?.( `Creating WordPress.com import session for ${ options.destination }...` );
+		session = await request< Session >( endpoint( options.destination ), options.token, {
+			method: 'POST',
+			body: JSON.stringify( {
+				source: {
+					type: 'artifact_upload',
+					sha256: digest,
+					bytes: archive.length,
+					files: entries.length,
+					entrypoint: 'index.html',
+				},
+			} ),
 		} );
 	}
 
-	options.log?.( `Uploading ${ entries.length } files (${ archive.length } archive bytes)...` );
-	await uploadArtifact( session.upload, archive );
-	await request< Session >(
-		endpoint( options.destination, `/${ encodeURIComponent( session.session_id ) }/upload-complete` ),
-		options.token,
-		{ method: 'POST', body: '{}' }
-	);
-
-	options.log?.( 'Waiting for the WordPress.com import plan...' );
-	const preview = await waitForState( options.destination, options.token, session.session_id, 'preview_ready' );
-	if ( ! preview.plan_hash ) {
+	if ( session.state === 'failed' ) {
 		throw new PublishError( {
-			code: 'plan_hash_missing',
-			message: 'WordPress.com preview did not return a plan hash.',
+			code: String( session.receipt?.code ?? 'wpcom_import_failed' ),
+			message: `WordPress.com import session ${ session.session_id } failed.`,
 		} );
 	}
-	if ( ! options.approve ) {
-		throw new PublishError( {
-			code: 'approval_required',
-			message: `WordPress.com plan ${ preview.plan_hash } is ready; rerun with --yes to approve it.`,
-		} );
+	if ( session.state === 'awaiting_upload' ) {
+		if ( ! session.upload ) {
+			const uploadGrant = await request< Session >(
+				endpoint( options.destination, `/${ encodeURIComponent( session.session_id ) }/upload-token` ),
+				options.token,
+				{ method: 'POST', body: '{}' }
+			);
+			session = { ...session, ...uploadGrant };
+		}
+		if ( ! session.upload ) {
+			throw new PublishError( {
+				code: 'upload_grant_missing',
+				message: 'WordPress.com did not return an upload grant.',
+			} );
+		}
+		options.log?.( `Uploading ${ entries.length } files (${ archive.length } archive bytes)...` );
+		await uploadArtifact( session.upload, archive );
+		const uploadComplete = await request< Session >(
+			endpoint( options.destination, `/${ encodeURIComponent( session.session_id ) }/upload-complete` ),
+			options.token,
+			{ method: 'POST', body: '{}' }
+		);
+		session = { ...session, ...uploadComplete };
 	}
 
-	options.log?.( `Approving WordPress.com import plan ${ preview.plan_hash }...` );
-	await request< Session >(
-		endpoint( options.destination, `/${ encodeURIComponent( session.session_id ) }/approve` ),
-		options.token,
-		{ method: 'POST', body: JSON.stringify( { plan_hash: preview.plan_hash } ) }
-	);
-	const finished = await waitForState( options.destination, options.token, session.session_id, 'finished' );
-	if ( ! finished.site_url || finished.receipt?.success !== true ) {
+	if ( [ 'capture_queued', 'artifact_queued', 'compiling' ].includes( session.state ) ) {
+		options.log?.( 'Waiting for the WordPress.com import plan...' );
+		session = await waitForState( options.destination, options.token, session.session_id, 'preview_ready' );
+	}
+	if ( session.state === 'preview_ready' ) {
+		if ( ! session.plan_hash ) {
+			throw new PublishError( {
+				code: 'plan_hash_missing',
+				message: 'WordPress.com preview did not return a plan hash.',
+			} );
+		}
+		if ( ! options.approve ) {
+			throw new PublishError( {
+				code: 'approval_required',
+				message: `WordPress.com plan ${ session.plan_hash } is ready; rerun with --session ${ session.session_id } --yes to approve it.`,
+			} );
+		}
+		options.log?.( `Approving WordPress.com import plan ${ session.plan_hash }...` );
+		const approved = await request< Session >(
+			endpoint( options.destination, `/${ encodeURIComponent( session.session_id ) }/approve` ),
+			options.token,
+			{ method: 'POST', body: JSON.stringify( { plan_hash: session.plan_hash } ) }
+		);
+		session = { ...session, ...approved };
+	}
+	if ( [ 'queued', 'applying' ].includes( session.state ) ) {
+		options.log?.( 'Waiting for the WordPress.com import to finish...' );
+		session = await waitForState( options.destination, options.token, session.session_id, 'finished' );
+	}
+	if ( session.state !== 'finished' ) {
+		throw new PublishError( {
+			code: 'invalid_session_state',
+			message: `WordPress.com import session ${ session.session_id } cannot continue from state ${ session.state }.`,
+		} );
+	}
+	if ( ! session.site_url || session.receipt?.success !== true ) {
 		throw new PublishError( {
 			code: 'receipt_incomplete',
 			message: 'WordPress.com returned an incomplete import receipt.',
@@ -156,7 +202,7 @@ async function publishToWpcom( options: PublishOptions ): Promise< PublishResult
 
 	return {
 		target: 'wpcom',
-		liveUrl: finished.site_url,
+		liveUrl: session.site_url,
 		files: entries.length,
 		bytes: archive.length,
 		notes: [ `session ${ session.session_id }`, `artifact sha256 ${ digest }` ],

--- a/src/lib/publish/wpcom.ts
+++ b/src/lib/publish/wpcom.ts
@@ -1,0 +1,169 @@
+import { createHash } from 'node:crypto';
+import { collectDirectoryEntries, createZipArchive } from './zip.js';
+import { PublishError, type PublishOptions, type PublishResult, type PublishTarget } from './types.js';
+
+const API_BASE = 'https://public-api.wordpress.com/wpcom/v2/sites';
+const POLL_INTERVAL_MS = 2_000;
+const MAX_POLLS = 300;
+
+interface Session {
+	session_id: string;
+	state: string;
+	plan_hash?: string;
+	site_url?: string;
+	receipt?: { success?: boolean; code?: string; [ key: string ]: unknown };
+	upload?: { url: string; token: string; filename: string };
+}
+
+function endpoint( site: string, suffix = '' ): string {
+	return `${ API_BASE }/${ encodeURIComponent( site ) }/static-site-import-session${ suffix }`;
+}
+
+async function request< T >( url: string, token: string, init: RequestInit = {} ): Promise< T > {
+	const headers = new Headers( init.headers );
+	headers.set( 'authorization', `Bearer ${ token }` );
+	if ( ! ( init.body instanceof FormData ) ) headers.set( 'content-type', 'application/json' );
+	const response = await fetch( url, { ...init, headers } );
+	const body = await response.json().catch( () => ( {} ) ) as Record< string, unknown >;
+	if ( ! response.ok ) {
+		throw new PublishError( {
+			code: String( body.code ?? `wpcom_http_${ response.status }` ),
+			message: String( body.message ?? `WordPress.com returned HTTP ${ response.status }` ),
+		} );
+	}
+	return body as T;
+}
+
+async function uploadArtifact( upload: NonNullable< Session['upload'] >, archive: Buffer ): Promise< void > {
+	const form = new FormData();
+	form.append(
+		'file',
+		new Blob( [ new Uint8Array( archive ) ], { type: 'application/zip' } ),
+		upload.filename
+	);
+	const response = await fetch( upload.url, {
+		method: 'POST',
+		headers: { authorization: `Bearer ${ upload.token }` },
+		body: form,
+	} );
+	if ( ! response.ok ) {
+		throw new PublishError( {
+			code: `wpcom_upload_http_${ response.status }`,
+			message: `WordPress.com artifact upload returned HTTP ${ response.status }`,
+		} );
+	}
+}
+
+async function waitForState(
+	site: string,
+	token: string,
+	sessionId: string,
+	wanted: string
+): Promise< Session > {
+	for ( let attempt = 0; attempt < MAX_POLLS; attempt++ ) {
+		const session = await request< Session >(
+			endpoint( site, `/${ encodeURIComponent( sessionId ) }` ),
+			token
+		);
+		if ( session.state === wanted ) return session;
+		if ( session.state === 'failed' ) {
+			throw new PublishError( {
+				code: String( session.receipt?.code ?? 'wpcom_import_failed' ),
+				message: `WordPress.com import failed${ session.receipt?.code ? `: ${ session.receipt.code }` : '' }`,
+			} );
+		}
+		await new Promise( ( resolve ) => setTimeout( resolve, POLL_INTERVAL_MS ) );
+	}
+	throw new PublishError( {
+		code: 'wpcom_timeout',
+		message: `WordPress.com import did not reach ${ wanted } in time.`,
+	} );
+}
+
+async function publishToWpcom( options: PublishOptions ): Promise< PublishResult > {
+	if ( ! options.token ) {
+		throw new PublishError( { code: 'token_required', message: 'WordPress.com requires WPCOM_TOKEN.' } );
+	}
+	if ( ! options.destination ) {
+		throw new PublishError( {
+			code: 'site_required',
+			message: 'WordPress.com requires a destination site (--site).',
+		} );
+	}
+
+	const entries = collectDirectoryEntries( options.directory );
+	if ( entries.length === 0 ) {
+		throw new PublishError( { code: 'empty_site', message: 'Cannot publish an empty directory.' } );
+	}
+	const archive = createZipArchive( entries );
+	const digest = createHash( 'sha256' ).update( archive ).digest( 'hex' );
+	options.log?.( `Creating WordPress.com import session for ${ options.destination }...` );
+	const session = await request< Session >( endpoint( options.destination ), options.token, {
+		method: 'POST',
+		body: JSON.stringify( {
+			source: {
+				type: 'artifact_upload',
+				sha256: digest,
+				bytes: archive.length,
+				files: entries.length,
+				entrypoint: 'index.html',
+			},
+		} ),
+	} );
+	if ( ! session.session_id || ! session.upload ) {
+		throw new PublishError( {
+			code: 'upload_grant_missing',
+			message: 'WordPress.com did not return an upload grant.',
+		} );
+	}
+
+	options.log?.( `Uploading ${ entries.length } files (${ archive.length } archive bytes)...` );
+	await uploadArtifact( session.upload, archive );
+	await request< Session >(
+		endpoint( options.destination, `/${ encodeURIComponent( session.session_id ) }/upload-complete` ),
+		options.token,
+		{ method: 'POST', body: '{}' }
+	);
+
+	options.log?.( 'Waiting for the WordPress.com import plan...' );
+	const preview = await waitForState( options.destination, options.token, session.session_id, 'preview_ready' );
+	if ( ! preview.plan_hash ) {
+		throw new PublishError( {
+			code: 'plan_hash_missing',
+			message: 'WordPress.com preview did not return a plan hash.',
+		} );
+	}
+	if ( ! options.approve ) {
+		throw new PublishError( {
+			code: 'approval_required',
+			message: `WordPress.com plan ${ preview.plan_hash } is ready; rerun with --yes to approve it.`,
+		} );
+	}
+
+	options.log?.( `Approving WordPress.com import plan ${ preview.plan_hash }...` );
+	await request< Session >(
+		endpoint( options.destination, `/${ encodeURIComponent( session.session_id ) }/approve` ),
+		options.token,
+		{ method: 'POST', body: JSON.stringify( { plan_hash: preview.plan_hash } ) }
+	);
+	const finished = await waitForState( options.destination, options.token, session.session_id, 'finished' );
+	if ( ! finished.site_url || finished.receipt?.success !== true ) {
+		throw new PublishError( {
+			code: 'receipt_incomplete',
+			message: 'WordPress.com returned an incomplete import receipt.',
+		} );
+	}
+
+	return {
+		target: 'wpcom',
+		liveUrl: finished.site_url,
+		files: entries.length,
+		bytes: archive.length,
+		notes: [ `session ${ session.session_id }`, `artifact sha256 ${ digest }` ],
+	};
+}
+
+export const wpcomTarget: PublishTarget = {
+	name: 'wpcom',
+	publish: publishToWpcom,
+};

--- a/src/lib/publish/zip.ts
+++ b/src/lib/publish/zip.ts
@@ -10,11 +10,36 @@
 // directory entries. A liberated site is a flat set of file paths.
 //
 import { deflateRawSync } from 'node:zlib';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
 
 export interface ZipEntry {
 	/** Archive-relative POSIX path. */
 	path: string;
 	contents: Buffer;
+}
+
+/** Collect every file under root as archive entries with POSIX-relative paths. */
+export function collectDirectoryEntries( root: string ): ZipEntry[] {
+	const entries: ZipEntry[] = [];
+	const walk = ( directory: string ): void => {
+		for ( const item of readdirSync( directory, { withFileTypes: true } ).sort( ( a, b ) =>
+			a.name.localeCompare( b.name )
+		) ) {
+			const absolute = join( directory, item.name );
+			if ( item.isDirectory() || ( item.isSymbolicLink() && statSync( absolute ).isDirectory() ) ) {
+				walk( absolute );
+				continue;
+			}
+			if ( ! item.isFile() && ! item.isSymbolicLink() ) continue;
+			entries.push( {
+				path: relative( root, absolute ).split( sep ).join( '/' ),
+				contents: readFileSync( absolute ),
+			} );
+		}
+	};
+	walk( root );
+	return entries;
 }
 
 const STORED = 0;

--- a/src/ui/publish.test.ts
+++ b/src/ui/publish.test.ts
@@ -41,6 +41,6 @@ describe( 'publishSite', () => {
 	it( 'rejects an unknown target and names the ones that exist', async () => {
 		await expect(
 			publishSite( { directory: liberatedRun(), target: 'nowhere' } )
-		).rejects.toThrow( /Unknown publish target "nowhere"\. Available: spacefast\./ );
+		).rejects.toThrow( /Unknown publish target "nowhere"\. Available: spacefast, wpcom\./ );
 	} );
 } );

--- a/src/ui/publish.ts
+++ b/src/ui/publish.ts
@@ -19,6 +19,7 @@ export interface PublishCliOptions {
 	token?: string | undefined;
 	destination?: string | undefined;
 	approve?: boolean | undefined;
+	session?: string | undefined;
 	log?: ( ( message: string ) => void ) | undefined;
 }
 
@@ -54,6 +55,7 @@ export async function publishSite( options: PublishCliOptions ): Promise< Publis
 		token: options.token,
 		destination: options.destination,
 		approve: options.approve,
+		session: options.session,
 		log: options.log,
 	} );
 }

--- a/src/ui/publish.ts
+++ b/src/ui/publish.ts
@@ -17,6 +17,8 @@ export interface PublishCliOptions {
 	directory: string;
 	target: string;
 	token?: string | undefined;
+	destination?: string | undefined;
+	approve?: boolean | undefined;
 	log?: ( ( message: string ) => void ) | undefined;
 }
 
@@ -50,6 +52,8 @@ export async function publishSite( options: PublishCliOptions ): Promise< Publis
 	return target.publish( {
 		directory: resolvePublishDirectory( options.directory ),
 		token: options.token,
+		destination: options.destination,
+		approve: options.approve,
 		log: options.log,
 	} );
 }


### PR DESCRIPTION
## Summary
- add a built-in `wpcom` publish target for already-liberated static sites
- upload a deterministic ZIP through the WordPress.com artifact/session API
- require explicit approval of the exact returned plan hash before applying
- add `--site`, `--yes`, and `WPCOM_TOKEN` CLI support

## Testing
- `npm test` (3154 passed, 1 skipped, 1 todo)
- `npm run build`

## AI assistance
OpenAI GPT-5.6 Sol was used through OpenCode to inspect the publish architecture, implement the adapter and CLI integration, and run the test/build verification. The resulting code and behavior were reviewed against the server upload contract.