### PR TITLE
discovery: resolve the canonical origin before filtering Wix's linked-route crawl

### DIFF
--- a/src/adapters/wix/discover.ts
+++ b/src/adapters/wix/discover.ts
@@ -2,7 +2,7 @@ import { classifyUrl, parseSitemapXml } from '../../lib/extraction/sitemap.js';
 import { ensureUrlScheme } from '../../lib/url/index.js';
 import { launchBrowser } from '../../lib/browser-kit/index.js';
 import { withTimeout } from '../../lib/concurrency.js';
-import { discoverLinkedRoutes } from './discovery-links.js';
+import { discoverLinkedRoutes, resolveCanonicalSiteUrl } from './discovery-links.js';
 import { RENDERER_CALL_TIMEOUT_MS } from './page.js';
 import type { InventoryUrl } from '../shared.js';
 import type { NavLink } from '../../lib/html-extract/index.js';
@@ -121,8 +121,11 @@ export async function discover(url: string, opts: Record<string, unknown>): Prom
 
     // 2. Merge sitemap inventory with a bounded rendered-link crawl. Wix can
     // advertise broken dynamic child sitemaps while linked routes remain public.
+    // resolveCanonicalSiteUrl matters here: blacksheepbikes.com redirects to www.blacksheepbikes.com,
+    // and discoverLinkedRoutes filters every URL to `siteUrl`'s origin - passing the raw (bare) input
+    // rejected all 28 real sitemap pages as "off-origin" and left only the one seed URL.
     const linkedDiscovery = await discoverLinkedRoutes({
-      siteUrl: url,
+      siteUrl: resolveCanonicalSiteUrl(url, sitemapUrls),
       initialUrls: sitemapUrls,
       maxPages: sitemapUrls.length > 0 ? 10 : 100,
       loadLinks: async (routeUrl) => {

--- a/src/adapters/wix/discovery-links.test.ts
+++ b/src/adapters/wix/discovery-links.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { discoverLinkedRoutes } from './discovery-links.js';
+import { discoverLinkedRoutes, resolveCanonicalSiteUrl } from './discovery-links.js';
 
 describe( 'discoverLinkedRoutes', () => {
 	it( 'merges partial sitemap inventory with recursively linked same-origin routes', async () => {
@@ -71,5 +71,33 @@ describe( 'discoverLinkedRoutes', () => {
 			'https://www.wix.com/demone2/nimbus-commute/privacy-policy',
 			'https://www.wix.com/demone2/nimbus-commute/accessibility-statement',
 		] );
+	} );
+} );
+
+describe( 'resolveCanonicalSiteUrl', () => {
+	it( 'takes the origin from a resolved URL when the input host redirects', () => {
+		// blacksheepbikes.com -> www.blacksheepbikes.com: the sitemap's own URLs are already on the
+		// real host, so passing the bare input straight to discoverLinkedRoutes rejected every one of
+		// them as off-origin.
+		expect(
+			resolveCanonicalSiteUrl( 'https://blacksheepbikes.com', [
+				'https://www.blacksheepbikes.com/about',
+				'https://www.blacksheepbikes.com/pricing',
+			] )
+		).toBe( 'https://www.blacksheepbikes.com/' );
+	} );
+
+	it( 'keeps the operator-supplied path for a path-hosted site', () => {
+		expect(
+			resolveCanonicalSiteUrl( 'https://www.wix.com/demone2/nimbus-commute', [
+				'https://www.wix.com/demone2/nimbus-commute/privacy-policy',
+			] )
+		).toBe( 'https://www.wix.com/demone2/nimbus-commute' );
+	} );
+
+	it( 'falls back to the input URL untouched when there are no resolved URLs yet', () => {
+		expect( resolveCanonicalSiteUrl( 'https://blacksheepbikes.com', [] ) ).toBe(
+			'https://blacksheepbikes.com'
+		);
 	} );
 } );

--- a/src/adapters/wix/discovery-links.ts
+++ b/src/adapters/wix/discovery-links.ts
@@ -16,6 +16,22 @@ export interface LinkedRouteDiscoveryResult {
 	failures: Array< { url: string; reason: string } >;
 }
 
+/**
+ * The `siteUrl` origin discoverLinkedRoutes filters every URL against has to be the site's real,
+ * resolved host - not necessarily what the operator typed. A site that redirects the bare host to
+ * www (or the reverse) returns every sitemap URL and every link scraped off the (redirected)
+ * rendered page on that resolved host; passing the raw input as `siteUrl` then rejects all of them
+ * as "off-origin" and the crawl returns only the one seed URL (blacksheepbikes.com: 28 real sitemap
+ * pages fell to 1). `resolvedUrls` - a sitemap's own URLs, already fetched from the real site - carry
+ * the correct host, so take the origin from the first one when there is one; keep the operator's own
+ * path either way, since that part of the input is still what scopes a path-hosted site
+ * (wix.com/user/site-name).
+ */
+export function resolveCanonicalSiteUrl( inputUrl: string, resolvedUrls: string[] ): string {
+	if ( resolvedUrls.length === 0 ) return inputUrl;
+	return new URL( resolvedUrls[ 0 ] ).origin + ( new URL( inputUrl ).pathname || '/' );
+}
+
 function contentUrl(
 	value: string,
 	baseUrl: string,


### PR DESCRIPTION
## What this changes
`discoverLinkedRoutes` filters every URL to the same origin as the `siteUrl` it's given. Wix's `discover()` passed the raw operator input straight through as that `siteUrl` - so a site that redirects its bare host to `www` (or the reverse) has every sitemap URL and every link scraped off the (redirected) rendered page come back on a *different* origin than the one the filter was built from, and all of them get silently rejected as "off-origin". A new `resolveCanonicalSiteUrl()` helper takes the origin from the sitemap's own (already-resolved) URLs when there are any, keeping the operator's own path so path-hosted sites (`wix.com/user/site-name`) still scope correctly.

## How I found it
Running `difm-migration-intake` on blacksheepbikes.com (Wix, redirects `blacksheepbikes.com` -> `www.blacksheepbikes.com`) for a DIFM Express migration test. The extraction's own feedback log said "the extractor downloaded almost none of the site's media (19 of 52 referenced files)" - framed as a media-fetching problem. Root-causing it live against the real site showed the sitemap parsing itself was fine (`blacksheepbikes.com/sitemap.xml` resolves cleanly to 28 real page URLs when fetched directly), so the loss had to be downstream: `discoverLinkedRoutes.retain()` calls `contentUrl()`, which returns `null` for anything off the origin computed from `siteUrl` - and every one of those 28 URLs comes back on `www`, never on the bare host the CLI was given. The extractor had in fact only ever visited the homepage; the "media" symptom was just the most visible downstream effect.

## Type of change
- [x] Bug fix (something broke)

## Tested against
- [x] Real Wix site: blacksheepbikes.com. Before the fix, `data-liberation extract` found 1 URL; after, 29 (28 sitemap pages + the seed) - verified live both ways.
- [x] Tests pass (`npx vitest run` - 90 files, 959 tests, all green). Added tests for the extracted `resolveCanonicalSiteUrl()` helper directly in `discovery-links.test.ts` (redirecting host, path-hosted site, no-sitemap-yet fallback).
- [x] Output looks correct (URL count, page/product classification counts all matched the independently-confirmed real sitemap contents)

One unrelated flake along the way, noted for the record: `capture-export.test.ts`'s "exports many large responsive routes within a constrained heap" test failed once with `result.status: null` while these files were dirty in the working tree. Confirmed it's a pre-existing artifact of that test's tight 128MB child-process heap combined with `tsx`'s cold transpile cache (warming the cache, or just re-running once everything settles, makes it pass reliably) - unrelated to this change, which touches none of that test's code path.

## Discovery log
- [ ] Entry added to DISCOVERIES.md (gitignored/local per CONTRIBUTING.md; not applicable to this PR body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
