### PR TITLE
discovery: don't classify store/shop category pages as products

### DIFF
--- a/src/lib/extraction/sitemap.test.ts
+++ b/src/lib/extraction/sitemap.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { classifyUrl } from './sitemap.js';
+
+describe('classifyUrl', () => {
+  it('classifies the homepage', () => {
+    expect(classifyUrl('https://example.com/')).toBe('homepage');
+    expect(classifyUrl('https://example.com')).toBe('homepage');
+  });
+
+  it('classifies an actual product page', () => {
+    expect(classifyUrl('https://example.com/store/p20/Widget.html')).toBe('product'); // Weebly
+    expect(classifyUrl('https://example.com/products/widget')).toBe('product');
+    expect(classifyUrl('https://example.com/shop/widget')).toBe('product');
+  });
+
+  it('does not classify a store/shop category page as a product', () => {
+    // Weebly names a category /store/c<N>/... against a product's /store/p<N>/...; importing
+    // one as a product creates a junk WooCommerce row named after the category (lonestardinners.com).
+    expect(classifyUrl('https://example.com/store/c1/Current_Menu.html')).toBe('page');
+    expect(classifyUrl('https://example.com/shop/c6/Beer_Soaps.html')).toBe('page');
+  });
+
+  it('does not classify the bare store/shop index as a product', () => {
+    expect(classifyUrl('https://example.com/store')).toBe('page');
+    expect(classifyUrl('https://example.com/store/')).toBe('page');
+    expect(classifyUrl('https://example.com/shop')).toBe('page');
+  });
+
+  it('does not classify generic category/collection listing pages as products', () => {
+    expect(classifyUrl('https://example.com/product-category/widgets')).toBe('page');
+    expect(classifyUrl('https://example.com/collections/widgets')).toBe('page'); // Shopify
+    expect(classifyUrl('https://example.com/category/widgets')).toBe('page');
+    expect(classifyUrl('https://example.com/product-tag/on-sale')).toBe('page');
+  });
+
+  it('classifies a blog post but not a bare blog listing', () => {
+    expect(classifyUrl('https://example.com/blog/my-post')).toBe('post');
+    expect(classifyUrl('https://example.com/blog')).toBe('page');
+    expect(classifyUrl('https://example.com/blog/')).toBe('page');
+  });
+
+  it('classifies gallery and event pages', () => {
+    expect(classifyUrl('https://example.com/gallery/summer')).toBe('gallery');
+    expect(classifyUrl('https://example.com/events/launch-party')).toBe('event');
+  });
+
+  it('falls back to page for anything else', () => {
+    expect(classifyUrl('https://example.com/about-us')).toBe('page');
+  });
+});

--- a/src/lib/extraction/sitemap.ts
+++ b/src/lib/extraction/sitemap.ts
@@ -28,6 +28,15 @@ export function classifyUrl(url: string): UrlType {
   if (/\/blogs\/[^/]+\/[^/]+/.test(path)) return 'post'; // Shopify /blogs/<blog>/<article>
   if (/\/blog-\d+\/post\//.test(path)) return 'post'; // Wix /blog-1/post/<slug>
   if (/\/single-post\//.test(path)) return 'post'; // Older Wix Blog URL pattern
+  // A category/listing page under a store path is not a product, the same way a bare
+  // /blog is not a post above. Weebly names these /store/c<N>/... against /store/p<N>/...
+  // for an actual product; other platforms use /category/, /collections/ (Shopify), etc.,
+  // or the bare /store//shop/ index. Check these before the broad product test below, or
+  // e.g. lonestardinners.com's /store/c1/Current_Menu.html imports into WooCommerce as a
+  // junk product named after the category, priced at whatever its cheapest listing costs.
+  if (/\/(?:store|shop)\/c\d+\//.test(path)) return 'page';
+  if (/\/(?:category|categories|collections|product-category|product-tag)(?:\/|$)/.test(path)) return 'page';
+  if (/\/(?:store|shop)\/?$/.test(path)) return 'page';
   if (/\/(products?|product-page|store|shop)\//.test(path)) return 'product';
   if (/\/(gallery|portfolio)/.test(path)) return 'gallery';
   if (/\/(event|events)/.test(path)) return 'event';


### PR DESCRIPTION
## What this changes
`classifyUrl()` matches any URL containing `/store/` or `/shop/` as type `'product'`. It has no equivalent to the bare-`/blog`-is-a-listing guard it already applies for posts, so a store/shop category (listing) page gets misclassified as a product. This adds that guard: `/store/c<N>/...` (Weebly's own product/category split), `/category/`, `/collections/` (Shopify), `/product-category/`, `/product-tag/`, and the bare `/store` or `/shop` index all now classify as `page`.

## How I found it
Running `difm-migration-intake` on lonestardinners.com (a Weebly site) for a DIFM Express migration test. 2 of 11 rows in the extracted store were category pages ("Current Menu", "Featured Products"), not products — each would import into WooCommerce as a junk product named after the category, priced at whatever its cheapest listing costs. `difm-migration-intake` already has its own `is_product_listing()` regex to filter these out of `products.csv` downstream; this fixes the root cause in `classifyUrl` so every consumer gets the same page/product boundary (Squarespace's product-URL filter reads `classifyUrl` results directly, for example).

## Type of change
- [x] Bug fix (something broke)

## Tested against
- [x] Real site: lonestardinners.com (Weebly, live DIFM Express migration test) — see `plugins/difm-migrations/feedback/2026-09-10-www.lonestardinners.com.md` in `Automattic/difm-express-tools` for the full intake run this surfaced it in
- [x] Tests pass (`npx vitest run` — 90 files, 956 tests, all green) — added `src/lib/extraction/sitemap.test.ts` (none existed for `classifyUrl` before)
- [x] Output looks correct

## Discovery log
- [ ] Entry added to DISCOVERIES.md (gitignored/local per CONTRIBUTING.md; not applicable to this PR body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)